### PR TITLE
release v0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Release v0.0.15

Removes KEEP/REF marker system (PR #33). Markers were removed from kernel source, compression rules, and tests.

### Changes since v0.0.14
- `refactor: remove KEEP/REF marker system` (6e010d5)
- `fix(compress): exclude protected tool messages from effectiveMessageIds (Bug 39)` (6a84457, PR #32)

### Verification
- typecheck ✅
- test ✅ 208 pass / 0 fail
- build ✅

> Merge this PR to trigger CI auto-publish to npm.