### PR TITLE
fix: nudge reason reports the actual blocking condition

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -849,7 +849,17 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       .map((t) => `T${t} (cadence)`);
     const blockedHint = blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
     const maxPending = Math.max(0, ...Object.values(tiers).map((t) => t.pending));
-    reason = `max compressible ${maxPending} < threshold ${nudgeGrowthTokens}${readyHint}${blockedHint}, growth ${growthSinceReference} (floor ${growthFloor})`;
+    // Report the ACTUAL blocking condition, not a fixed template. A session
+    // can have plenty to compress (pending >= threshold) but still not
+    // inject because growth/floor/cadence isn't met — the old fixed
+    // "< threshold" string lied in that case.
+    const pendingShort = maxPending < nudgeGrowthTokens;
+    const growthShort = growthSinceReference < growthFloor;
+    const parts: string[] = [];
+    if (pendingShort) parts.push(`max compressible ${maxPending} < threshold ${nudgeGrowthTokens}`);
+    if (growthShort) parts.push(`growth ${growthSinceReference} < floor ${growthFloor}`);
+    if (parts.length === 0) parts.push(`max compressible ${maxPending}, growth ${growthSinceReference}`);
+    reason = `${parts.join("; ")}${readyHint}${blockedHint}`;
   }
 
   const ctxBreakdown = computeContextBreakdown(input.messages, tokenCount, growthSinceReference);


### PR DESCRIPTION
Cherry-picked from PR#16's branch — pushed there *after* #16 was merged, so it never landed on master.

The not-injected reason always said `max compressible X < threshold Y` with a fixed `<`, even when pending was plenty (X > Y) and the real blocker was growth < floor or cadence. A session with 92K compressible against a 50K threshold reported "max compressible 92676 < threshold 50000" — a lie that read as "nothing to compress".

Now computes which conditions actually failed:
- pending < threshold → "max compressible X < threshold Y"
- growth < floor      → "growth G < floor F"
- both                → joined with "; "
- neither (cadence)   → just lists pending/growth

typecheck ✅ · 191/191 tests ✅