### PR TITLE
release: v0.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.5",
+    "version": "0.0.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.5",
+            "version": "0.0.13",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Release v0.0.13

Patch release — includes **#28** (soft-protect recent zone: filter instead of fail; exclude decompress).

### Changes since v0.0.12
- **#28** `fix: soft-protect recent zone — filter instead of fail; exclude decompress`
  - `NEVER_PRESERVE_RECENT_TOOLS=["decompress"]` — decompress results no longer enter the recent-zone preserve set (so they stay compressible)
  - `applySingleRange` now **filters** protected refs out of a partially-overlapping range (with a warning) instead of failing the whole call; throws only when nothing remains after filtering
  - `ApplyCompressionResult.result` gains an optional `warnings: string[]` (backward compatible)

### Verification
- typecheck ✓ / 199 tests pass ✓ / build ✓

> Human merge only — Agent MUST NOT merge. CI auto-tags + publishes on merge.