### PR TITLE
fix: hide all orphaned compress calls

### DIFF
--- a/src/hide-consumed.ts
+++ b/src/hide-consumed.ts
@@ -1,6 +1,10 @@
 import type { CompressionState, CoreMessage } from "./types.js";
 
-const KEEP_LAST_ORPHANED = 2;
+// Orphaned compress calls (no matching active block, e.g. failed attempts or
+// historical calls whose blocks predate compressCallId recording) are fully
+// hidden — they carry no recoverable information and only pollute context.
+// Active-block compress calls are kept (matched via compressCallId).
+const KEEP_LAST_ORPHANED = 0;
 
 export interface HideConsumedResult {
     messages: CoreMessage[];

--- a/tests/hide-merge-rebuild.test.ts
+++ b/tests/hide-merge-rebuild.test.ts
@@ -23,7 +23,7 @@ function block(overrides: Partial<CompressionBlock>): CompressionBlock {
     };
 }
 
-test("hideConsumedCompressCalls keeps active-block compress calls and recent orphaned", () => {
+test("hideConsumedCompressCalls keeps active-block compress calls, hides all orphaned", () => {
     const state: CompressionState = {
         ...createInitialState(),
         blocks: [block({ blockId: "b1", compressCallId: "call-active", active: true })],
@@ -36,10 +36,13 @@ test("hideConsumedCompressCalls keeps active-block compress calls and recent orp
         { id: "m5", role: "user", contentType: "text", text: "hello" },
     ];
     const result = hideConsumedCompressCalls(state, messages);
-    assert.equal(result.hidden, 1);
+    // active-block call kept; consumed + all orphaned hidden (KEEP_LAST_ORPHANED=0).
+    assert.equal(result.hidden, 3);
     const remainingCallIds = result.messages.filter((m) => m.toolName === "compress").map((m) => m.toolCallId);
     assert.ok(remainingCallIds.includes("call-active"));
     assert.ok(!remainingCallIds.includes("call-consumed"));
+    assert.ok(!remainingCallIds.includes("call-orphan1"));
+    assert.ok(!remainingCallIds.includes("call-orphan2"));
     assert.ok(result.messages.some((m) => m.text === "hello"));
 });
 


### PR DESCRIPTION
## Bug
KEEP_LAST_ORPHANED=2 保留了最近 2 个 orphan compress 调用。但 orphan 调用(失败的、或历史 block 没记 compressCallId 的)无信息价值, 只污染上下文。长会话累积了 12 个 compress 残留永不清除。

## Fix
KEEP_LAST_ORPHANED=0, 所有 orphan compress 调用一律隐藏, 只保留 active-block 匹配的(compressCallId)。

## 验证
实测: 一个 blockCallId 记录后, input 10 compress → hidden 4 → remaining 6(1 active + result + 2 orphan + results)。设 0 后 orphan 也清除。

typecheck ✅ · 191/191 tests ✅