### PR TITLE
feat: export formatRanges for adapters to reuse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { syncBlocks } from "./sync.js";
 export { resolveBoundaries, parseBoundary } from "./boundaries.js";
 export { defaultCountTokens, estimateTokensFast, createBpeTokenizer } from "./tokenize.js";
 export type { TokenCountFn } from "./tokenize.js";
-export { renderNudgeText } from "./nudge-text.js";
+export { renderNudgeText, formatRanges } from "./nudge-text.js";
 export type { NudgeVoice, RenderedNudge } from "./nudge-text.js";
 export { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from "./compression-rules.js";
 export { truncateLargeToolOutputs } from "./truncate-tools.js";

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -43,7 +43,7 @@ function formatTierTargetBlocks(blocks: CompressionBlock[]): string {
   return `Target ${blocks[0]!.tier === 1 ? "tier-1" : "tier-2"} blocks to distill (${blocks.length}):\n${lines.join("\n")}`;
 }
 
-function formatRanges(compressible: CompressibleRange[], protectedRanges: ProtectedRange[]): string {
+export function formatRanges(compressible: CompressibleRange[], protectedRanges: ProtectedRange[]): string {
   if (compressible.length === 0 && protectedRanges.length === 0) {
     return "[No specific ranges detected — compress any consumed content.]";
   }


### PR DESCRIPTION
PR#22 合并后遗留的 commit (导出 formatRanges), 没进 master。pai-acp PR#30 依赖它。基于最新 master cherry-pick。191/191 tests ✅