### PR TITLE
release: v0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.12 — adds `collectBlockContent` (cache-safe decompress primitive, PR#26). Merging triggers CI auto-publish.