### PR TITLE
release v0.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Release v0.0.16

### Changes since v0.0.15
- `feat(protected): exclude read/bash from recent-zone` (7d9e67d, PR #35)

`read` (file/image contents) and `bash` (build/test/log output) added to `NEVER_PRESERVE_RECENT_TOOLS`. Large tool results no longer fill the `preserveRecentMessages` soft-zone, so the protected window covers actual conversation turns (user intent, assistant reasoning, tool dispatch) instead of spent file/command output. Messages remain fully visible and compressible.

### Verification (pre-flight, matches release.yml)
- typecheck ✅
- test ✅ 208 pass / 0 fail
- build ✅

> Merge this PR to trigger CI auto-publish to npm.