### PR TITLE
fix: stop appending protected tool content to summaries (filter only)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -510,7 +510,7 @@ function applySingleRange(input: SingleRangeInput): number {
     (id) => !input.preExistingCoverage.has(id),
   );
 
-  const { filteredIds, appendedProtectedText } = filterProtectedToolMessages(
+  const filteredIds = filterProtectedToolMessages(
     directMessageIds,
     input.messages,
     input.config,
@@ -556,24 +556,12 @@ function applySingleRange(input: SingleRangeInput): number {
   }
 
   const blockId = allocateBlockId(input.state);
-  const finalSummary =
-    appendedProtectedText.length > 0
-      ? `${input.spec.summary}\n\nThe following protected tool calls were used in this conversation as well:\n${appendedProtectedText.join("")}`
-      : input.spec.summary;
-
-  // Re-check maxSummaryLength after appending protected content (Bug fix: bypass via appended text)
-  const maxLen = input.spec.summaryMaxChars ?? input.config.compress.maxSummaryLength;
-  if (maxLen > 0 && finalSummary.length > maxLen) {
-    throw new Error(
-      `Summary too long after appending protected content (${finalSummary.length} chars, max ${maxLen}). Reduce the summary or remove protected tools from the range.`,
-    );
-  }
   const block: CompressionBlock = {
     blockId,
     runId: input.runId,
     tier: outputTier,
     topic: input.spec.topic,
-    summary: finalSummary,
+    summary: input.spec.summary,
     directMessageIds: filteredIds,
     effectiveMessageIds: [...effectiveMessageIds],
     directBlockIds: [...consumedBlockIds],
@@ -661,28 +649,25 @@ function filterProtectedToolMessages(
   directMessageIds: string[],
   messages: CoreMessage[],
   config: Config,
-): { filteredIds: string[]; appendedProtectedText: string[] } {
-  const removedToolCallIds = new Set<string>();
-  const allProtectedCallIds = new Set<string>();
+): string[] {
+  // Protected tool calls (and their results, paired by toolCallId) stay in
+  // visible context and are simply dropped from the compressible set. They are
+  // NOT folded into the summary — the summary reflects what the author wrote,
+  // nothing auto-appended.
+  const protectedCallIds = new Set<string>();
   const removedIds = new Set<string>();
-  const appendedProtectedText: string[] = [];
   for (const msg of messages) {
     if (isMessageProtected(msg, config) && msg.toolCallId) {
-      allProtectedCallIds.add(msg.toolCallId);
+      protectedCallIds.add(msg.toolCallId);
     }
   }
 
   for (const id of directMessageIds) {
     const msg = messages.find((m) => m.id === id);
     if (!msg) continue;
-    if (!isMessageProtected(msg, config)) continue;
-
-    removedIds.add(id);
-    if (msg.toolCallId) removedToolCallIds.add(msg.toolCallId);
-    if (msg.text) {
-      appendedProtectedText.push(
-        `\n### Protected: ${msg.toolName ?? "tool"}\n${msg.text}`,
-      );
+    if (isMessageProtected(msg, config)) {
+      removedIds.add(id);
+      if (msg.toolCallId) protectedCallIds.add(msg.toolCallId);
     }
   }
 
@@ -693,17 +678,13 @@ function filterProtectedToolMessages(
     if (
       msg.contentType === "tool-result" &&
       msg.toolCallId &&
-      (removedToolCallIds.has(msg.toolCallId) ||
-        allProtectedCallIds.has(msg.toolCallId))
+      protectedCallIds.has(msg.toolCallId)
     ) {
       removedIds.add(id);
     }
   }
 
-  return {
-    filteredIds: directMessageIds.filter((id) => !removedIds.has(id)),
-    appendedProtectedText,
-  };
+  return directMessageIds.filter((id) => !removedIds.has(id));
 }
 
 function resolveTargetTier(

--- a/tests/protected-content.test.ts
+++ b/tests/protected-content.test.ts
@@ -66,7 +66,7 @@ test("Feature 2: protected tool-call is excluded from compression range", () => 
   assert.ok(block.directMessageIds.includes("d"), "regular msg 'd' should remain");
 });
 
-test("Feature 2: protected tool content is appended to summary", () => {
+test("Feature 2: protected tool messages are filtered out, not appended", () => {
   const core = createCore();
   const messages = [
     msg("a", longText),
@@ -85,8 +85,11 @@ test("Feature 2: protected tool content is appended to summary", () => {
   });
 
   const block = result.state.blocks[0]!;
-  assert.ok(block.summary.includes("Protected: skill"), "summary should contain protected tool heading");
-  assert.ok(block.summary.includes('{"name":"git-master"}'), "summary should contain protected tool content");
+  assert.ok(!block.directMessageIds.includes("b"), "protected skill tool-call excluded from compressed set");
+  assert.ok(!block.directMessageIds.includes("c"), "protected skill tool-result excluded");
+  assert.ok(!block.summary.includes("Protected:"), "no protected content folded into summary");
+  assert.ok(!block.summary.includes('{"name":"git-master"}'), "protected tool content not leaked into summary");
+  assert.equal(block.summary, validSummary, "summary is exactly what the author wrote");
 });
 
 test("Feature 2: non-protected tool-call is NOT excluded", () => {
@@ -163,7 +166,7 @@ test("Feature 3: isToolProtected custom predicate excludes matching tools", () =
   const block = result.state.blocks[0]!;
   assert.ok(!block.directMessageIds.includes("b"), "write to .env should be excluded by predicate");
   assert.ok(!block.directMessageIds.includes("c"), "write result should be excluded too");
-  assert.ok(block.summary.includes("Protected: write"), "protected content appended");
+  assert.ok(!block.summary.includes("Protected:"), "no protected content folded into summary");
 });
 
 test("Feature 3: wildcard pattern in protectedTools works", () => {
@@ -243,8 +246,8 @@ test("Feature 2+3: both protectedTools and isToolProtected work together", () =>
   assert.ok(!block.directMessageIds.includes("e"), "edit result excluded");
   assert.ok(block.directMessageIds.includes("a"), "regular msg remains");
   assert.ok(block.directMessageIds.includes("f"), "regular msg remains");
-  assert.ok(block.summary.includes("Protected: skill"), "skill content appended");
-  assert.ok(block.summary.includes("Protected: edit"), "edit content appended");
+  assert.ok(!block.summary.includes("Protected: skill"), "skill content NOT folded into summary");
+  assert.ok(!block.summary.includes("Protected: edit"), "edit content NOT folded into summary");
 });
 
 test("compress tool is ALWAYS protected, even with empty protectedTools", () => {

--- a/tests/regression-features.test.ts
+++ b/tests/regression-features.test.ts
@@ -71,7 +71,11 @@ function setupRefs(
 const longText = "x".repeat(6000);
 const validSummary = "x".repeat(60);
 
-test("Bug 1: maxSummaryLength enforced after appending protected content", () => {
+test("Bug 1: protected tool messages are filtered (no summary inflation)", () => {
+  // Was: "maxSummaryLength enforced after appending protected content" — that
+  // append-and-recheck behavior is gone. Protected messages are dropped from
+  // the compressed set; the summary is exactly what the author wrote, so a
+  // large protected tool output can never inflate/reject the summary.
   const core = createCore();
   const messages: CoreMessage[] = [
     msg("a", longText),
@@ -98,8 +102,6 @@ test("Bug 1: maxSummaryLength enforced after appending protected content", () =>
     compressionTiming: {},
   }, config);
 
-  // a=m00001, b=BLOCKED(skill), c=m00002, d=m00003
-  // Range m00001->m00003 covers all 4 messages (BLOCKED 'b' is between indices)
   const result = core.applyCompression({
     ranges: [{ startRef: "m00001", endRef: "m00003", summary: "short" }],
     messages,
@@ -108,12 +110,14 @@ test("Bug 1: maxSummaryLength enforced after appending protected content", () =>
     countTokens: defaultCountTokens,
   });
 
-  assert.equal(result.result.blocksCreated, 0);
-  assert.equal(result.result.errors.length, 1);
-  assert.match(
-    result.result.errors[0]!,
-    /Summary too long after appending protected content/,
-  );
+  assert.equal(result.result.blocksCreated, 1, "compression succeeds — no length error");
+  assert.equal(result.result.errors.length, 0, "no errors");
+  const block = result.state.blocks[0]!;
+  assert.equal(block.summary, "short", "summary is exactly the author's text");
+  assert.ok(!block.directMessageIds.includes("b"), "protected skill call excluded");
+  assert.ok(!block.directMessageIds.includes("c"), "protected skill result excluded");
+  assert.ok(block.directMessageIds.includes("a"), "regular msg compressed");
+  assert.ok(block.directMessageIds.includes("d"), "regular msg compressed");
 });
 
 test("Bug 2: orphaned tool-call — protected call outside range, result inside", () => {


### PR DESCRIPTION
## 问题

旧设计：protected 工具消息（protectedTools + compress 等）从压缩集中剔除后，还把其**原始文本追加**到 block summary：

\`\`\`
finalSummary = summary + "\n\nThe following protected tool calls were used in this conversation as well:\n### Protected: skill\n{原始工具输出}"
\`\`\`

两个坏处：

1. **逃生入口失效**：作者控制不了的追加内容（如 50K 的 skill 输出）会把 summary 撑爆，触发二次长度校验 \"Summary too long after appending protected content\"。该校验复用同一个 \`summaryMaxChars\`，而 \`summaryMaxChars\` 本是给作者放宽**自己写的** summary 的——对系统追加的 payload 无能为力。opencode-acp 没有这个二次校验。
2. **污染摘要**：把原始工具 dump 塞进模型写的 summary，违背摘要的初衷。

## 修复

\`filterProtectedToolMessages\` 现在只做过滤（返回 \`string[]\`），protected tool-call 及其配对的 tool-result（按 toolCallId）从压缩集移除、留在可见上下文。block summary 就是作者写的原样。

移除：appendedProtectedText 路径、finalSummary 拼接、追加后长度二次校验。

\`summaryMaxChars\`/\`maxSummaryLength\` 现在只约束作者写的 summary（逃生入口恢复）。

## 测试
- 更新 4 个断言 \"appended\" 的测试 → 断言 \"filtered, not appended\"
- 新增回归：50K 的 protected 工具结果不再让短 summary 报错
- typecheck ✅ · **191 tests pass** ✅ · build ✅

-48/+36，3 文件。