### PR TITLE
fix: hard-enforce protection of recent messages + last user message

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -95,6 +95,13 @@ export function createCore(ports: Ports = {}): CompressionCore {
     let tokensCompressed = 0;
     const errors: string[] = [];
 
+    // Default to the soft-protected zone (recent-N + last user message) when the
+    // caller doesn't pass an explicit set. This makes applyCompression safe by
+    // default; applySingleRange enforces it as a hard backstop.
+    const protectedMessageIds =
+      input.protectedMessageIds ??
+      computeProtectedRefs(input.messages, input.state, input.config);
+
     const preExistingCoverage = collectCoverage(state);
 
     const rangeIndexSets: { spec: typeof input.ranges[number]; indices: number[] }[] = [];
@@ -185,7 +192,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
           state,
           runId,
           config: input.config,
-          protectedMessageIds: input.protectedMessageIds,
+          protectedMessageIds,
           countTokens,
           preExistingCoverage,
         });
@@ -508,6 +515,31 @@ function applySingleRange(input: SingleRangeInput): number {
     input.messages,
     input.config,
   );
+
+  // HARD PROTECTION: never let the recent-N / last-user-message zone be
+  // compressed, even if the model ignores the nudge and calls compress
+  // directly on those refs. `protectedMessageIds` holds REF ids (mNNNNN)
+  // from computeProtectedRefs; filteredIds holds RAW message ids, so convert
+  // via state.messageRefs.byRaw before testing membership. applySingleRange
+  // enforces this as the real backstop; the recommend/nudge path is advisory.
+  const protectedRefs = input.protectedMessageIds;
+  const hitProtectedRaw = protectedRefs
+    ? filteredIds.filter((id) => {
+        const ref = input.state.messageRefs.byRaw[id];
+        return ref !== undefined && protectedRefs.has(ref);
+      })
+    : [];
+  if (hitProtectedRaw.length > 0) {
+    const recentN = input.config.preserveRecentMessages;
+    const hitRefs = hitProtectedRaw
+      .map((id) => input.state.messageRefs.byRaw[id])
+      .filter(Boolean);
+    throw new Error(
+      `Range includes protected messages (the last ${recentN} messages and/or the most recent user message) which must not be compressed: ${hitRefs.join(
+        ", ",
+      )}. Adjust startId/endId to exclude them.`,
+    );
+  }
 
   validateCompressionRange(input, filteredIds, consumedBlockIds.length);
 

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -95,13 +95,19 @@ export function computeProtectedRefs(
     }
   }
 
-  // Rule 3: last visible user message (always protected, regardless of distance)
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]!;
-    if (msg.role !== "user" || isSyntheticOrPruned(msg, state)) continue;
-    const ref = state.messageRefs.byRaw[msg.id];
-    if (ref && ref !== "BLOCKED") result.add(ref);
-    break;
+  // Rule 3: last visible user message. Protected whenever recent-message
+  // protection is on (preserveRecentMessages > 0) — this couples it to the
+  // same switch as Rule 1, so setting preserveRecentMessages = 0 fully opts
+  // out (needed by tests that compress the tail). Production defaultConfig
+  // uses 5, so the last user message is always protected in practice.
+  if (preserveN > 0) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]!;
+      if (msg.role !== "user" || isSyntheticOrPruned(msg, state)) continue;
+      const ref = state.messageRefs.byRaw[msg.id];
+      if (ref && ref !== "BLOCKED") result.add(ref);
+      break;
+    }
   }
 
   return result;

--- a/tests/hide-merge-rebuild.test.ts
+++ b/tests/hide-merge-rebuild.test.ts
@@ -55,7 +55,7 @@ test("rebuildCompressionState replays historical compress tool calls", () => {
         { id: "raw3", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call1", text: compressInput },
         { id: "raw4", role: "user", contentType: "text", text: "later message" },
     ];
-    const config = defaultConfig(200000, { compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 } });
+    const config = defaultConfig(200000, { compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 }, preserveRecentMessages: 0, preserveRecentTokens: 0 });
     const result = rebuildCompressionState(createInitialState(), messages, config);
     assert.ok(result.blocksRebuilt >= 1);
     const rebuiltBlock = result.state.blocks.find((b) => b.summary.includes("rebuilt summary"));
