### PR TITLE
fix(compress): per-block hide-consumed to stop summary leak in batched calls (#288)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -647,6 +647,8 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
     generation: "young",
     active: true,
     compressCallId: input.spec.compressCallId,
+    startRef: input.spec.startRef,
+    endRef: input.spec.endRef,
   };
   input.state.blocks.push(block);
 

--- a/src/hide-consumed.ts
+++ b/src/hide-consumed.ts
@@ -1,9 +1,5 @@
 import type { CompressionState, CoreMessage } from "./types.js";
 
-// Orphaned compress calls (no matching active block, e.g. failed attempts or
-// historical calls whose blocks predate compressCallId recording) are fully
-// hidden — they carry no recoverable information and only pollute context.
-// Active-block compress calls are kept (matched via compressCallId).
 const KEEP_LAST_ORPHANED = 0;
 
 export interface HideConsumedResult {
@@ -11,18 +7,57 @@ export interface HideConsumedResult {
     hidden: number;
 }
 
-// Keep active-block compress calls + the most recent orphaned calls; hide the rest.
+function rangeKey(startRef: string, endRef: string): string {
+    return `${startRef}::${endRef}`;
+}
+
+function rewriteCompressText(text: string | undefined, liveKeys: Set<string>): string | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text ?? "");
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as { content?: unknown };
+    const content = obj.content;
+    if (!Array.isArray(content) || content.length === 0) return null;
+
+    const kept = content.filter((entry): entry is Record<string, unknown> => {
+        if (!entry || typeof entry !== "object") return false;
+        const s = typeof entry.startId === "string" ? entry.startId : typeof entry.messageId === "string" ? entry.messageId : "";
+        const e = typeof entry.endId === "string" ? entry.endId : typeof entry.messageId === "string" ? entry.messageId : "";
+        return liveKeys.has(rangeKey(s, e));
+    });
+
+    if (kept.length === content.length || kept.length === 0) return null;
+
+    return JSON.stringify({ ...obj, content: kept });
+}
+
 export function hideConsumedCompressCalls(
     state: CompressionState,
     messages: CoreMessage[],
 ): HideConsumedResult {
-    const activeCallIds = new Set<string>();
     const allBlockCallIds = new Set<string>();
+    const activeCallIds = new Set<string>();
+    const liveRangeKeysByCallId = new Map<string, Set<string>>();
+    const legacyLiveByCallId = new Set<string>();
     for (const block of state.blocks) {
-        if (block.compressCallId) {
-            allBlockCallIds.add(block.compressCallId);
-            if (block.active) activeCallIds.add(block.compressCallId);
+        if (!block.compressCallId) continue;
+        allBlockCallIds.add(block.compressCallId);
+        if (!block.active) continue;
+        activeCallIds.add(block.compressCallId);
+        if (block.startRef === undefined || block.endRef === undefined) {
+            legacyLiveByCallId.add(block.compressCallId);
+            continue;
         }
+        let keys = liveRangeKeysByCallId.get(block.compressCallId);
+        if (!keys) {
+            keys = new Set<string>();
+            liveRangeKeysByCallId.set(block.compressCallId, keys);
+        }
+        keys.add(rangeKey(block.startRef, block.endRef));
     }
 
     const lastOrphanedCallIds: string[] = [];
@@ -66,6 +101,21 @@ export function hideConsumedCompressCalls(
         ) {
             hidden++;
             continue;
+        }
+        if (
+            message.toolName === "compress" &&
+            message.contentType === "tool-call" &&
+            message.toolCallId &&
+            keepCallIds.has(message.toolCallId)
+        ) {
+            const liveKeys = liveRangeKeysByCallId.get(message.toolCallId);
+            if (liveKeys && liveKeys.size > 0 && !legacyLiveByCallId.has(message.toolCallId)) {
+                const rewritten = rewriteCompressText(message.text, liveKeys);
+                if (rewritten !== null) {
+                    result.push({ ...message, text: rewritten });
+                    continue;
+                }
+            }
         }
         result.push(message);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface CompressionBlock {
   active: boolean;
   durationMs?: number;
   compressCallId?: string;
+  startRef?: string;
+  endRef?: string;
 }
 
 export interface MessageRefMap {

--- a/tests/hide-merge-rebuild.test.ts
+++ b/tests/hide-merge-rebuild.test.ts
@@ -118,19 +118,21 @@ test("batched compress: no rewrite when all sibling blocks are live", () => {
             block({ blockId: "b8", compressCallId: "call-batch", active: true, startRef: "m8", endRef: "m9" }),
         ],
     };
+    const originalText = compressInput([
+        { startId: "m5", endId: "m6", summary: "S1" },
+        { startId: "m8", endId: "m9", summary: "S2" },
+    ]);
     const messages: CoreMessage[] = [
         {
             id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
-            text: compressInput([
-                { startId: "m5", endId: "m6", summary: "S1" },
-                { startId: "m8", endId: "m9", summary: "S2" },
-            ]),
+            text: originalText,
         },
     ];
     const result = hideConsumedCompressCalls(state, messages);
     assert.equal(result.hidden, 0);
     const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
-    assert.equal(parseContent(kept.text).length, 2, "both live entries retained, no rewrite");
+    assert.equal(kept.text, originalText, "byte-identical: rewrite path did not fire/re-serialize");
+    assert.equal(parseContent(kept.text).length, 2, "both live entries retained");
 });
 
 test("batched compress: fully removed when all sibling blocks consumed", () => {
@@ -176,4 +178,84 @@ test("batched compress: legacy live block (no startRef/endRef) keeps whole part 
     assert.equal(result.hidden, 0);
     const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
     assert.equal(parseContent(kept.text).length, 2, "legacy live block → no rewrite, all entries kept");
+});
+
+test("batched compress: message-mode entry matched via messageId fallback", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b1", compressCallId: "call-batch", active: true, startRef: "msg-3", endRef: "msg-3" }),
+            block({ blockId: "b2", compressCallId: "call-batch", active: false, startRef: "msg-7", endRef: "msg-7" }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: JSON.stringify({
+                content: [
+                    { messageId: "msg-3", summary: "live message-mode summary" },
+                    { messageId: "msg-7", summary: "consumed message-mode summary" },
+                ],
+            }),
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0);
+    const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
+    const content = parseContent(kept.text) as Array<{ messageId?: string; summary?: string }>;
+    assert.equal(content.length, 1, "consumed message-mode entry dropped");
+    assert.equal(content[0]!.messageId, "msg-3");
+    assert.equal(content[0]!.summary, "live message-mode summary");
+});
+
+test("batched compress: matching-miss keeps original message intact (no data loss)", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b1", compressCallId: "call-batch", active: true, startRef: "m5", endRef: "m6" }),
+        ],
+    };
+    const originalText = compressInput([
+        { startId: "mx", endId: "my", summary: "unmatched entry" },
+        { startId: "mz", endId: "mw", summary: "another unmatched" },
+    ]);
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: originalText,
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0);
+    const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
+    assert.equal(kept.text, originalText, "no entries matched live keys → message preserved verbatim");
+});
+
+test("batched compress: rewritten batch keeps its tool-result message", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b5", compressCallId: "call-batch", active: true, startRef: "m5", endRef: "m6" }),
+            block({ blockId: "b8", compressCallId: "call-batch", active: false, startRef: "m8", endRef: "m9" }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: compressInput([
+                { startId: "m5", endId: "m6", summary: "S1" },
+                { startId: "m8", endId: "m9", summary: "S2" },
+            ]),
+        },
+        {
+            id: "mc-result", role: "tool", contentType: "tool-result", toolCallId: "call-batch",
+            text: '{"ok":true}',
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0, "neither tool-call nor tool-result removed on a kept/rewritten batch");
+    assert.ok(result.messages.find((m) => m.id === "mc"), "rewritten tool-call survives");
+    assert.ok(result.messages.find((m) => m.id === "mc-result"), "tool-result for kept callId survives");
+    const kept = result.messages.find((m) => m.id === "mc")!;
+    assert.equal(parseContent(kept.text).length, 1, "tool-call text rewritten to drop consumed entry");
 });

