### PR TITLE
release: v0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release acp-kernel 0.0.9. Bundles merged-but-unreleased work:

- #13 feat: uncompressed ranges view merges consecutive messages into blocks
- #14 refactor: unified tier nudge model (per-tier cadence, shared suppression)

0.0.8 only contained the tokenizer/tier-list/tier-growth fixes (#9/#10/#11). pai-acp needs 0.0.9 for the unified tier model and range merging.

Merging triggers CI auto-tag + npm publish. 191/191 tests pass.