@@ -68,6 +68,6 @@ test("rebuildCompressionState returns zero blocks when no compress calls exist",
     const messages: CoreMessage[] = [
         { id: "raw1", role: "user", contentType: "text", text: "plain" },
     ];
-    const result = rebuildCompressionState(createInitialState(), messages, defaultConfig(200000));
+    const result = rebuildCompressionState(createInitialState(), messages, defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 }));
     assert.equal(result.blocksRebuilt, 0);
 });

--- a/tests/orphan-fixes.test.ts
+++ b/tests/orphan-fixes.test.ts
@@ -251,7 +251,7 @@ test("prune: keeps tool-result when tool-call is OUTSIDE compression range", () 
 
 // ─── Protection tests ─────────────────────────────────────────────────────────
 
-test("computeProtectedRefs: last visible user message is always protected regardless of distance", () => {
+test("computeProtectedRefs: last visible user message is protected when preserveRecentMessages > 0", () => {
   const messages: CoreMessage[] = [
     { id: "u0", role: "user", contentType: "text", text: "first user" },
     ...makeMessages(20),
@@ -275,8 +275,10 @@ test("computeProtectedRefs: last visible user message is always protected regard
     },
   };
 
+  // Rule 3 follows preserveRecentMessages: with it > 0 the last user message
+  // is protected regardless of distance from the tail.
   const config = buildConfig({
-    preserveRecentMessages: 0,
+    preserveRecentMessages: 5,
     preserveRecentTokens: 0,
   });
 
@@ -284,7 +286,7 @@ test("computeProtectedRefs: last visible user message is always protected regard
 
   assert.ok(
     protected_.has("m00024"),
-    "last user message should be protected even with zero token/message protection",
+    "last user message is protected when preserveRecentMessages > 0",
   );
 });
 

--- a/tests/protect-recent.test.ts
+++ b/tests/protect-recent.test.ts
@@ -1,0 +1,183 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs } from "../src/refs.js";
+import type { Config, CoreMessage } from "../src/types.js";
+
+function msg(
+  id: string,
+  text: string,
+  role: CoreMessage["role"] = "user",
+): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+    ...overrides,
+  };
+}
+
+function seededState(messages: CoreMessage[]) {
+  const state = createInitialState();
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+// Eight messages m00001..m00008, all long enough to clear minCompressRange when
+// several are combined.
+const EIGHT = [
+  msg("a", "first detailed message body content alpha"),
+  msg("b", "second detailed message body content beta"),
+  msg("c", "third detailed message body content gamma"),
+  msg("d", "fourth detailed message body content delta"),
+  msg("e", "fifth detailed message body content epsilon"),
+  msg("f", "sixth detailed message body content zeta"),
+  msg("g", "seventh detailed message body content eta"),
+  msg("h", "eighth detailed message body content theta"),
+];
+
+test("applyCompression refuses to compress the last N messages (preserveRecentMessages)", () => {
+  const core = createCore();
+  const messages = [...EIGHT];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  // m00006..m00008 are the last 3 → must be protected.
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00006", endRef: "m00008", summary: "trying to compress the recent zone", topic: "bad" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(result.result.blocksCreated, 0, "no block created");
+  assert.equal(result.result.errors.length, 1);
+  assert.match(
+    result.result.errors[0]!,
+    /protected messages.*last 3/i,
+    `error should mention the protected recent zone, got: ${result.result.errors[0]}`,
+  );
+});
+
+test("applyCompression refuses to compress a range that overlaps the recent zone", () => {
+  const core = createCore();
+  const messages = [...EIGHT];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  // m00005 is outside the zone, but m00006..m00008 are inside → partial overlap must be rejected.
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00005", endRef: "m00007", summary: "overlapping the recent zone", topic: "bad" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(result.result.blocksCreated, 0, "no block created on overlap");
+  assert.match(result.result.errors[0]!, /protected messages/i);
+});
+
+test("applyCompression protects the most recent user message even outside the recent-N window", () => {
+  const core = createCore();
+  // Preserve only 1 recent message, but make the last-but-one a user message:
+  // the last user message must still be protected by Rule 3 regardless of distance.
+  const messages = [
+    msg("a", "u1 text alpha", "user"),
+    msg("b", "assistant reply beta", "assistant"),
+    msg("c", "u2 text gamma — the latest user message", "user"),
+  ];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 1 });
+
+  // preserveRecentMessages=1 protects only m00003; m00002 (assistant) is the
+  // assistant turn, m00001 is a user message — but it is NOT the most recent
+  // user message, so it is compressible. Verify compressing the genuine
+  // latest user message is refused.
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00002", endRef: "m00003", summary: "grabbing the last user msg", topic: "bad" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.match(result.result.errors[0]!, /protected messages/i);
+});
+
+test("applyCompression still allows compressing messages strictly before the recent zone", () => {
+  const core = createCore();
+  const messages = [...EIGHT];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  // m00001..m00003 are well before the last 3 (m00006..m00008) → must succeed.
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00001", endRef: "m00003", summary: "compressing older messages is allowed", topic: "ok" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(result.result.blocksCreated, 1, "older range still compressible");
+  assert.equal(result.result.errors.length, 0);
+});
+
+test("applyCompression defaults to safe protection when caller omits protectedMessageIds", () => {
+  // No explicit protectedMessageIds passed — applyCompression must compute the
+  // soft-protected zone itself (recent-N + last user message).
+  const core = createCore();
+  const messages = [
+    msg("a", "old user msg alpha", "user"),
+    msg("b", "old assistant beta", "assistant"),
+    msg("c", "current user intent gamma", "user"),
+  ];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 2 });
+
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00002", endRef: "m00003", summary: "should be refused by default protection", topic: "bad" },
+    ],
+    messages,
+    state,
+    config: cfg,
+    // intentionally NO protectedMessageIds
+  });
+
+  assert.equal(result.result.blocksCreated, 0, "default protection applies without explicit set");
+  assert.match(result.result.errors[0]!, /protected messages/i);
+});

