### PR TITLE
fix: always protect the compress tool (and its result)

### DIFF
--- a/src/protected.ts
+++ b/src/protected.ts
@@ -1,5 +1,12 @@
 import type { Config, CoreMessage } from "./types.js";
 
+/** Tools that are ALWAYS protected, regardless of user config. These are ACP's
+ *  own metadata tools whose records must remain in context: compress calls
+ *  carry the summaries that decompress/search rely on, and the system prompt
+ *  treats past compress calls as load-bearing metadata. Letting them be
+ *  compressed away breaks decompress and the "summary is historical" contract. */
+export const ALWAYS_PROTECTED_TOOLS = ["compress"] as const;
+
 export function matchToolPattern(toolName: string, pattern: string): boolean {
   if (pattern.endsWith("*")) {
     return toolName.startsWith(pattern.slice(0, -1));
@@ -11,7 +18,19 @@ export function isMessageProtected(
   msg: CoreMessage,
   config: Pick<Config, "protectedTools" | "isToolProtected">,
 ): boolean {
-  if (msg.contentType !== "tool-call" || !msg.toolName) return false;
+  // tool-result carries the same toolName as its tool-call (the host projects
+  // it), so checking toolName covers both sides of a tool exchange.
+  if (
+    (msg.contentType !== "tool-call" && msg.contentType !== "tool-result") ||
+    !msg.toolName
+  ) {
+    return false;
+  }
+
+  // Hard-coded protection: ACP metadata tools are never compressible.
+  if ((ALWAYS_PROTECTED_TOOLS as readonly string[]).includes(msg.toolName)) {
+    return true;
+  }
 
   for (const pattern of config.protectedTools) {
     if (matchToolPattern(msg.toolName, pattern)) return true;
@@ -19,5 +38,40 @@ export function isMessageProtected(
 
   if (config.isToolProtected?.(msg.toolName, msg.text)) return true;
 
+  return false;
+}
+
+/** Build the set of toolCallIds whose tool-call is protected. Use this to also
+ *  protect tool-results that lack a toolName (common when the host projects a
+ *  tool-result with only toolCallId). Without it, the result half of a
+ *  protected tool exchange leaks into compressible ranges. */
+export function collectProtectedToolCallIds(
+  messages: CoreMessage[],
+  config: Pick<Config, "protectedTools" | "isToolProtected">,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const m of messages) {
+    if (m.contentType === "tool-call" && m.toolCallId && isMessageProtected(m, config)) {
+      ids.add(m.toolCallId);
+    }
+  }
+  return ids;
+}
+
+/** Like isMessageProtected, but also matches tool-results by toolCallId against
+ *  the protected call set. Use when you have the full message list available. */
+export function isMessageProtectedWithPairing(
+  msg: CoreMessage,
+  config: Pick<Config, "protectedTools" | "isToolProtected">,
+  protectedCallIds: Set<string>,
+): boolean {
+  if (isMessageProtected(msg, config)) return true;
+  if (
+    msg.contentType === "tool-result" &&
+    msg.toolCallId &&
+    protectedCallIds.has(msg.toolCallId)
+  ) {
+    return true;
+  }
   return false;
 }

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -20,7 +20,10 @@ import type {
   ProtectedRange,
 } from "./types.js";
 import type { CompressionState } from "./types.js";
-import { isMessageProtected } from "./protected.js";
+import {
+  collectProtectedToolCallIds,
+  isMessageProtectedWithPairing,
+} from "./protected.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -147,6 +150,10 @@ export function buildCompressibleRanges(
     tools: string[];
   }[] = [];
 
+  // Pairing: a tool-result may carry only toolCallId (no toolName). Collect the
+  // callIds of protected tool-calls first, then protect matching results too.
+  const protectedCallIds = collectProtectedToolCallIds(messages, config);
+
   for (const msg of messages) {
     if (isSyntheticOrPruned(msg, state)) continue;
     const ref = state.messageRefs.byRaw[msg.id];
@@ -154,7 +161,7 @@ export function buildCompressibleRanges(
 
     const rn = refNum(ref);
 
-    if (isMessageProtected(msg, config)) {
+    if (isMessageProtectedWithPairing(msg, config, protectedCallIds)) {
       protectedMsgs.push({
         ref,
         refNum: rn,

--- a/tests/protected-content.test.ts
+++ b/tests/protected-content.test.ts
@@ -246,3 +246,56 @@ test("Feature 2+3: both protectedTools and isToolProtected work together", () =>
   assert.ok(block.summary.includes("Protected: skill"), "skill content appended");
   assert.ok(block.summary.includes("Protected: edit"), "edit content appended");
 });
+
+test("compress tool is ALWAYS protected, even with empty protectedTools", () => {
+  const core = createCore();
+  const messages = [
+    msg("a", longText),
+    toolCall("b", "compress", "call1", JSON.stringify({ content: [{ startId: "m00001", endId: "m00001", summary: "x".repeat(60) }] })),
+    toolResult("c", "call1", "compressed"),
+    msg("d", longText),
+  ];
+  const state = setupRefs(messages);
+  // No protectedTools configured at all — compress must still be protected.
+  const config = cfg({ protectedTools: [] });
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00004", summary: validSummary }],
+    messages,
+    state,
+    config,
+  });
+
+  const block = result.state.blocks[0]!;
+  assert.ok(!block.directMessageIds.includes("b"), "compress tool-call excluded regardless of config");
+  assert.ok(!block.directMessageIds.includes("c"), "compress tool-result excluded regardless of config");
+  assert.ok(block.directMessageIds.includes("a"), "regular msg remains");
+  assert.ok(block.directMessageIds.includes("d"), "regular msg remains");
+});
+
+test("compress tool-result is protected by toolCallId pairing even without toolName", () => {
+  // Hosts often project a tool-result with only toolCallId (no toolName).
+  // The result half of a compress call must still be protected via pairing.
+  const core = createCore();
+  const messages = [
+    msg("a", longText),
+    toolCall("b", "compress", "callX", "{}"),
+    { id: "c", role: "tool", contentType: "tool-result", toolCallId: "callX", text: "result".repeat(50) },
+    msg("d", longText),
+  ];
+  const state = setupRefs(messages);
+  const config = cfg({ protectedTools: [] });
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00004", summary: validSummary }],
+    messages,
+    state,
+    config,
+  });
+
+  const block = result.state.blocks[0]!;
+  assert.ok(!block.directMessageIds.includes("b"), "compress tool-call excluded");
+  assert.ok(!block.directMessageIds.includes("c"), "compress tool-result (no toolName) excluded via pairing");
+  assert.ok(block.directMessageIds.includes("a"), "regular msg remains");
+  assert.ok(block.directMessageIds.includes("d"), "regular msg remains");
+});


### PR DESCRIPTION
## 问题

compress 工具的调用记录是 ACP 元数据（system prompt 依赖、decompress 依赖），但 \`isMessageProtected\` 只匹配 \`contentType === \"tool-call\"\` **且**要求该工具列在 \`protectedTools\` 里 —— 而 pai-acp 默认 \`protectedTools: []\`。

后果：compress 的 tool-call **和** tool-result 都漏进推荐给模型的可压缩范围，模型可能被 nudge 去压缩掉自己的 compress 调用，破坏 decompress/search 和"summary 是历史元数据"的契约。

实测（修复前）：
\`\`\`
消息: u0, bash, tool, compress(call), tool(result), u1, bash, tool
可压缩块: m00001–m00005  ← compress 调用(m4) 和 result(m5) 都在里
\`\`\`

## 修复

1. **\`ALWAYS_PROTECTED_TOOLS = [\"compress\"]\`**：\`isMessageProtected\` 硬编码此列表，compress 无论用户配置如何都受保护。未来加更多元数据工具只需一行。

2. **tool-result 也纳入判断**：contentType 守卫从 \`tool-call\` 扩展到 \`tool-call | tool-result\`。host 投影 tool-result 时带相同 toolName，有 toolName 时直接匹配。

3. **toolCallId 配对**（应对 tool-result 缺 toolName 的常见情况）：新增 \`collectProtectedToolCallIds()\` + \`isMessageProtectedWithPairing()\`。recommend 路径用配对版，compress 的 tool-result 即便没有 toolName 也通过其 call 的 id 被保护。

\`applyCompression\` 的 \`filterProtectedToolMessages\` 已有 toolCallId 配对逻辑，硬编码列表同时流经 recommend（buildCompressibleRanges）和执行（applySingleRange）两条路径。

## 修复后
\`\`\`
可压缩块: m00001–m00003, m00006–m00008  ← compress 调用/result 都排除
protected: m00004–m00005 [compress]
\`\`\`

## 测试
- 2 个新测试：空 protectedTools 下 compress 仍被排除；无 toolName 的 compress result 通过配对被排除
- typecheck ✅ · **191 tests pass** ✅ · build ✅

+117/-3，3 文件。