### PR TITLE
fix: review findings — typed breakdown, countTokens, double-count

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -862,7 +862,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     reason = `${parts.join("; ")}${readyHint}${blockedHint}`;
   }
 
-  const ctxBreakdown = computeContextBreakdown(input.messages, tokenCount, growthSinceReference);
+  const ctxBreakdown = computeContextBreakdown(input.messages, tokenCount, growthSinceReference, countTokens);
 
   return {
     shouldInject,
@@ -889,10 +889,11 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   };
 }
 
-function computeContextBreakdown(messages: CoreMessage[], total: number, growth: number): ContextBreakdown {
+function computeContextBreakdown(messages: CoreMessage[], total: number, growth: number, countTokens: (t: string) => number): ContextBreakdown {
+  const count = countTokens ?? ((t: string) => Math.ceil(t.length / 4));
   let system = 0, tool = 0, summaries = 0, code = 0, text = 0;
   for (const msg of messages) {
-    const tokens = Math.ceil((msg.text ?? "").length / 4);
+    const tokens = count(msg.text ?? "");
     if (msg.text?.startsWith("[Compressed conversation section]")) {
       summaries += tokens;
     } else if (msg.contentType === "tool-call" || msg.contentType === "tool-result") {

--- a/src/report.ts
+++ b/src/report.ts
@@ -22,18 +22,17 @@ function summaryTokensOf(block: CompressionBlock, countTokens: (t: string) => nu
 
 function effectiveCompressedTokens(
     block: CompressionBlock,
-    state: CompressionState,
-    countTokens: (t: string) => number,
-    visited: Set<string> = new Set(),
+    _state: CompressionState,
+    _countTokens: (t: string) => number,
 ): number {
-    if (visited.has(block.blockId)) return 0;
-    visited.add(block.blockId);
-    let total = block.compressedTokens;
-    for (const nestedId of block.directBlockIds) {
-        const nested = state.blocks.find((b) => b.blockId === nestedId);
-        if (nested) total += effectiveCompressedTokens(nested, state, countTokens, visited);
-    }
-    return total;
+    // block.compressedTokens already records the full input token count of the
+    // operation that created this block: for a tier-1 block that is the raw
+    // messages; for a tier-2 block it is the tier-1 summaries + the new
+    // messages it spans. Recursing into directBlockIds and summing children's
+    // compressedTokens double-counts the consumed children, so we return the
+    // block's own value directly. (The previous recursion inflated tier-2+
+    // "original" figures and mis-ordered the status report.)
+    return block.compressedTokens;
 }
 
 function tierLabel(block: CompressionBlock): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,8 +191,27 @@ export interface NudgeDecision {
   tierTargetBlocks?: CompressionBlock[];
   contextUsage: number;
   tier: CompressionTier | null;
-  breakdown: Record<string, number>;
+  breakdown: NudgeBreakdown;
   contextBreakdown?: ContextBreakdown;
+}
+
+/** Numeric debug/reason fields exposed alongside a nudge decision. Keeping
+ *  these typed (rather than a bare Record<string, number>) means adapters
+ *  that read e.g. emergencyOverride get a compile-time signal if a key is
+ *  renamed or removed. */
+export interface NudgeBreakdown {
+  usage: number;
+  growth: number;
+  growthReference: number;
+  effectiveThreshold: number;
+  nudgeGrowthTokens: number;
+  growthFloor: number;
+  hasPendingNudge: number;
+  emergencyOverride: number;
+  pendingT1: number;
+  pendingT2: number;
+  pendingT3: number;
+  [key: string]: number;
 }
 
 export interface ResolvedBoundary {


### PR DESCRIPTION
## Review 发现

1. **NudgeDecision.breakdown 类型化**: 从 \`Record<string, number>\` 改为显式 \`NudgeBreakdown\` interface (含 emergencyOverride 等显式 key + 保留 index signature)。kernel 改名会在 pai-acp typecheck 暴露。
2. **computeContextBreakdown 用 countTokens**: 之前硬编码 chars/4, CJK 被低估且与 report.ts 不一致。传入 countTokens (fallback chars/4)。
3. **effectiveCompressedTokens 去重复**: 父块 compressedTokens 已含子块 summary, 递归累加子块 compressedTokens 重复计算 tier-2+ 原始量。直接返回 block.compressedTokens。

typecheck ✅ · 191/191 tests ✅