### PR TITLE
fix: defaultCountTokens no longer drops digits/symbols to zero

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -4,9 +4,12 @@ const require = createRequire(import.meta.url);
 
 export function defaultCountTokens(text: string): number {
   if (!text) return 0;
-  const ascii = text.match(/[a-zA-Z][a-zA-Z0-9_'-]*/g);
+  // CJK chars tokenize ~1:1 (chars/4 badly underestimates them). Count them
+  // directly, then estimate the non-CJK remainder with chars/4 so digits,
+  // punctuation, and symbols in code/JSON are not dropped to zero.
   const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g);
-  return (ascii?.length ?? 0) + (cjk?.length ?? 0);
+  const cjkCount = cjk?.length ?? 0;
+  return cjkCount + Math.ceil((text.length - cjkCount) / 4);
 }
 
 export function estimateMessageTokens(text: string | undefined): number {

--- a/tests/tokenizer.test.ts
+++ b/tests/tokenizer.test.ts
@@ -13,11 +13,13 @@ test("estimateTokensFast: chars/4 ratio", () => {
   assert.equal(estimateTokensFast("你好世界测试"), 2);
 });
 
-test("defaultCountTokens: English word counting", () => {
+test("defaultCountTokens: English + code via chars/4", () => {
   assert.equal(defaultCountTokens(""), 0);
-  assert.equal(defaultCountTokens("hello world"), 2);
-  assert.equal(defaultCountTokens("function test_fn() {}"), 2);
-  assert.equal(defaultCountTokens("camelCase snake_case kebab-case"), 3);
+  // "hello world": 11 non-CJK chars → ceil(11/4) = 3
+  assert.equal(defaultCountTokens("hello world"), 3);
+  // "function test_fn() {}": 21 non-CJK chars → ceil(21/4) = 6 (symbols now count)
+  assert.equal(defaultCountTokens("function test_fn() {}"), 6);
+  assert.equal(defaultCountTokens("camelCase snake_case kebab-case"), 8);
 });
 
 test("defaultCountTokens: CJK character counting", () => {
@@ -26,9 +28,11 @@ test("defaultCountTokens: CJK character counting", () => {
   assert.equal(defaultCountTokens("안녕하세요"), 5);
 });
 
-test("defaultCountTokens: mixed ASCII + CJK", () => {
-  const count = defaultCountTokens("hello 你好 world 世界");
-  assert.equal(count, 6);
+test("defaultCountTokens: digits and symbols are counted", () => {
+  // Old impl dropped digits/symbols to zero; chars/4 covers them now.
+  assert.ok(defaultCountTokens("12345 67890") > 0);
+  assert.ok(defaultCountTokens("{ } ( ) [ ] = + - * /") > 0);
+  assert.equal(defaultCountTokens("x = 1"), 2);
 });
 
 test("createBpeTokenizer: falls back when @anthropic-ai/tokenizer not installed", () => {
@@ -50,13 +54,10 @@ test("createBpeTokenizer: fallback handles CJK", () => {
   assert.equal(count, 4);
 });
 
-test("estimateTokensFast vs defaultCountTokens: different accuracy profiles", () => {
-  const text = "function compressMessages(messages: CoreMessage[]): CoreMessage[]";
-  const fast = estimateTokensFast(text);
-  const word = defaultCountTokens(text);
-
-  assert.ok(fast > word, "chars/4 should overestimate for code (many symbols)");
-  assert.ok(fast > 0 && word > 0, "both should return positive counts");
+test("defaultCountTokens: mixed ASCII + CJK", () => {
+  // 4 CJK chars (1 each) + 13 non-CJK chars → ceil(13/4) = 4 → 8 total
+  const count = defaultCountTokens("hello 你好 world 世界");
+  assert.equal(count, 8);
 });
 
 test("TokenCountFn type is compatible with createCore ports", () => {


### PR DESCRIPTION
## 问题
旧正则 \`/[a-zA-Z][a-zA-Z0-9_'-]*/g\` 只匹配字母开头的单词,导致**数字、标点、符号全部计 0 token**。代码/JSON 密集的会话被系统性低估(实测约 0.6× chars/4),直接拖偏压缩阈值、nudge 触发和 status 报告。

## 修复
- CJK 字符 1:1 计数(chars/4 严重低估中文,保持)
- 非 CJK 部分用 chars/4 统一覆盖 ASCII 单词、数字、符号

\`\`\`js
const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g);
const cjkCount = cjk?.length ?? 0;
return cjkCount + Math.ceil((text.length - cjkCount) / 4);
\`\`\`

## 实测样本对比
| 样本 | 旧 | 新 |
|------|-----|-----|
| \`function test_fn() {}\` | 2 | 6 (符号纳入) |
| \`{"topic":"auth",...}\` | 4 | 10 (JSON 不再为0) |
| \`你好世界\` | 4 | 4 (CJK 不变) |

测试更新为新语义; 191/191 pass。

> 这是 pai-acp token 计数偏低(显示 2% vs pi 实际 24%)的根因之一。修复后 pai-acp 的 nudge/usage 判断会更准确。pai-acp 侧还需接入 pi 的 \`ctx.getContextUsage()\` 获取真实 token。