### PR TITLE
refactor: unified tier nudge model (per-tier cadence, shared suppression)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -212,6 +212,10 @@ export function createCore(ports: Ports = {}): CompressionCore {
       // nudge re-fires in a feedback loop (the §5.7 baseline-reset bug).
       state.nudge.lastPerMessageNudgeTokens = 0;
       state.nudge.lastNudgeShownTokens = 0;
+      // Clearing the per-tier cadence too: after a successful compression
+      // (which may have consumed blocks of tier N to produce tier N+1), every
+      // tier should be eligible to re-evaluate from the new token count.
+      state.nudge.lastShownByTier = {};
     }
 
     return { state, result: { blocksCreated, tokensCompressed, errors } };
@@ -383,6 +387,7 @@ const nudgeNode: PipelineNode = {
       state: io.state,
       messages: io.messages,
       recommendation: io.effects.recommendation,
+      countTokens: ctx.countTokens,
     });
 
     const baseline = io.state.nudge.lastPerMessageNudgeTokens;
@@ -407,6 +412,12 @@ const nudgeNode: PipelineNode = {
 
     if (nudge.shouldInject) {
       stamped.lastNudgeShownTokens = ctx.tokenCount;
+      // Record the injected tier's own cadence baseline. Shared baseline
+      // (lastNudgeShownTokens) suppresses lower-priority tiers within this
+      // turn; the per-tier entry throttles re-firing of the SAME tier.
+      if (nudge.tier !== null) {
+        stamped.lastShownByTier = { ...stamped.lastShownByTier, [nudge.tier]: ctx.tokenCount };
+      }
     }
 
     return {
@@ -716,6 +727,7 @@ interface NudgeInput {
   state: CompressionState;
   messages: CoreMessage[];
   recommendation?: Recommendation;
+  countTokens: (t: string) => number;
 }
 
 function resolveAdaptiveGrowth(
@@ -732,8 +744,30 @@ function resolveAdaptiveGrowth(
   );
 }
 
+/** Compressible amount for each tier — all tiers use the SAME definition
+ *  ("how much can be compressed at this tier"), so they are handled by one
+ *  unified loop. T1 = compressible raw-message tokens (excludes protected /
+ *  already-covered); T2 = total summary tokens of all active tier-1 blocks;
+ *  T3 = total summary tokens of all active tier-2 blocks. The "zero filter"
+ *  for block tiers is simply that all blocks are compressible by default. */
+function pendingByTier(
+  state: CompressionState,
+  recommendation: Recommendation | undefined,
+  countTokens: (t: string) => number,
+): Record<number, { pending: number; targetBlocks: CompressionBlock[] }> {
+  const out: Record<number, { pending: number; targetBlocks: CompressionBlock[] }> = {};
+  const compressible = recommendation?.contextRanges.compressible ?? [];
+  out[1] = { pending: compressible.reduce((s, r) => s + r.tokens, 0), targetBlocks: [] };
+  const active = activeBlocks(state);
+  const t1 = active.filter((b) => b.tier === 1);
+  const t2 = active.filter((b) => b.tier === 2);
+  out[2] = { pending: t1.reduce((s, b) => s + countTokens(b.summary), 0), targetBlocks: t1 };
+  out[3] = { pending: t2.reduce((s, b) => s + countTokens(b.summary), 0), targetBlocks: t2 };
+  return out;
+}
+
 function decideNudge(input: NudgeInput): NudgeDecision {
-  const { config, state, tokenCount, recommendation } = input;
+  const { config, state, tokenCount, recommendation, countTokens } = input;
   const limit = config.modelContextLimit;
   const usage = limit > 0 ? tokenCount / limit : 0;
 
@@ -763,52 +797,59 @@ function decideNudge(input: NudgeInput): NudgeDecision {
 
   const growthSinceReference = tokenCount - growthReference;
 
-  const growthTriggered = growthSinceReference >= effectiveThreshold;
+  const rec = recommendation;
+  const tiers = pendingByTier(state, rec, countTokens);
 
-  let shouldContextNudge = emergencyOverride || growthTriggered;
-
-  if (shouldContextNudge && !emergencyOverride) {
-    shouldContextNudge = growthSinceReference >= growthFloor;
-  }
-
-  let tier: CompressionTier | null = null;
-  let tierTargetBlocks: CompressionBlock[] = [];
-  if (config.tiers.enabled) {
-    const active = activeBlocks(state);
-    const activeT1 = active.filter((b) => b.tier === 1);
-    const activeT2 = active.filter((b) => b.tier === 2);
-    if (activeT2.length >= config.tiers.tier3Trigger) {
-      tier = 3;
-      tierTargetBlocks = activeT2;
-    } else if (activeT1.length >= config.tiers.tier2Trigger) {
-      tier = 2;
-      tierTargetBlocks = activeT1;
+  // Unified injection arbitration, priority T1 > T2 > T3 (ascending). Each
+  // tier has its OWN cadence (lastShownByTier) so firing one doesn't block
+  // another across turns; within a turn we inject at most the FIRST eligible
+  // tier and stop, which raises the shared baseline (lastNudgeShownTokens) so
+  // lower-priority tiers see a higher reference and naturally defer.
+  let injectedTier: CompressionTier | null = null;
+  let injectedReason = "";
+  // growth acts as the "has accumulated since baseline" signal; pending is the
+  // "there is enough compressible content" signal. Both must hold for a
+  // non-emergency injection. This keeps the first turn (growth 0) from firing
+  // immediately even if a lot is compressible — it just establishes baseline.
+  const growthReady = growthSinceReference >= growthFloor;
+  if (!emergencyOverride && growthReady) {
+    for (const tier of [1, 2, 3] as const) {
+      if (!config.tiers.enabled && tier > 1) break;
+      const info = tiers[tier];
+      if (!info || info.pending < nudgeGrowthTokens) continue;
+      const lastShown = state.nudge.lastShownByTier[tier] ?? 0;
+      // Per-tier cadence: even with growth, a tier that fired recently waits
+      // for its own cadence window. First time (lastShown===0) is always met.
+      const cadenceMet = lastShown === 0 || tokenCount - lastShown >= growthFloor;
+      if (!cadenceMet) continue;
+      injectedTier = tier;
+      injectedReason = tier === 1
+        ? `T1 compressible ${info.pending} >= ${nudgeGrowthTokens}, growth ${growthSinceReference}, usage ${Math.round(usage * 100)}%`
+        : `T${tier} distill ready: ${info.targetBlocks.length} tier-${tier - 1} blocks (${info.pending} tokens) >= ${nudgeGrowthTokens}, usage ${Math.round(usage * 100)}%`;
+      break;
     }
   }
 
-  const rec = recommendation;
-  const nothingToCompress = rec ? rec.contextRanges.compressible.length === 0 : false;
-
-  // `tier` changes WHAT a nudge says (list target blocks, distillation rules),
-  // not WHETHER it fires. A tier-2/3 trigger should not bypass the growth
-  // check — otherwise once tier blocks accumulate the nudge fires on every
-  // turn regardless of how little context grew, and since tier ignores
-  // lastNudgeShownTokens the halving logic can't throttle it either. The only
-  // unconditional trigger is emergency overflow.
-  const shouldInject = shouldContextNudge;
+  const shouldInject = emergencyOverride || injectedTier !== null;
 
   let reason: string;
-  if (!shouldInject) {
-    const tierHint = tier !== null ? `, tier-${tier} ready (distill when growth reaches threshold)` : "";
-    reason = `growth ${growthSinceReference} < threshold ${effectiveThreshold}${hasPendingNudge ? " (halved)" : ""} (floor ${growthFloor})${tierHint}`;
-  } else if (emergencyOverride) {
+  if (emergencyOverride) {
     reason = `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}%`;
-  } else if (tier !== null) {
-    reason = `growth ${growthSinceReference} >= ${effectiveThreshold}${hasPendingNudge ? " (halved)" : ""}, usage ${Math.round(usage * 100)}%, tier-${tier} distillation`;
-  } else if (nothingToCompress) {
-    reason = `growth ${growthSinceReference} >= ${effectiveThreshold} but no specific ranges worth compressing`;
+  } else if (injectedTier !== null) {
+    reason = injectedReason;
   } else {
-    reason = `growth ${growthSinceReference} >= ${effectiveThreshold}${hasPendingNudge ? " (halved)" : ""}, usage ${Math.round(usage * 100)}%`;
+    const tiersList = [1, 2, 3] as const;
+    const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
+    const ready = eligible
+      .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens)
+      .map((t) => `T${t} ${tiers[t]!.pending}`);
+    const readyHint = ready.length > 0 ? `, ready: ${ready.join(", ")}` : "";
+    const blocked = eligible
+      .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens && (state.nudge.lastShownByTier[t] ?? 0) > 0 && tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor)
+      .map((t) => `T${t} (cadence)`);
+    const blockedHint = blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
+    const maxPending = Math.max(0, ...Object.values(tiers).map((t) => t.pending));
+    reason = `max compressible ${maxPending} < threshold ${nudgeGrowthTokens}${readyHint}${blockedHint}, growth ${growthSinceReference} (floor ${growthFloor})`;
   }
 
   const ctxBreakdown = computeContextBreakdown(input.messages, tokenCount, growthSinceReference);
@@ -818,9 +859,9 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     reason,
     compressibleRanges: rec?.recommendedRanges ?? [],
     protectedRanges: rec?.contextRanges.protected ?? [],
-    tierTargetBlocks,
+    tierTargetBlocks: injectedTier ? tiers[injectedTier]!.targetBlocks : [],
     contextUsage: usage,
-    tier,
+    tier: injectedTier,
     breakdown: {
       usage,
       growth: growthSinceReference,
@@ -830,6 +871,9 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       growthFloor,
       hasPendingNudge: hasPendingNudge ? 1 : 0,
       emergencyOverride: emergencyOverride ? 1 : 0,
+      pendingT1: tiers[1]!.pending,
+      pendingT2: tiers[2]!.pending,
+      pendingT3: tiers[3]!.pending,
     },
     contextBreakdown: ctxBreakdown,
   };

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,6 +9,7 @@ export function createInitialState(): CompressionState {
       lastNudgeShownTokens: 0,
       baselineTokens: 0,
       anchors: {},
+      lastShownByTier: {},
     },
     stats: { tokensCompressed: 0, compressionCount: 0 },
     nextBlockId: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,12 @@ export interface NudgeState {
   lastNudgeShownTokens: number;
   baselineTokens: number;
   anchors: Record<string, unknown>;
+  /** Per-tier cadence baseline: the tokenCount at which that tier last had a
+   *  nudge injected. A tier is allowed to inject again only once
+   *  `tokenCount - lastShownByTier[tier] >= growthFloor`, independent of other
+   *  tiers. Using a record (not N named fields) so adding tier 4+ needs no
+   *  schema change. */
+  lastShownByTier: Record<number, number>;
 }
 
 export interface CompressionStats {

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -215,23 +215,25 @@ test("nudge: full growth cycle — baseline → growth → nudge → compress �
   assert.equal(turn.nudge.shouldInject, true, "growth 25000 >= 6000, usage 55% >= 45%");
 });
 
-test("nudge: tier flags ready but does not bypass growth check", () => {
+test("nudge: tier distillation fires when lower-tier blocks accumulate enough", () => {
   const core = createCore();
-  const config = buildConfig({ tiers: { enabled: true, tier2Trigger: 3, tier3Trigger: 10 } });
+  // Preserve recent messages so pendingT1 (raw compressible) stays below
+  // threshold — we want to isolate the T2 distillation path, not T1.
+  const config = buildConfig({ tiers: { enabled: true, tier2Trigger: 3, tier3Trigger: 10 }, preserveRecentMessages: 30 });
   const messages = makeMessages(30);
   let state = createInitialState();
   // First turn establishes a baseline at a high token count.
   state = core.processTurn({ messages, state, config, tokenCount: 50000 }).state;
 
-  // Inject three active T1 blocks directly — we are testing the nudge tier
-  // logic, not applyCompression validation.
+  // Inject three active T1 blocks with large summaries so pendingT2 (sum of
+  // their summary tokens) exceeds the nudge threshold (buildConfig → 6000).
   state = {
     ...state,
     blocks: [0, 1, 2].map((i) => ({
       blockId: `b${i + 1}`,
       runId: "r1",
       tier: 1 as const,
-      summary: `tier-1 summary ${i} `.repeat(20),
+      summary: `tier-1 summary block ${i} with substantial content `.repeat(1200),
       directMessageIds: [`m${i}`],
       effectiveMessageIds: [`m${i}`],
       directBlockIds: [],
@@ -244,17 +246,16 @@ test("nudge: tier flags ready but does not bypass growth check", () => {
   };
   assert.equal(state.blocks.filter((b) => b.active && b.tier === 1).length, 3, "three T1 blocks present");
 
-  // tier-2 is READY (3 T1 blocks), but growth is zero — must NOT inject.
-  // Tier changes the nudge content, not whether it fires.
+  // growth is zero — must NOT inject even though T2 blocks are ready.
   let turn = core.processTurn({ messages, state, config, tokenCount: 50000 });
-  assert.equal(turn.nudge.tier, 2, "tier-2 is flagged as ready");
-  assert.equal(turn.nudge.shouldInject, false, "no growth → no injection even with tier ready");
-  assert.equal(turn.nudge.tierTargetBlocks?.length, 3, "target blocks listed");
+  assert.equal(turn.nudge.shouldInject, false, "no growth → no injection even with T2 ready");
 
-  // Once growth passes the threshold, the nudge fires WITH tier distillation info.
-  turn = core.processTurn({ messages, state, config, tokenCount: 80000 });
-  assert.equal(turn.nudge.shouldInject, true, "growth past threshold → injects");
-  assert.equal(turn.nudge.tier, 2, "nudge carries tier-2 distillation guidance");
+  // Once growth passes the floor (buildConfig floor 5000), the nudge fires
+  // WITH tier-2 distillation info (T1 blocked by preserve → T2 wins).
+  turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, "growth past floor → injects");
+  assert.equal(turn.nudge.tier, 2, "nudge carries tier-2 distillation guidance (T1 blocked by preserve)");
+  assert.ok((turn.nudge.tierTargetBlocks?.length ?? 0) >= 1, "target T1 blocks listed");
 });
 
 test("nudge: production config (preserveRecentMessages > 0) computes compressible ranges", () => {


### PR DESCRIPTION
## 核心重构: T1/T2/T3 统一处理

按设计意图: T1/T2/T3 本质一样, 都是\"该层当前可压缩的量\"(一个值), 不是 N 个字段。

### 统一模型
- **pendingByTier()**: 每个 tier 的 pending = 可压缩量。T1=可压缩原始消息token(排除protected); T2=所有T1块summary总量; T3=所有T2块summary总量。三者定义完全一样。
- **共用阈值** nudgeGrowthTokens。

### 触发 (优先级 T1 > T2 > T3)
某 tier 注入条件: \`pending >= threshold AND growth >= floor AND 自身cadence满足\`。同 turn 内只注入**第一个**满足的 tier 然后停止 → 抬高共享基准(lastNudgeShownTokens) → 低优先级 tier 自然推迟。

### State
\`NudgeState.lastShownByTier: Record<number, number>\` — 每 tier 独立 cadence 基准。用 record(非N个字段), 加 tier 4+ 无需改 schema。压缩成功时清零。

### 为什么
之前 tier 触发不看 growth、与 T1 无共享 cadence → T1 块一堆积就每 turn 触发(刷屏), 且 T2 会抢在 T1 压缩前。现在 T1 永远优先, 蒸馏只在没更紧急的事时发生。

typecheck ✅ · 191/191 tests ✅