### PR TITLE
fix: split compressible ranges at user-turn boundaries

### DIFF
--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -138,6 +138,7 @@ export function buildCompressibleRanges(
     refNum: number;
     tokens: number;
     isTool: boolean;
+    isUser: boolean;
   }[] = [];
   const protectedMsgs: {
     ref: string;
@@ -172,17 +173,23 @@ export function buildCompressibleRanges(
       refNum: rn,
       tokens: estimateMessageTokens(msg),
       isTool: isToolMessage(msg),
+      isUser: msg.role === "user",
     });
   }
 
-  // Build compressible groups (contiguous, split at gaps and user messages)
+  // Build compressible groups (contiguous, split at ref gaps and at user
+  // messages once a group has >= 3 messages). Splitting at user boundaries
+  // keeps each compressible range aligned to roughly one user turn, instead
+  // of producing one giant range spanning many turns (or, conversely, a
+  // fragment per message when ref gaps appear). Mirrors opencode-acp's
+  // buildCompressibleRanges condition.
   const compressible: CompressibleRange[] = [];
   let cur: CompressibleRange | null = null;
   let prevRefNum = -2;
 
   for (const info of compressibleMsgs) {
     const hasGap = info.refNum > prevRefNum + 1;
-    if (cur && hasGap) {
+    if (cur && ((info.isUser && cur.count >= 3) || hasGap)) {
       compressible.push(cur);
       cur = null;
     }

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -177,6 +177,41 @@ test("buildCompressibleRanges: tool/text percentage computed", () => {
   assert.equal(ranges.compressible[0]!.toolPct + ranges.compressible[0]!.textPct, 100);
 });
 
+test("buildCompressibleRanges: splits at user-turn boundaries once a group has >= 3 messages", () => {
+  // 4 user turns: each user + assistant(tool-call) + tool-result = 3 msgs.
+  // Without user-boundary splitting these collapse into one m00001–m00012
+  // block; with it they form 4 turn-aligned blocks.
+  const messages: CoreMessage[] = [];
+  for (let i = 0; i < 4; i++) {
+    messages.push(msg("u" + i, "user turn " + i + " content".repeat(50)));
+    messages.push(toolMsg("a" + i, "bash"));
+    messages.push({ id: "t" + i, role: "tool", contentType: "tool-result", toolCallId: "c" + i, text: "result".repeat(50) });
+  }
+  const state = assignAll(messages);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  assert.equal(ranges.compressible.length, 4, "one compressible block per user turn");
+  // Each block covers exactly one turn (3 msgs): u0/a0/t0, u1/a1/t1, ...
+  assert.equal(ranges.compressible[0]!.startRef, "m00001");
+  assert.equal(ranges.compressible[0]!.endRef, "m00003");
+  assert.equal(ranges.compressible[0]!.count, 3);
+  assert.equal(ranges.compressible[3]!.startRef, "m00010");
+  assert.equal(ranges.compressible[3]!.endRef, "m00012");
+});
+
+test("buildCompressibleRanges: does NOT split before a group reaches 3 messages", () => {
+  // 2 messages then a user message: group is only 2 when the user arrives,
+  // so the user message should join the existing group rather than start a new one.
+  const messages = [
+    toolMsg("a", "bash"),
+    { id: "t", role: "tool", contentType: "tool-result", toolCallId: "c", text: "result".repeat(50) },
+    msg("u", "user message"),
+  ];
+  const state = assignAll(messages);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  assert.equal(ranges.compressible.length, 1, "short group not split at user boundary");
+  assert.equal(ranges.compressible[0]!.count, 3);
+});
+
 // ─── Integration: 19-token bug fix ─────────────────────────────────────────────
 
 test("integration: tiny ranges are suppressed — fixes the 19-token compression bug", () => {


### PR DESCRIPTION
## 问题

\`buildCompressibleRanges\` 只按 refNum 连续性（gap）分组，**不按 user 消息边界分组**——与 opencode-acp 原版设计不符，注释写着 "split at gaps and user messages" 但代码没做。

两个后果：
- **过度聚合**：多个 user 回合塌成一个巨大的可压缩范围（如 4 个回合 m00001–m00012 被当作单一 chunk），过度压缩、丢失回合级粒度。
- **过度碎片化**：当出现 ref gap（protected tool 被 BLOCKED、tool-pair 调整）时，每个 assistant/tool 消息变成独立 range —— 即你观察到的 nudge 输出"一行一个消息"的现象。

## 修复

恢复 opencode-acp 原版（\`lib/messages/inject/utils.ts:695\`）的分组规则：当下一条消息是 user 消息**且当前组已达 ≥3 条**时断开新组。

\`\`\`js
// 之前
if (cur && hasGap) { ... }
// 之后 (对齐 opencode-acp)
if (cur && ((info.isUser && cur.count >= 3) || hasGap)) { ... }
\`\`\`

这保持每个可压缩块大致对应一个 user 回合，同时避免产生 sub-turn 的小碎片（≥3 才在 user 边界断开）。

## 改动
- \`compressibleMsgs\` 增加 \`isUser: msg.role === \"user\"\` 字段
- 分组条件：\`hasGap\` → \`(info.isUser && cur.count >= 3) || hasGap\`
- 2 个新测试：4 回合对话产生 4 个对齐块；2 条消息的组不在 user 边界断开（min-3 守卫）

## 验证
- 4 回合 (u/a/t)×4 fixture → 4 块：m00001–03 / 04–06 / 07–09 / 10–12（修复前是 1 块 m00001–12）
- typecheck ✅ · **189 tests pass** ✅ · build ✅

最小改动：+44/-2，2 文件。