### PR TITLE
fix: backward-compatible renderMessage option for tool messages

### DIFF
--- a/.acp-019fc0fc-f454-74d3-8d19-f9af6f837aad.acp.json
+++ b/.acp-019fc0fc-f454-74d3-8d19-f9af6f837aad.acp.json
@@ -1,0 +1,1 @@
+{"blocks":[],"messageRefs":{"byRaw":{"6e473b99":"m00001","b9495b28":"m00002","773e2a86":"m00003"},"byRef":{"m00001":"6e473b99","m00002":"b9495b28","m00003":"773e2a86"}},"nudge":{"lastPerMessageNudgeTokens":30,"lastNudgeShownTokens":0,"baselineTokens":0,"anchors":{},"lastShownByTier":{}},"stats":{"tokensCompressed":0,"compressionCount":0},"nextBlockId":1,"nextRunId":1}

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -1,8 +1,16 @@
-import type { CoreMessage, CompressionState, MessageRefMap } from "./types.js";
+import type {
+  CoreMessage,
+  CompressionState,
+  MessageRefMap,
+  RenderConfig,
+} from "./types.js";
 import { refForRaw, BLOCKED_REF } from "./refs.js";
 import type { PipelineNode, PipelineContext, NodeIO } from "./pipeline.js";
 
