### PR TITLE
release: v0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release acp-kernel 0.0.10. Bundles since 0.0.9:

- #18 hide all orphaned compress calls (KEEP_LAST_ORPHANED=0) — failed/historical compress calls no longer pollute context
- #19 nudge compressible ranges listed oldest-first, not largest-first — now consistent with acp_status and /acp

191/191 tests pass. Merging triggers CI auto-tag + npm publish.