### PR TITLE
release v0.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Ships PR #38 (renderTags three-state: all/text-only/none) + regression test for renderVisibleRefs "none".

- Includes RenderStrategy type + createRenderRefsNode(strategy) factory
- renderMessage honors "none" (fixes the exported-helper gap)
- README documents renderTags under core engine API
- 212 tests pass

Merge to trigger CI auto-publish to npm (0.0.16 → 0.0.17).