-/** Format token count: <1K raw, <10K "X.YK", >=10K "XK". */
+export interface RenderOptions {
+  skipToolMessages?: boolean;
+}
+
 function formatTokens(tokens: number): string {
   if (tokens < 1000) return String(tokens);
   if (tokens < 10000) return (tokens / 1000).toFixed(1) + "K";
@@ -32,23 +40,23 @@ function acpTag(ref: string, tokens: number, type: string): string {
   return TAG_OPEN + 'tokens="' + formatTokens(tokens) + '" type="' + type + '"' + GT + ref + TAG_CLOSE;
 }
 
-function renderMessage(
+export function renderMessage(
   message: CoreMessage,
   map: MessageRefMap,
   countTokens: (text: string) => number,
+  options?: RenderOptions,
 ): CoreMessage {
   const ref = refForRaw(map, message.id);
   if (!ref || ref === BLOCKED_REF) return message;
 
   if (
-    message.contentType === "tool-call" ||
-    message.contentType === "tool-result"
+    options?.skipToolMessages &&
+    (message.contentType === "tool-call" ||
+      message.contentType === "tool-result")
   ) {
     return message;
   }
 
-  // Strip own stale tag BEFORE computing tokens (idempotency).
-  // Match the message's own ref only — foreign tags survive (content-corruption fix).
   const ownTagRe = new RegExp(
     "^" + escapeRegex(TAG_OPEN) + "[^>]*" + GT + escapeRegex(ref) + escapeRegex(TAG_CLOSE) + "\\n?",
   );
@@ -67,11 +75,21 @@ export function renderVisibleRefs(
   state: CompressionState,
   countTokens: (text: string) => number = (text) =>
     Math.ceil(text.length / 4),
+  options?: RenderOptions,
 ): CoreMessage[] {
   const map = state.messageRefs;
   return messages.map((message) =>
-    renderMessage(message, map, countTokens),
+    renderMessage(message, map, countTokens, options),
   );
+}
+
+export function optionsFromConfig(
+  config?: { render?: RenderConfig },
+): RenderOptions | undefined {
+  if (config?.render?.skipToolMessageTags) {
+    return { skipToolMessages: true };
+  }
+  return undefined;
 }
 
 export const renderRefsNode: PipelineNode = {
@@ -79,7 +97,12 @@ export const renderRefsNode: PipelineNode = {
   run(io: NodeIO, ctx: PipelineContext): NodeIO {
     return {
       ...io,
-      messages: renderVisibleRefs(io.messages, io.state, ctx.countTokens),
+      messages: renderVisibleRefs(
+        io.messages,
+        io.state,
+        ctx.countTokens,
+        optionsFromConfig(ctx.config),
+      ),
     };
   },
 };

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -40,6 +40,13 @@ function renderMessage(
   const ref = refForRaw(map, message.id);
   if (!ref || ref === BLOCKED_REF) return message;
 
+  if (
+    message.contentType === "tool-call" ||
+    message.contentType === "tool-result"
+  ) {
+    return message;
+  }
+
   // Strip own stale tag BEFORE computing tokens (idempotency).
   // Match the message's own ref only — foreign tags survive (content-corruption fix).
   const ownTagRe = new RegExp(

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,10 @@ export interface CompressValidationConfig {
   minSummaryLength: number;
 }
 
+export interface RenderConfig {
+  skipToolMessageTags?: boolean;
+}
+
 export interface Config {
   tiers: TierConfig;
   nudge: NudgeConfig;
@@ -123,6 +127,7 @@ export interface Config {
   preserveRecentTokens: number;
   modelContextLimit: number;
   messageFilters?: import("./filter/types.js").MessageFiltersConfig;
+  render?: RenderConfig;
 }
 
 export type CompressMode = "range" | "message";

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -142,7 +142,7 @@ test("processTurn tags every mapped message with a derived ref (end-to-end)", ()
   assert.match(result.messages[1]!.text!, /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/);
 });
 
-test("renderVisibleRefs skips tool-call and tool-result messages", () => {
+test("renderVisibleRefs tags tool messages by default (backward compat)", () => {
   const state = createInitialState();
   const messages: CoreMessage[] = [
     { id: "u1", role: "user", contentType: "text", text: "run echo" },
@@ -158,7 +158,54 @@ test("renderVisibleRefs skips tool-call and tool-result messages", () => {
   const rendered = renderVisibleRefs(messages, state);
 
   assert.match(rendered[0]!.text!, /m00001<\/acp>/, "user message gets tag");
+  assert.match(rendered[1]!.text!, /m00002<\/acp>/, "tool-call gets tag (default)");
+  assert.match(rendered[2]!.text!, /m00003<\/acp>/, "tool-result gets tag (default)");
+  assert.match(rendered[3]!.text!, /m00004<\/acp>/, "assistant text gets tag");
+});
+
+test("renderVisibleRefs skips tool messages when options.skipToolMessages is set", () => {
+  const state = createInitialState();
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "run echo" },
+    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
+    { id: "t1", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc1", text: "hello" },
+    { id: "a2", role: "assistant", contentType: "text", text: "Done." },
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const rendered = renderVisibleRefs(messages, state, undefined, {
+    skipToolMessages: true,
+  });
+
+  assert.match(rendered[0]!.text!, /m00001<\/acp>/, "user message gets tag");
   assert.equal(rendered[1]!.text, '{"command":"echo hello"}', "tool-call args unmodified");
   assert.equal(rendered[2]!.text, "hello", "tool-result content unmodified");
   assert.match(rendered[3]!.text!, /m00004<\/acp>/, "assistant text gets tag");
+});
+
+test("renderRefsNode respects config.render.skipToolMessageTags", () => {
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "run echo" },
+    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
+  ];
+  const state = createInitialState();
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const configWithSkip = { ...defaultConfig(100000), render: { skipToolMessageTags: true } };
+  const io = makeIO(messages, state);
+  const ctx = {
+    config: configWithSkip,
+    tokenCount: 100,
+    countTokens: (t: string) => Math.ceil(t.length / 4),
+  };
+  const result = renderRefsNode.run(io, ctx);
+
+  assert.match(result.messages[0]!.text!, /m00001<\/acp>/, "user text gets tag");
+  assert.equal(result.messages[1]!.text, '{"command":"echo hello"}', "tool-call args unmodified with skip flag");
 });

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -141,3 +141,24 @@ test("processTurn tags every mapped message with a derived ref (end-to-end)", ()
   assert.match(result.messages[0]!.text!, /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/);
   assert.match(result.messages[1]!.text!, /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/);
 });
+
+test("renderVisibleRefs skips tool-call and tool-result messages", () => {
+  const state = createInitialState();
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "run echo" },
+    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
+    { id: "t1", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc1", text: "hello" },
+    { id: "a2", role: "assistant", contentType: "text", text: "Done." },
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const rendered = renderVisibleRefs(messages, state);
+
+  assert.match(rendered[0]!.text!, /m00001<\/acp>/, "user message gets tag");
+  assert.equal(rendered[1]!.text, '{"command":"echo hello"}', "tool-call args unmodified");
+  assert.equal(rendered[2]!.text, "hello", "tool-result content unmodified");
+  assert.match(rendered[3]!.text!, /m00004<\/acp>/, "assistant text gets tag");
+});


### PR DESCRIPTION
## Problem

`renderMessage()` tags ALL messages including tool-call arguments in `CoreMessage.text`. In **proxy adapters** (e.g. `acp-proxy`) that store wire-format JSON in `.text` (OpenAI `function.arguments`), this corrupted the JSON → `SchemaError(Missing key at ["command"])`.

## Approach (redesigned per review)

~~Unconditionally skip tool messages.~~ ← **rejected**: breaking change for existing callers.

**New approach**: opt-in via `RenderOptions` + `RenderConfig`, zero behavior change for existing callers.

### API changes

```typescript
// New: optional parameter (backward compat — default = tag everything)
export function renderMessage(
  message, map, countTokens,
  options?: { skipToolMessages?: boolean },  // ← NEW
): CoreMessage

export function renderVisibleRefs(
  messages, state, countTokens?,
  options?: { skipToolMessages?: boolean },  // ← NEW
): CoreMessage[]

// New: config option
interface RenderConfig { skipToolMessageTags?: boolean }
interface Config { ...; render?: RenderConfig }

// New: helper for pipeline node
export function optionsFromConfig(config?): RenderOptions | undefined
```

### Who opts in?

| Caller | Behavior | Change needed? |
|--------|----------|---------------|
| **Plugin (opencode-acp)** | Tags all messages (original) | None |
| **Pipeline default** | Tags all messages (original) | None (render undefined) |
| **Proxy (acp-proxy)** | Skips tool messages | `config.render = { skipToolMessageTags: true }` |

## Tests (211/211 pass)

- `renderVisibleRefs tags tool messages by default (backward compat)` — existing behavior preserved
- `renderVisibleRefs skips tool messages when options.skipToolMessages is set` — opt-in works
- `renderRefsNode respects config.render.skipToolMessageTags` — pipeline integration

## Why this is safe

- `renderMessage()` default path: **identical** to before
- `renderVisibleRefs()` default path: **identical** to before
- `renderRefsNode` with no `config.render`: **identical** to before
- `renderMessage()` now exported: adapters can reuse without reimplementing
- Refs still allocated for tool messages (`assignRefs` runs before `render-refs`)
- Tool pairs still tracked (`adjustBoundariesForToolPairs` auto-expands ranges)