### PR TITLE
release: v0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release acp-kernel 0.0.8. Bundles #9 (tokenizer fix), #10 (tier list blocks), #11 (tier doesn't bypass growth) — all merged on master but unreleased (npm still 0.0.7 = old tokenizer). pai-acp CI fails installing real 0.0.7. Merging triggers CI auto-tag + npm publish. 191/191 pass.