### PR TITLE
release v0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.14.

Includes search overhaul from PR #30:
- Pluggable algorithm registry (substring/bm25/fuzzy/hybrid/semantic)
- Hybrid default (BM25 ⊕ fuzzy), CJK bigram tokenizer, stemmer
- Unified block + message search with role weighting
- `search_context` added to NEVER_PRESERVE_RECENT_TOOLS

Merge to trigger CI publish to npm.