### PR TITLE
feat: collectBlockContent — cache-safe decompress primitive

### DIFF
--- a/src/decompress.ts
+++ b/src/decompress.ts
@@ -1,3 +1,4 @@
+import { SUMMARY_HEADER } from "./prune.js";
 import type { CompressionBlock, CompressionState, CoreMessage } from "./types.js";
 
 export function parseBlockIdArg(arg: string): string | null {
@@ -126,6 +127,89 @@ export function buildRestoredContentPreview(
     }
 
     return { preview: lines.join("\n"), restoredCount: restored.length };
+}
+
+export interface CollectedContentResult {
+    /** Rendered, human-readable content string (empty when count is 0). */
+    text: string;
+    /** Number of items rendered: direct messages + nested summaries (full=false) or all messages (full=true). */
+    count: number;
+}
+
+export interface CollectContentOptions {
+    /** When true, recurse through all nested tiers to original messages. Default: false (one tier up — nested active children stay folded, their summaries shown). */
+    full?: boolean;
+}
+
+/**
+ * Collect a block's content as a readable string WITHOUT modifying state.
+ *
+ * This is the cache-safe decompress primitive: the block stays compressed
+ * (folded), its summary stays in place, and the full content is returned as
+ * text for the caller to surface (e.g. as a tool result appended to the
+ * conversation). Unlike deactivateBlock + prune, this does not mutate the
+ * message-array prefix, so prompt cache is preserved.
+ *
+ * full=false (default): one tier up. Nested ACTIVE children of this block
+ *   stay folded; their summaries are rendered in place of their messages.
+ *   The block's own direct messages (not covered by any active child) are
+ *   rendered in full.
+ * full=true: recurse through all nested tiers; every effective message is
+ *   rendered in full.
+ *
+ * Returns { text: "", count: 0 } when the block covers no messages.
+ */
+export function collectBlockContent(
+    state: CompressionState,
+    block: CompressionBlock,
+    messages: CoreMessage[],
+    options: CollectContentOptions = {},
+): CollectedContentResult {
+    const full = options.full ?? false;
+    const targetIds = new Set(block.effectiveMessageIds);
+
+    if (full) {
+        const msgs = messages.filter((m) => targetIds.has(m.id));
+        if (msgs.length === 0) return { text: "", count: 0 };
+        return { text: msgs.map(formatMessage).join("\n\n"), count: msgs.length };
+    }
+
+    // One tier up: messages covered by nested ACTIVE children stay folded
+    // (their summaries shown); the block's own direct messages shown in full.
+    const nestedChildren: CompressionBlock[] = [];
+    const nestedCovered = new Set<string>();
+    for (const childId of block.directBlockIds) {
+        const child = state.blocks.find((b) => b.blockId === childId);
+        if (!child?.active) continue;
+        nestedChildren.push(child);
+        for (const id of child.effectiveMessageIds) nestedCovered.add(id);
+    }
+
+    const parts: string[] = [];
+    for (const child of nestedChildren) {
+        const label = child.topic ? `${child.blockId}: ${child.topic}` : child.blockId;
+        parts.push(`${SUMMARY_HEADER} — ${label}\n${child.summary}`);
+    }
+
+    let directCount = 0;
+    for (const m of messages) {
+        if (targetIds.has(m.id) && !nestedCovered.has(m.id)) {
+            parts.push(formatMessage(m));
+            directCount++;
+        }
+    }
+
+    const count = directCount + nestedChildren.length;
+    if (count === 0) return { text: "", count: 0 };
+    return { text: parts.join("\n\n"), count };
+}
+
+function formatMessage(message: CoreMessage): string {
+    const text = message.text ?? "";
+    if (message.toolName && message.contentType !== "text") {
+        return `[${message.role} • ${message.toolName}]\n${text}`;
+    }
+    return `[${message.role}]\n${text}`;
 }
 
 function numericPart(blockId: string): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,9 @@ export {
     findActiveAncestor,
     deactivateBlock,
     buildRestoredContentPreview,
+    collectBlockContent,
 } from "./decompress.js";
-export type { DeactivateOptions } from "./decompress.js";
+export type { DeactivateOptions, CollectedContentResult, CollectContentOptions } from "./decompress.js";
 export { buildStatusReport, buildRecap } from "./report.js";
 export type { StatusReportOptions } from "./report.js";
 export { hideConsumedCompressCalls } from "./hide-consumed.js";

--- a/tests/decompress-report.test.ts
+++ b/tests/decompress-report.test.ts
@@ -6,6 +6,7 @@ import {
     findActiveAncestor,
     deactivateBlock,
     buildRestoredContentPreview,
+    collectBlockContent,
 } from "../src/decompress.js";
 import { buildStatusReport, buildRecap } from "../src/report.js";
 import { createInitialState } from "../src/state.js";
