### PR TITLE
fix: soft-protect recent zone — filter instead of fail; exclude decompress

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -94,6 +94,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
     let blocksCreated = 0;
     let tokensCompressed = 0;
     const errors: string[] = [];
+    const warnings: string[] = [];
 
     // Default to the soft-protected zone (recent-N + last user message) when the
     // caller doesn't pass an explicit set. This makes applyCompression safe by
@@ -141,6 +142,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
             errors: [
               `content: range (${prev.spec.startRef}..${prev.spec.endRef}) overlaps (${curr.spec.startRef}..${curr.spec.endRef}). Overlapping ranges cannot be compressed in the same batch.`,
             ],
+            warnings: [],
           },
         };
       }
@@ -179,6 +181,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
             errors: [
               `Total compressible content too small (${totalRangeChars} chars across ${input.ranges.length} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`,
             ],
+            warnings: [],
           },
         };
       }
@@ -186,7 +189,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
 
     for (const spec of input.ranges) {
       try {
-        const compressed = applySingleRange({
+        const outcome = applySingleRange({
           spec,
           messages: input.messages,
           state,
@@ -197,7 +200,8 @@ export function createCore(ports: Ports = {}): CompressionCore {
           preExistingCoverage,
         });
         blocksCreated++;
-        tokensCompressed += compressed;
+        tokensCompressed += outcome.tokens;
+        warnings.push(...outcome.warnings);
       } catch (error) {
         errors.push(error instanceof Error ? error.message : String(error));
       }
@@ -218,7 +222,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
       state.nudge.lastShownByTier = {};
     }
 
-    return { state, result: { blocksCreated, tokensCompressed, errors } };
+    return { state, result: { blocksCreated, tokensCompressed, errors, warnings } };
   }
 
   function processTurn(input: ProcessTurnInput): ProcessTurnResult {
@@ -462,7 +466,13 @@ interface SingleRangeInput {
   preExistingCoverage: Set<string>;
 }
 
-function applySingleRange(input: SingleRangeInput): number {
+interface SingleRangeOutcome {
+  tokens: number;
+  warnings: string[];
+}
+
+function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
+  const warnings: string[] = [];
   const resolved = resolveBoundaries({
     startRef: input.spec.startRef,
     endRef: input.spec.endRef,
@@ -521,18 +531,21 @@ function applySingleRange(input: SingleRangeInput): number {
     (id) => !input.preExistingCoverage.has(id),
   );
 
-  const filteredIds = filterProtectedToolMessages(
+  let filteredIds = filterProtectedToolMessages(
     directMessageIds,
     input.messages,
     input.config,
   );
 
-  // HARD PROTECTION: never let the recent-N / last-user-message zone be
-  // compressed, even if the model ignores the nudge and calls compress
-  // directly on those refs. `protectedMessageIds` holds REF ids (mNNNNN)
-  // from computeProtectedRefs; filteredIds holds RAW message ids, so convert
-  // via state.messageRefs.byRaw before testing membership. applySingleRange
-  // enforces this as the real backstop; the recommend/nudge path is advisory.
+  // SOFT PROTECTION: the recent-N / last-user-message zone is advisory-only at
+  // compress time. Instead of failing the whole range when it brushes protected
+  // messages, exclude those messages and proceed with the rest (so the model
+  // isn't blocked when it picks a range that slightly overlaps the recent
+  // window). If excluding them empties the range entirely AND there are no
+  // consumed blocks to merge, we still fail — there is genuinely nothing to
+  // compress. `protectedMessageIds` holds REF ids (mNNNNN) from
+  // computeProtectedRefs; filteredIds holds RAW message ids, so convert via
+  // state.messageRefs.byRaw before testing membership.
   const protectedRefs = input.protectedMessageIds;
   const hitProtectedRaw = protectedRefs
     ? filteredIds.filter((id) => {
@@ -541,14 +554,28 @@ function applySingleRange(input: SingleRangeInput): number {
       })
     : [];
   if (hitProtectedRaw.length > 0) {
-    const recentN = input.config.preserveRecentMessages;
+    const protectedSet = new Set(hitProtectedRaw);
+    filteredIds = filteredIds.filter((id) => !protectedSet.has(id));
+    // Remove protected messages from effective coverage too, so they are NOT
+    // hidden by the new block (they must stay fully visible).
+    for (const id of hitProtectedRaw) effectiveMessageIds.delete(id);
+
     const hitRefs = hitProtectedRaw
       .map((id) => input.state.messageRefs.byRaw[id])
-      .filter(Boolean);
-    throw new Error(
-      `Range includes protected messages (the last ${recentN} messages and/or the most recent user message) which must not be compressed: ${hitRefs.join(
+      .filter((v): v is string => typeof v === "string");
+
+    if (filteredIds.length === 0 && consumedBlockIds.length === 0) {
+      const recentN = input.config.preserveRecentMessages;
+      throw new Error(
+        `Range is entirely within the protected zone (the last ${recentN} messages and/or the most recent user message): ${hitRefs.join(
+          ", ",
+        )}. Adjust startId/endId to older messages.`,
+      );
+    }
+    warnings.push(
+      `Excluded ${hitProtectedRaw.length} protected message(s) ${hitRefs.join(
         ", ",
-      )}. Adjust startId/endId to exclude them.`,
+      )} from compression range (recent/last-user zone).`,
     );
   }
 
@@ -590,7 +617,7 @@ function applySingleRange(input: SingleRangeInput): number {
     if (consumed) consumed.active = false;
   }
 
-  return compressedTokens;
+  return { tokens: compressedTokens, warnings };
 }
 
 function applyToolPairAdjustment(

--- a/src/protected.ts
+++ b/src/protected.ts
@@ -7,6 +7,32 @@ import type { Config, CoreMessage } from "./types.js";
  *  compressed away breaks decompress and the "summary is historical" contract. */
 export const ALWAYS_PROTECTED_TOOLS = ["compress"] as const;
 
+/** Tool results that must NEVER participate in the soft-protected recent zone
+ *  (preserveRecentMessages / preserveRecentTokens / last user message).
+ *
+ *  `decompress` returns large restored content as an inline tool result. If it
+ *  lands in the last-N window it becomes un-compressible: the model cannot
+ *  reclaim that context, and it never appears in the compressible-ranges
+ *  recommendation list. Excluding it from the protected zone lets the model
+ *  compress it again immediately, while still leaving it visible (the host's
+ *  preserveRecent is about not compressing the active working set, not about
+ *  which tool results are in scope).
+ *
+ *  Note: this only affects the recent-zone computation. Such messages remain
+ *  fully visible and compressible like any ordinary message. */
+export const NEVER_PRESERVE_RECENT_TOOLS = ["decompress"] as const;
+
+/** True for tool-call / tool-result messages whose toolName is in the
+ *  NEVER_PRESERVE_RECENT_TOOLS list — i.e. tool results (like decompress)
+ *  that should be excluded from the soft-protected recent zone. */
+export function isNeverPreserveRecent(msg: CoreMessage): boolean {
+  if (msg.contentType !== "tool-call" && msg.contentType !== "tool-result") {
+    return false;
+  }
+  if (!msg.toolName) return false;
+  return (NEVER_PRESERVE_RECENT_TOOLS as readonly string[]).includes(msg.toolName);
+}
+
 export function matchToolPattern(toolName: string, pattern: string): boolean {
   if (pattern.endsWith("*")) {
     return toolName.startsWith(pattern.slice(0, -1));

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -23,6 +23,7 @@ import type { CompressionState } from "./types.js";
 import {
   collectProtectedToolCallIds,
   isMessageProtectedWithPairing,
+  isNeverPreserveRecent,
 } from "./protected.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -77,6 +78,12 @@ export function computeProtectedRefs(
 
   for (const msg of messages) {
     if (isSyntheticOrPruned(msg, state)) continue;
+    // Exclude decompress-style tool results from the recent-zone window.
+    // These are large inline restorations that the model should be free to
+    // compress again immediately; counting them toward the last-N window
+    // would make them un-compressible and hide them from recommendations.
+    // The message stays fully visible — this only affects protection scope.
+    if (isNeverPreserveRecent(msg)) continue;
     const ref = state.messageRefs.byRaw[msg.id];
     if (!ref || ref === "BLOCKED") continue;
     visible.push({ ref, tokens: estimateMessageTokens(msg) });
@@ -103,6 +110,10 @@ export function computeProtectedRefs(
   // same switch as Rule 1, so setting preserveRecentMessages = 0 fully opts
   // out (needed by tests that compress the tail). Production defaultConfig
   // uses 5, so the last user message is always protected in practice.
+  // Note: we scan the raw messages array (not `visible`) here so the last
+  // user message is still found even when a decompress tool result was
+  // skipped above — user intent is always protected regardless of recent
+  // tool results.
   if (preserveN > 0) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]!;

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,10 @@ export interface ApplyCompressionResult {
     blocksCreated: number;
     tokensCompressed: number;
     errors: string[];
+    /** Non-fatal notices (e.g. protected messages excluded from a range).
+     *  The compression still succeeded; the host should surface these to the
+     *  model so it understands what was skipped. */
+    warnings: string[];
   };
 }
 

--- a/tests/protect-recent.test.ts
+++ b/tests/protect-recent.test.ts
@@ -62,13 +62,14 @@ const EIGHT = [
   msg("h", "eighth detailed message body content theta"),
 ];
 
-test("applyCompression refuses to compress the last N messages (preserveRecentMessages)", () => {
+test("applyCompression fails when the range is ENTIRELY within the recent zone", () => {
   const core = createCore();
   const messages = [...EIGHT];
   const state = seededState(messages);
   const cfg = config({ preserveRecentMessages: 3 });
 
-  // m00006..m00008 are the last 3 → must be protected.
+  // m00006..m00008 are the last 3 → entirely protected. After filtering there
+  // is nothing left to compress, so the range must still fail.
   const result = core.applyCompression({
     ranges: [
       { startRef: "m00006", endRef: "m00008", summary: "trying to compress the recent zone", topic: "bad" },
@@ -82,35 +83,44 @@ test("applyCompression refuses to compress the last N messages (preserveRecentMe
   assert.equal(result.result.errors.length, 1);
   assert.match(
     result.result.errors[0]!,
-    /protected messages.*last 3/i,
-    `error should mention the protected recent zone, got: ${result.result.errors[0]}`,
+    /entirely.*protected.*last 3|last 3.*protected/i,
+    `error should mention the protected recent zone with nothing left, got: ${result.result.errors[0]}`,
   );
 });
 
-test("applyCompression refuses to compress a range that overlaps the recent zone", () => {
+test("applyCompression excludes protected tail and compresses the rest (partial overlap)", () => {
   const core = createCore();
   const messages = [...EIGHT];
   const state = seededState(messages);
   const cfg = config({ preserveRecentMessages: 3 });
 
-  // m00005 is outside the zone, but m00006..m00008 are inside → partial overlap must be rejected.
+  // m00005 is outside the zone, m00006..m00007 are inside. The unprotected
+  // head (m00005) must still be compressed; the protected tail is excluded
+  // and surfaced as a warning rather than failing the whole range.
   const result = core.applyCompression({
     ranges: [
-      { startRef: "m00005", endRef: "m00007", summary: "overlapping the recent zone", topic: "bad" },
+      { startRef: "m00005", endRef: "m00007", summary: "overlapping the recent zone", topic: "partial" },
     ],
     messages,
     state,
     config: cfg,
   });
 
-  assert.equal(result.result.blocksCreated, 0, "no block created on overlap");
-  assert.match(result.result.errors[0]!, /protected messages/i);
+  assert.equal(result.result.blocksCreated, 1, "unprotected head still compressed");
+  assert.equal(result.result.errors.length, 0, "no error — overlap is non-fatal");
+  assert.equal(result.result.warnings.length, 1, "a warning is surfaced");
+  assert.match(result.result.warnings[0]!, /Excluded.*protected.*m0000[67]/i);
+  // The created block must NOT cover the protected messages.
+  const block = result.state.blocks[result.state.blocks.length - 1]!;
+  assert.ok(!block.effectiveMessageIds.includes("f"), "m00006 raw id not covered");
+  assert.ok(!block.effectiveMessageIds.includes("g"), "m00007 raw id not covered");
+  assert.ok(block.directMessageIds.includes("e"), "m00005 raw id IS compressed");
 });
 
-test("applyCompression protects the most recent user message even outside the recent-N window", () => {
+test("applyCompression excludes the most recent user message and compresses the rest", () => {
   const core = createCore();
-  // Preserve only 1 recent message, but make the last-but-one a user message:
-  // the last user message must still be protected by Rule 3 regardless of distance.
+  // Preserve only 1 recent message; the last user message (m00003) is still
+  // protected by Rule 3. The assistant message m00002 is compressible.
   const messages = [
     msg("a", "u1 text alpha", "user"),
     msg("b", "assistant reply beta", "assistant"),
@@ -119,21 +129,22 @@ test("applyCompression protects the most recent user message even outside the re
   const state = seededState(messages);
   const cfg = config({ preserveRecentMessages: 1 });
 
-  // preserveRecentMessages=1 protects only m00003; m00002 (assistant) is the
-  // assistant turn, m00001 is a user message — but it is NOT the most recent
-  // user message, so it is compressible. Verify compressing the genuine
-  // latest user message is refused.
   const result = core.applyCompression({
     ranges: [
-      { startRef: "m00002", endRef: "m00003", summary: "grabbing the last user msg", topic: "bad" },
+      { startRef: "m00002", endRef: "m00003", summary: "grabbing the last user msg", topic: "partial" },
     ],
     messages,
     state,
     config: cfg,
   });
 
-  assert.equal(result.result.blocksCreated, 0);
-  assert.match(result.result.errors[0]!, /protected messages/i);
+  assert.equal(result.result.blocksCreated, 1, "assistant msg still compressed");
+  assert.equal(result.result.errors.length, 0);
+  assert.equal(result.result.warnings.length, 1);
+  assert.match(result.result.warnings[0]!, /Excluded.*protected.*m00003/i);
+  const block = result.state.blocks[result.state.blocks.length - 1]!;
+  assert.ok(block.directMessageIds.includes("b"), "m00002 compressed");
+  assert.ok(!block.effectiveMessageIds.includes("c"), "m00003 stays visible");
 });
 
 test("applyCompression still allows compressing messages strictly before the recent zone", () => {
@@ -154,11 +165,13 @@ test("applyCompression still allows compressing messages strictly before the rec
 
   assert.equal(result.result.blocksCreated, 1, "older range still compressible");
   assert.equal(result.result.errors.length, 0);
+  assert.equal(result.result.warnings.length, 0, "no warnings for a clean range");
 });
 
-test("applyCompression defaults to safe protection when caller omits protectedMessageIds", () => {
+test("applyCompression fails by default when the whole range is protected (no explicit set)", () => {
   // No explicit protectedMessageIds passed — applyCompression must compute the
-  // soft-protected zone itself (recent-N + last user message).
+  // soft-protected zone itself (recent-N + last user message). When the entire
+  // range falls in that zone, it still fails.
   const core = createCore();
   const messages = [
     msg("a", "old user msg alpha", "user"),
@@ -179,5 +192,89 @@ test("applyCompression defaults to safe protection when caller omits protectedMe
   });
 
   assert.equal(result.result.blocksCreated, 0, "default protection applies without explicit set");
-  assert.match(result.result.errors[0]!, /protected messages/i);
+  assert.match(result.result.errors[0]!, /protected/i);
+});
+
+// --- decompress results are excluded from the recent-protected zone ---
+
+function toolResult(
+  id: string,
+  toolName: string,
+  text: string,
+  toolCallId = "tc-" + id,
+): CoreMessage {
+  return { id, role: "tool", contentType: "tool-result", toolName, toolCallId, text };
+}
+
+test("computeProtectedRefs excludes decompress tool results from the recent zone", async () => {
+  // A decompress tool result sits at the tail. Without the NEVER_PRESERVE_RECENT
+  // exclusion it would occupy the recent-N window and become un-compressible.
+  const { computeProtectedRefs } = await import("../src/recommend.js");
+  const messages: CoreMessage[] = [
+    msg("a", "old alpha", "user"),
+    msg("b", "old beta", "assistant"),
+    msg("c", "old gamma", "user"),
+    toolResult("d", "decompress", "x".repeat(20000)),
+  ];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  const protectedRefs = computeProtectedRefs(messages, state, cfg);
+  // m00004 is the decompress result — must NOT be in the protected zone.
+  assert.ok(!protectedRefs.has("m00004"), "decompress result not protected by recent zone");
+  // The last USER message (m00003) is still protected by Rule 3.
+  assert.ok(protectedRefs.has("m00003"), "last user message still protected");
+});
+
+test("applyCompression can compress a decompress tool result in the recent tail", () => {
+  // The decompress result is the last message (within preserveRecentMessages=3).
+  // It must still be compressible because it is excluded from the protected zone.
+  const core = createCore();
+  const messages: CoreMessage[] = [
+    msg("a", "first message alpha", "user"),
+    msg("b", "second message beta", "assistant"),
+    msg("c", "third message gamma", "user"),
+    toolResult("d", "decompress", "restored content " + "x".repeat(200)),
+  ];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00004", endRef: "m00004", summary: "compressing the decompress result", topic: "reclaim" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(result.result.blocksCreated, 1, "decompress result is compressible despite being in the tail");
+  assert.equal(result.result.errors.length, 0);
+  assert.equal(result.result.warnings.length, 0, "no warning — it is genuinely outside the protected zone");
+});
+
+test("warnings accumulate across multiple ranges in one batch", () => {
+  const core = createCore();
+  const messages = [
+    ...EIGHT,
+    msg("i", "ninth message iota", "user"),
+    msg("j", "tenth message kappa", "assistant"),
+  ];
+  const state = seededState(messages);
+  const cfg = config({ preserveRecentMessages: 3 });
+
+  // Two ranges: each partially overlaps the recent zone (m00008..m00010).
+  // Both should produce warnings, and both unprotected heads should compress.
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00004", endRef: "m00009", summary: "first partial range summary", topic: "a" },
+      { startRef: "m00010", endRef: "m00010", summary: "second range fully protected tail", topic: "b" },
+    ],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.ok(result.result.blocksCreated >= 1, "at least the unprotected head compresses");
+  assert.ok(result.result.warnings.length >= 1, "warnings surfaced");
 });


### PR DESCRIPTION
Two coupled issues around the recent-protected zone. (1) decompress tool results landed in the protected zone and became un-compressible + invisible in recommendations. (2) any range brushing the recent zone failed entirely.

Fix A: NEVER_PRESERVE_RECENT_TOOLS=["decompress"] + isNeverPreserveRecent(); computeProtectedRefs skips such tool results so they stay compressible. Last-user-message rule still scans raw messages.

Fix B: applySingleRange filters protected messages (from directMessageIds + effectiveMessageIds so they stay visible), records a warning, compresses the rest. Only throws when the ENTIRE range is protected. ApplyCompressionResult.result gains warnings:string[] (backward-compatible).

Tests: rewrote 4 protect-recent tests to new contract; added 3 for decompress exclusion + warnings. 199/199 pass, typecheck/build OK. Details in commit msg. Not merging — awaits human review. Release 0.0.13 after merge.