### PR TITLE
release: v0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Export formatRanges so pai-acp can reuse the merged range formatter (PR#23). pai-acp PR#30 depends on it. 191/191 tests pass. Merging triggers CI auto-tag + npm publish.