### PR TITLE
feat(protected): exclude read/bash from recent-zone

### DIFF
--- a/src/protected.ts
+++ b/src/protected.ts
@@ -10,20 +10,28 @@ export const ALWAYS_PROTECTED_TOOLS = ["compress"] as const;
 /** Tool results that must NEVER participate in the soft-protected recent zone
  *  (preserveRecentMessages / preserveRecentTokens / last user message).
  *
- *  `decompress` returns large restored content as an inline tool result. If it
- *  lands in the last-N window it becomes un-compressible: the model cannot
- *  reclaim that context, and it never appears in the compressible-ranges
- *  recommendation list. Excluding it from the protected zone lets the model
- *  compress it again immediately, while still leaving it visible (the host's
- *  preserveRecent is about not compressing the active working set, not about
- *  which tool results are in scope).
+ *  These tools return large content (restored blocks, search hits, file bodies,
+ *  command output). If such a result lands in the last-N window it becomes
+ *  un-compressible: the model cannot reclaim that context, and it never appears
+ *  in the compressible-ranges recommendation list. Excluding these tools from
+ *  the protected zone lets the model compress them again immediately, while
+ *  still leaving them visible (the host's preserveRecent is about not
+ *  compressing the active working set, not about which tool results are in
+ *  scope).
  *
- *  `search_context` returns large result lists (10 ranked hits with previews).
- *  Same reasoning: excluding it from the protected zone keeps it compressible.
+ *  - `decompress`: large restored content as an inline tool result.
+ *  - `search_context`: large result lists (10 ranked hits with previews).
+ *  - `read`: file/image contents — the largest common source of context bloat.
+ *  - `bash`: command output (build/test/logs) — frequently large and spent.
  *
  *  Note: this only affects the recent-zone computation. Such messages remain
  *  fully visible and compressible like any ordinary message. */
-export const NEVER_PRESERVE_RECENT_TOOLS = ["decompress", "search_context"] as const;
+export const NEVER_PRESERVE_RECENT_TOOLS = [
+  "decompress",
+  "search_context",
+  "read",
+  "bash",
+] as const;
 
 /** True for tool-call / tool-result messages whose toolName is in the
  *  NEVER_PRESERVE_RECENT_TOOLS list — i.e. tool results (like decompress)


### PR DESCRIPTION
## Why

`read` (file/image contents) and `bash` (build/test/log output) are the largest common sources of tool-result context bloat. When such results land in the `preserveRecentMessages` last-N window they become un-compressible — the model cannot reclaim that context, and they never appear in compressible-ranges recommendations.

## Change

Add `read` and `bash` to `NEVER_PRESERVE_RECENT_TOOLS` (alongside `decompress` and `search_context`).

They remain fully visible and compressible like any ordinary message — this only removes them from the soft-protected recent zone, so the protected window covers actual conversation turns (user intent, assistant reasoning, tool dispatch decisions) instead of being filled by spent file/command output.

## Verification
- typecheck ✅
- test ✅ 208 pass / 0 fail (no test asserts the list contents or depends on read/bash being in the recent zone)
- No behavior change for `compress`/`protectedTools` (always-protected) — only the soft recent-zone is affected.