--- a/tests/hide-merge-rebuild.test.ts
+++ b/tests/hide-merge-rebuild.test.ts
@@ -74,3 +74,106 @@ test("rebuildCompressionState returns zero blocks when no compress calls exist",
     const result = rebuildCompressionState(createInitialState(), messages, defaultConfig(200000, { preserveRecentMessages: 0, preserveRecentTokens: 0 }));
     assert.equal(result.blocksRebuilt, 0);
 });
+
+function compressInput(entries: Array<{ startId: string; endId: string; summary: string }>): string {
+    return JSON.stringify({ content: entries });
+}
+
+function parseContent(text: string | undefined): Array<{ startId?: string; endId?: string; summary?: string }> {
+    return (JSON.parse(text ?? "{}") as { content?: Array<{ startId?: string; endId?: string; summary?: string }> }).content ?? [];
+}
+
+test("batched compress: rewrites kept call to drop consumed sibling entries (issue #288)", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b5", compressCallId: "call-batch", active: true, startRef: "m5", endRef: "m6" }),
+            block({ blockId: "b8", compressCallId: "call-batch", active: false, startRef: "m8", endRef: "m9" }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: compressInput([
+                { startId: "m5", endId: "m6", summary: "live entry summary" },
+                { startId: "m8", endId: "m9", summary: "consumed entry summary" },
+            ]),
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0, "kept batch is not removed");
+    const kept = result.messages.find((m) => m.toolCallId === "call-batch");
+    assert.ok(kept, "batch call survives (one live sibling)");
+    const content = parseContent(kept!.text);
+    assert.equal(content.length, 1, "consumed entry dropped, live entry retained");
+    assert.equal(content[0]!.startId, "m5");
+    assert.equal(content[0]!.summary, "live entry summary");
+});
+
+test("batched compress: no rewrite when all sibling blocks are live", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b5", compressCallId: "call-batch", active: true, startRef: "m5", endRef: "m6" }),
+            block({ blockId: "b8", compressCallId: "call-batch", active: true, startRef: "m8", endRef: "m9" }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: compressInput([
+                { startId: "m5", endId: "m6", summary: "S1" },
+                { startId: "m8", endId: "m9", summary: "S2" },
+            ]),
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0);
+    const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
+    assert.equal(parseContent(kept.text).length, 2, "both live entries retained, no rewrite");
+});
+
+test("batched compress: fully removed when all sibling blocks consumed", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b5", compressCallId: "call-batch", active: false, startRef: "m5", endRef: "m6" }),
+            block({ blockId: "b8", compressCallId: "call-batch", active: false, startRef: "m8", endRef: "m9" }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: compressInput([
+                { startId: "m5", endId: "m6", summary: "S1" },
+                { startId: "m8", endId: "m9", summary: "S2" },
+            ]),
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 1, "fully-consumed batch removed");
+    assert.equal(result.messages.find((m) => m.toolCallId === "call-batch"), undefined);
+});
+
+test("batched compress: legacy live block (no startRef/endRef) keeps whole part intact", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [
+            block({ blockId: "b5", compressCallId: "call-batch", active: true, startRef: "m5", endRef: "m6" }),
+            block({ blockId: "b8", compressCallId: "call-batch", active: true }),
+        ],
+    };
+    const messages: CoreMessage[] = [
+        {
+            id: "mc", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-batch",
+            text: compressInput([
+                { startId: "m5", endId: "m6", summary: "S1" },
+                { startId: "m8", endId: "m9", summary: "S2" },
+            ]),
+        },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0);
+    const kept = result.messages.find((m) => m.toolCallId === "call-batch")!;
+    assert.equal(parseContent(kept.text).length, 2, "legacy live block → no rewrite, all entries kept");
+});


