### PR TITLE
release: v0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Release v0.0.7 (patch)

Patch release shipping **#3** — removes the destructive mechanical `merge-blocks` pipeline node.

### What changed
The `merge-blocks` node destroyed high-quality model-written T1 summaries: once N old-gen summaries exceeded `merge.maxSummaryLength` (3000 chars), it kept only the first line (a `## title`) of each, discarding the entire body. Removed entirely; tier promotion is left to model-driven distillation (nudge → `compress`).

### Quality
- typecheck ✅
- **181 tests pass** ✅
- build ✅ (`dist/index.js` 86KB)

### Merged PRs in this release
- #3 fix: remove mechanical merge-blocks node

CI (`release.yml`) auto-tags `v0.0.7` + publishes to npm on merge of this `*_release-v*` branch.