@@ -168,4 +169,103 @@ test("buildRecap reports missing and inactive blocks", () => {
     assert.ok(missing.includes("not found"));
     const inactive = buildRecap(state, "b1");
     assert.ok(inactive.includes("inactive"));
+});
+
+test("collectBlockContent: full=false shows nested active child summary + direct messages", () => {
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "hello" },
+        { id: "m2", role: "assistant", contentType: "tool-result", toolName: "read", text: "file a" },
+        { id: "m3", role: "assistant", contentType: "text", text: "found bug" },
+        { id: "m4", role: "user", contentType: "text", text: "direct message" },
+    ];
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            // T1 child covering m1,m2 — stays folded, its summary shown
+            block({ blockId: "b1", effectiveMessageIds: ["m1", "m2"], active: true, summary: "child summary", topic: "intro" }),
+            // T2 parent covering m1..m4, consumes b1
+            block({ blockId: "b2", effectiveMessageIds: ["m1", "m2", "m3", "m4"], directBlockIds: ["b1"], active: true }),
+        ],
+    };
+    const parent = state.blocks.find((b) => b.blockId === "b2")!;
+    const result = collectBlockContent(state, parent, messages);
+    assert.ok(result.count > 0);
+    // child summary rendered with topic label
+    assert.match(result.text, /\[Compressed conversation section\] — b1: intro/);
+    assert.ok(result.text.includes("child summary"));
+    // m1,m2 NOT shown (covered by active child); m3,m4 shown in full
+    assert.ok(!result.text.includes("hello"));
+    assert.ok(!result.text.includes("file a"));
+    assert.ok(result.text.includes("found bug"));
+    assert.ok(result.text.includes("direct message"));
+});
+
+test("collectBlockContent: full=true recurses to all original messages", () => {
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "hello" },
+        { id: "m2", role: "assistant", contentType: "tool-result", toolName: "read", text: "file a" },
+        { id: "m3", role: "assistant", contentType: "text", text: "found bug" },
+    ];
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b1", effectiveMessageIds: ["m1", "m2"], active: true, summary: "child summary" }),
+            block({ blockId: "b2", effectiveMessageIds: ["m1", "m2", "m3"], directBlockIds: ["b1"], active: true }),
+        ],
+    };
+    const parent = state.blocks.find((b) => b.blockId === "b2")!;
+    const result = collectBlockContent(state, parent, messages, { full: true });
+    assert.equal(result.count, 3);
+    // ALL original messages shown, no summary
+    assert.ok(result.text.includes("hello"));
+    assert.ok(result.text.includes("file a"));
+    assert.ok(result.text.includes("found bug"));
+    assert.ok(!result.text.includes("child summary"));
+    assert.ok(!result.text.includes("[Compressed"));
+});
+
+test("collectBlockContent: full=false with inactive nested child shows child's messages directly", () => {
+    // If the nested child is inactive (e.g. already decompressed), its messages
+    // are NOT considered covered and are shown in full — only ACTIVE children fold.
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "hello" },
+        { id: "m2", role: "assistant", contentType: "text", text: "world" },
+    ];
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b1", effectiveMessageIds: ["m1"], active: false, summary: "inactive child" }),
+            block({ blockId: "b2", effectiveMessageIds: ["m1", "m2"], directBlockIds: ["b1"], active: true }),
+        ],
+    };
+    const parent = state.blocks.find((b) => b.blockId === "b2")!;
+    const result = collectBlockContent(state, parent, messages);
+    assert.equal(result.count, 2);
+    assert.ok(result.text.includes("hello"));
+    assert.ok(result.text.includes("world"));
+    assert.ok(!result.text.includes("inactive child"));
+});
+
+test("collectBlockContent: does not mutate state", () => {
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "hello" },
+    ];
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [block({ blockId: "b1", effectiveMessageIds: ["m1"], active: true })],
+    };
+    const before = JSON.stringify(state);
+    collectBlockContent(state, state.blocks[0]!, messages, { full: true });
+    const after = JSON.stringify(state);
+    assert.equal(after, before, "state must not be mutated");
+});
+
+test("collectBlockContent: empty block returns empty", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [block({ blockId: "b1", effectiveMessageIds: [], active: true })],
+    };
+    const result = collectBlockContent(state, state.blocks[0]!, []);
+    assert.equal(result.count, 0);
+    assert.equal(result.text, "");
 });


### PR DESCRIPTION
## 动机
解压的缓存安全实现 (append 语义) 需要一个**纯函数**: 给 block, 返回完整内容, 不改 state。旧 \`deactivateBlock + prune\` 会原位置展开, 破坏消息前缀 → 缓存失效。

之前这个逻辑临时放在 pai-acp adapter 层 (PR#37 的 \`collectRestoredContent\`), 但它只依赖 kernel 类型, 每个adapter得重写一遍。下沉到 kernel 共享。

## API
\`\`\`ts
collectBlockContent(state, block, messages, { full?: boolean }): { text, count }
\`\`\`
- **不改 state** (纯函数) — block 保持折叠, 摘要留在原位
- \`full=false\` (默认): 恢复一层 — 嵌套 active children 保持折叠(显示summary), 本层直接消息完整显示
- \`full=true\`: 递归所有嵌套层到原始消息

## 向后兼容
保留 \`deactivateBlock\` + \`buildRestoredContentPreview\` (现有调用方/原地展开流程)。新代码应优先用 \`collectBlockContent\`。

## 验证
5 个新测试: full=false混合 / full=true全原文 / inactive child不折叠 / 不改state / 空 block。196/196 ✅