### PR DESCRIPTION
# fix: per-block hide-consumed to stop summary leak in batched compress calls

Counterpart to opencode-acp#289. Same root cause as opencode-acp issue #288.

## Problem

`hideConsumedCompressCalls` keyed its keep-set on `compressCallId`, which is a
**1:N** key under batched `compress` calls. `rebuild.ts:103` assigns a single
`compressCallId: callId` to every `content[]` entry extracted from one tool call,
and `compress.ts:649` propagates that same id to every block. When a higher-tier
distillation consumed only SOME sibling blocks, a surviving sibling kept the
shared callId in `activeCallIds`, rescuing the WHOLE tool-call message —
including the summaries of the already-consumed siblings. Those summaries leak
back into context permanently and are unreclaimable (`compress` is a protected
tool).

## Fix

Record the entry's `startRef`/`endRef` on each block (`types.ts` +
`compress.ts:649`), then key visibility **per-block** (on `${startRef}::${endRef}`)
in `hide-consumed.ts` instead of per-callId:

1. Group every block by `compressCallId`; record each LIVE member's range key.
   A callId is kept iff ≥1 live member.
2. For kept batches with mixed liveness, `rewriteCompressText` parses the
   tool-call message's JSON `text`, filters `content[]` to live entries, and
   re-serializes. Returns `null` on all-live, matching-miss, or unparseable text
   (safe fallback — leaves the message intact).
3. **Migration guard**: if any live block under a callId lacks `startRef`/`endRef`
   (pre-existing persisted state), the whole part is kept intact (old behavior).
   The fix only activates for blocks created after this change.
4. All-consumed batch → message fully removed (unchanged).
5. Orphan logic (`KEEP_LAST_ORPHANED = 0`) unchanged.

## Tests

`tests/hide-merge-rebuild.test.ts` (+4):
- `batched compress: rewrites kept call to drop consumed sibling entries (issue #288)` — core regression
- `batched compress: no rewrite when all sibling blocks are live`
- `batched compress: fully removed when all sibling blocks consumed`
- `batched compress: legacy live block (no startRef/endRef) keeps whole part intact`

The core regression test was verified to **FAIL** with the pre-fix code (`✖`) and
**PASS** after.

## Verification

- `tsc --noEmit`: clean
- `npm run build`: success (100.73 KB)
- Full suite: **216 pass / 0 fail**
- No version bump (fix branch, not a release branch — AGENTS.md §"Version")

## Schema note

Adds two optional fields (`startRef?`, `endRef?`) to `CompressionBlock`. Safe for
a 0.0.x package; the migration guard ensures pre-existing persisted blocks (which
lack the fields) fall back to whole-part retention rather than incorrect dropping.