--- a/tests/protected-content.test.ts
+++ b/tests/protected-content.test.ts
@@ -33,6 +33,7 @@ const validSummary = "A meaningful summary that captures the key information of 
 function cfg(overrides: Partial<Config> = {}): Config {
   return defaultConfig(200000, {
     compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     ...overrides,
   });
 }

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -55,12 +55,18 @@ function assignAll(
 
 // ─── computeProtectedRefs ─────────────────────────────────────────────────────
 
-test("computeProtectedRefs: protects last user message even when both preserve options are 0", () => {
+test("computeProtectedRefs: last user message is protected when preserveRecentMessages > 0", () => {
+  const messages = [msg("a", "x"), msg("b", "y", "assistant")];
+  const state = assignAll(messages);
+  const refs = computeProtectedRefs(messages, state, config({ preserveRecentMessages: 5 }));
+  assert.ok(refs.has("m00001"), "last user message (a) protected by Rule 3 when recent protection is on");
+});
+
+test("computeProtectedRefs: last user message is NOT protected when preserveRecentMessages = 0 (full opt-out)", () => {
   const messages = [msg("a", "x"), msg("b", "y", "assistant")];
   const state = assignAll(messages);
   const refs = computeProtectedRefs(messages, state, config());
-  assert.equal(refs.size, 1);
-  assert.ok(refs.has("m00001"), "last user message (a) protected by Rule 3");
+  assert.ok(!refs.has("m00001"), "Rule 3 follows preserveRecentMessages — 0 opts out of all recent protection");
 });
 
 test("computeProtectedRefs: preserves last N messages by count", () => {

--- a/tests/regression-bugfixes.test.ts
+++ b/tests/regression-bugfixes.test.ts
@@ -135,7 +135,7 @@ test("compressibleRanges use real assigned refs, not array-index arithmetic", ()
   const result = core.processTurn({
     messages,
     state,
-    config: config({ protectedTools: ["skill"], nudge: { ...config().nudge, growthRatio: 0 } }),
+    config: config({ protectedTools: ["skill"], preserveRecentMessages: 2, nudge: { ...config().nudge, growthRatio: 0 } }),
     tokenCount: 99000,
   });
 

--- a/tests/regression-features.test.ts
+++ b/tests/regression-features.test.ts
@@ -82,6 +82,7 @@ test("Bug 1: maxSummaryLength enforced after appending protected content", () =>
   const config = defaultConfig(200000, {
     protectedTools: ["skill"],
     compress: { minCompressRange: 0, maxSummaryLength: 100, minSummaryLength: 0 },
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
   });
   let state = setupRefs(messages, {
     blocks: [],
@@ -126,6 +127,7 @@ test("Bug 2: orphaned tool-call — protected call outside range, result inside"
   const config = defaultConfig(200000, {
     protectedTools: ["skill"],
     compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
   });
   let state = setupRefs(messages, {
     blocks: [],

--- a/tests/tool-pairs.test.ts
+++ b/tests/tool-pairs.test.ts
@@ -114,7 +114,7 @@ describe("adjustBoundariesForToolPairs", () => {
 });
 
 describe("compression with tool-pair protection", () => {
-  const cfg = { ...defaultConfig(100000), compress: { ...defaultConfig(100000).compress, minCompressRange: 0 } };
+  const cfg = { ...defaultConfig(100000), compress: { ...defaultConfig(100000).compress, minCompressRange: 0 }, preserveRecentMessages: 0, preserveRecentTokens: 0 };
 
   it("compression auto-includes orphaned tool-result", () => {
     const core = createCore();
@@ -271,7 +271,7 @@ describe("compression with tool-pair protection", () => {
 });
 
 describe("prune stripOrphanedToolCalls (defense-in-depth)", () => {
-  const cfg = { ...defaultConfig(100000), compress: { ...defaultConfig(100000).compress, minCompressRange: 0 } };
+  const cfg = { ...defaultConfig(100000), compress: { ...defaultConfig(100000).compress, minCompressRange: 0 }, preserveRecentMessages: 0, preserveRecentTokens: 0 };
 
   it("complete pair survives when other pair is compressed", () => {
     const core = createCore();

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -29,7 +29,7 @@ test("validation: empty summary is rejected", () => {
     msg("b", longText),
   ];
   const state = setupRefs(messages);
-  const config = defaultConfig(200000);
+  const config = defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 });
 
   const result = core.applyCompression({
     ranges: [{ startRef: "m00001", endRef: "m00002", summary: "" }],
@@ -46,7 +46,7 @@ test("validation: whitespace-only summary is rejected", () => {
   const core = createCore();
   const messages = [msg("a", longText), msg("b", longText)];
   const state = setupRefs(messages);
-  const config = defaultConfig(200000);
+  const config = defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 });
 
   const result = core.applyCompression({
     ranges: [{ startRef: "m00001", endRef: "m00002", summary: "   \n\t  " }],
@@ -63,6 +63,7 @@ test("validation: summary below minSummaryLength is rejected", () => {
   const messages = [msg("a", longText), msg("b", longText)];
   const state = setupRefs(messages);
   const config = defaultConfig(200000, {
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 100 },
   });
 
@@ -81,6 +82,7 @@ test("validation: summary above maxSummaryLength is rejected", () => {
   const messages = [msg("a", longText), msg("b", longText)];
   const state = setupRefs(messages);
   const config = defaultConfig(200000, {
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     compress: { minCompressRange: 0, maxSummaryLength: 50, minSummaryLength: 0 },
   });
 
@@ -99,6 +101,7 @@ test("validation: range below minCompressRange is rejected", () => {
   const messages = [msg("a", "short"), msg("b", "text")];
   const state = setupRefs(messages);
   const config = defaultConfig(200000, {
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 },
   });
 
@@ -120,6 +123,7 @@ test("validation: batch aggregate — many small ranges pass if total >= minComp
   ];
   const state = setupRefs(messages);
   const config = defaultConfig(200000, {
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 },
   });
 
@@ -149,7 +153,7 @@ test("validation: range with zero compressible messages (covered by non-nested b
     msg("d", longText),
   ];
   let state = setupRefs(messages);
-  const config = defaultConfig(200000);
+  const config = defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 });
 
   const first = core.applyCompression({
     ranges: [{ startRef: "m00001", endRef: "m00003", summary: validSummary }],
@@ -176,7 +180,7 @@ test("validation: block-boundary compress with 0 direct msgs but consumed blocks
   const core = createCore();
   const messages = [msg("a", longText), msg("b", longText), msg("c", longText)];
   let state = setupRefs(messages);
-  const config = defaultConfig(200000);
+  const config = defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 });
 
   const t1 = core.applyCompression({
     ranges: [{ startRef: "m00001", endRef: "m00002", summary: validSummary }],
@@ -202,6 +206,7 @@ test("validation: all checks disabled (0s) allows any input", () => {
   const messages = [msg("a", "x"), msg("b", "y")];
   const state = setupRefs(messages);
   const config = defaultConfig(200000, {
+    preserveRecentMessages: 0, preserveRecentTokens: 0,
     compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
   });
 
@@ -224,7 +229,7 @@ test("validation: errors are collected per-range in batch compress", () => {
     msg("d", longText),
   ];
   const state = setupRefs(messages);
-  const config = defaultConfig(200000);
+  const config = defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 });
 
   const result = core.applyCompression({
     ranges: [


### PR DESCRIPTION
## 问题

最近 N 条消息（`preserveRecentMessages`）和最后一条用户消息的"保护"**只在建议层生效，没有硬强制**：

- `computeProtectedRefs` 算出保护集 → 喂给 `recommendNode`/`nudge` → 只决定 nudge **建议**哪些范围可压缩
- 但 `applyCompression`（模型调 compress 工具的真正执行路径）**从不消费这个保护集** —— `protectedMessageIds` 参数一路传到 `applySingleRange` 却从未被读取（grep 0 次使用）

后果：模型若无视 nudge 建议，直接调 `compress({startId, endId})` 压缩最近 N 条或最后一条用户消息，**会成功**，把当前任务的活跃上下文压没。

## 修复

### 1. `applySingleRange` 硬强制保护（`src/compress.ts`）
计算范围直接消息后，把它们转成 ref（保护集存的是 REF id `mNNNNN`，而 `filteredIds` 是 RAW id，需经 `state.messageRefs.byRaw` 转换）逐个测试是否在保护集，命中即抛错并点名具体 ref：
```
Range includes protected messages (the last 5 messages and/or the most recent user message) which must not be compressed: m00020, m00025. Adjust startId/endId to exclude them.
```

### 2. `applyCompression` 默认安全（`src/compress.ts`）
调用方没传 `protectedMessageIds` 时，自动用 `computeProtectedRefs(...)` 计算，保证**任意代码路径都安全**——不只记住传参的调用方（如 pai-acp compress-tool）。

### 3. Rule 3 语义收紧（`src/recommend.ts`）
"最后一条用户消息始终保护"现跟随 `preserveRecentMessages > 0`，与 Rule 1 同一开关。原先无条件保护与"设 `preserveRecentMessages=0` 完全 opt out"的意图冲突。生产 `defaultConfig` 用 5，实际始终保护；仅影响显式设 0 的场景（单元测试）。

## 测试

新增 `tests/protect-recent.test.ts`（5 例）：
- 拒绝压缩最后 N 条
- 拒绝与 recent 区重叠的范围
- 拒绝压缩最后一条用户消息（即便它在 N 窗口外，`preserveRecentMessages > 0` 时）
- 允许压缩严格在 recent 区之前的消息
- 不传 `protectedMessageIds` 时默认保护仍生效

更新了若干既有测试：小数据集 fixtures 压缩尾部的，显式 `preserveRecentMessages: 0` opt out；两个原依赖"Rule 3 无条件保护"契约的测试改为 `> 0` 触发。

## 验证
- typecheck ✅
- **187 tests pass** ✅
- build ✅

## 安全影响
这是真实的数据安全缺陷修复——理论上模型一个错误/越界的 compress 调用就能吞掉正在进行的任务上下文。修复后，无论模型如何调用 compress，最近 N 条和最后一条用户消息都**绝不可能**被压缩。