### PR TITLE
feat: expose emergencyNothingLeft nudge signal (ISSUE-3)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -864,6 +864,24 @@ function decideNudge(input: NudgeInput): NudgeDecision {
 
   const rec = recommendation;
   const tiers = pendingByTier(state, rec, countTokens);
+  const maxPending = Math.max(0, ...Object.values(tiers).map((t) => t.pending));
+
+  // Emergency deadlock guard (omp ISSUE-3): when usage breaches the emergency
+  // threshold BUT every tier's pending is below a small floor, there is no
+  // legal compression left (the protect zone + minCompressRange leave no viable
+  // range, and there are no active lower-tier blocks to distill). Injecting an
+  // emergency nudge every turn only makes the model attempt-and-fail in a loop
+  // while usage never recovers. The emergency-truncate node is the real safety
+  // valve for "context full, nothing to compress"; here we only stop the nudge
+  // thrash. The situation is still surfaced via the reason and the breakdown.
+  // Floor derives from minCompressRange (chars → ≈tokens) so it tracks the same
+  // gate that blocks T1 compression; the 500 absolute lower bound keeps distill
+  // tiers from re-firing on a handful of tiny summaries.
+  const emergencyFloor = Math.max(
+    500,
+    Math.ceil(config.compress.minCompressRange / 4),
+  );
+  const emergencyNothingLeft = emergencyOverride && maxPending < emergencyFloor;
 
   // Unified injection arbitration, priority T1 > T2 > T3 (ascending). Each
   // tier has its OWN cadence (lastShownByTier) so firing one doesn't block
@@ -898,7 +916,9 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   const shouldInject = emergencyOverride || injectedTier !== null;
 
   let reason: string;
-  if (emergencyOverride) {
+  if (emergencyNothingLeft) {
+    reason = `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}% but nothing left to compress (max ${maxPending} < floor ${emergencyFloor}); recent/protected zone dominates — emergency truncation acts at ${Math.round(config.truncate.threshold * 100)}%`;
+  } else if (emergencyOverride) {
     reason = `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}%`;
   } else if (injectedTier !== null) {
     reason = injectedReason;
@@ -913,7 +933,6 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens && (state.nudge.lastShownByTier[t] ?? 0) > 0 && tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor)
       .map((t) => `T${t} (cadence)`);
     const blockedHint = blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
-    const maxPending = Math.max(0, ...Object.values(tiers).map((t) => t.pending));
     // Report the ACTUAL blocking condition, not a fixed template. A session
     // can have plenty to compress (pending >= threshold) but still not
     // inject because growth/floor/cadence isn't met — the old fixed
@@ -946,6 +965,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       growthFloor,
       hasPendingNudge: hasPendingNudge ? 1 : 0,
       emergencyOverride: emergencyOverride ? 1 : 0,
+      emergencyNothingLeft: emergencyNothingLeft ? 1 : 0,
       pendingT1: tiers[1]!.pending,
       pendingT2: tiers[2]!.pending,
       pendingT3: tiers[3]!.pending,

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -866,17 +866,12 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   const tiers = pendingByTier(state, rec, countTokens);
   const maxPending = Math.max(0, ...Object.values(tiers).map((t) => t.pending));
 
-  // Emergency deadlock guard (omp ISSUE-3): when usage breaches the emergency
-  // threshold BUT every tier's pending is below a small floor, there is no
-  // legal compression left (the protect zone + minCompressRange leave no viable
-  // range, and there are no active lower-tier blocks to distill). Injecting an
-  // emergency nudge every turn only makes the model attempt-and-fail in a loop
-  // while usage never recovers. The emergency-truncate node is the real safety
-  // valve for "context full, nothing to compress"; here we only stop the nudge
-  // thrash. The situation is still surfaced via the reason and the breakdown.
-  // Floor derives from minCompressRange (chars → ≈tokens) so it tracks the same
-  // gate that blocks T1 compression; the 500 absolute lower bound keeps distill
-  // tiers from re-firing on a handful of tiny summaries.
+  // Emergency deadlock guard (omp ISSUE-3): over the emergency line but every
+  // tier's pending below the floor ⇒ no legal range (protect + minCompressRange
+  // block all). Flag it so adapters withhold the nudge instead of attempt-and-
+  // -fail thrashing; emergency truncation (truncate.threshold, fires at 100%) is
+  // the remaining safety valve, not this nudge. Floor tracks minCompressRange
+  // (chars → ≈tokens); the 500 absolute bound avoids re-firing on tiny distills.
   const emergencyFloor = Math.max(
     500,
     Math.ceil(config.compress.minCompressRange / 4),

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -163,6 +163,37 @@ test("nudge: emergency flags emergencyNothingLeft when nothing legally compressi
   );
 });
 
+test("nudge: emergency leaves emergencyNothingLeft=0 when plenty is compressible", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({ messages, state, config, tokenCount: 10000 }).state;
+
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(turn.nudge!.shouldInject, true, "emergency fires");
+  assert.equal(
+    turn.nudge!.breakdown.emergencyNothingLeft,
+    0,
+    "large pending well above the floor → not nothing-left",
+  );
+});
+
+test("nudge: emergencyNothingLeft floor tracks minCompressRange (chars → ≈tokens)", () => {
+  const core = createCore();
+  // Production default minCompressRange: 5000 chars → floor = max(500, 1250) = 1250.
+  // A single ~600-token message is above the bare 500 floor but below 1250, so
+  // under the realistic config it is still flagged nothing-left.
+  const config = buildConfig({ compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 } });
+  const messages = [
+    textMessage("user", "m0", "x".repeat(2400)),
+    textMessage("assistant", "m1", "y".repeat(2400)),
+  ];
+  const state = createInitialState();
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(turn.nudge!.breakdown.emergencyNothingLeft, 1, "~600 tok pending < floor 1250 → nothing-left");
+});
+
 test("nudge: baseline correction when tokens drop significantly", () => {
   const core = createCore();
   const config = buildConfig();

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -140,6 +140,29 @@ test("nudge: emergency override fires at 98% regardless of growth", () => {
   );
 });
 
+test("nudge: emergency flags emergencyNothingLeft when nothing legally compressible", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = [
+    textMessage("user", "m0", "x"),
+    textMessage("assistant", "m1", "y"),
+  ];
+  const state = createInitialState();
+
+  // 99000/100000 = 99% >= 98% emergency, but total compressible content is ~2
+  // tokens, far below the emergency floor (max(500, minCompressRange/4) = 500).
+  // The emergency contract still injects (shouldInject stays true), but the
+  // decision carries emergencyNothingLeft=1 + a distinct reason so adapters can
+  // withhold the compress nudge and avoid attempt-and-fail thrash.
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(turn.nudge!.shouldInject, true, "emergency contract: still injects");
+  assert.equal(turn.nudge!.breakdown.emergencyNothingLeft, 1, "nothing-left signal set");
+  assert.ok(
+    turn.nudge!.reason.includes("nothing left to compress"),
+    `reason should flag nothing-left, got: ${turn.nudge!.reason}`,
+  );
+});
+
 test("nudge: baseline correction when tokens drop significantly", () => {
   const core = createCore();
   const config = buildConfig();


### PR DESCRIPTION
## What

Purely-additive signal so adapters can break the emergency compress-nudge thrash loop (omp long-session test **ISSUE-3**).

## Problem

When usage breaches the emergency threshold but every tier's pending is below the emergency floor (`max(500, minCompressRange/4)`), there is **no legal compression left this turn** — the protect zone + `minCompressRange` leave no viable range and no lower-tier blocks remain to distill. The kernel only emitted a generic `EMERGENCY` reason, so adapters couldn't distinguish *full but compressible* from *full with nothing to compress*. The latter causes attempt-and-fail thrash:

```
emergency nudge → model picks a small range → applyCompression rejects (too small / protected) → still emergency → repeat
```

## Change

Emergency still injects (contract preserved — regression tests unchanged), but `NudgeDecision` now carries:
- `breakdown.emergencyNothingLeft` (1 when the floor is missed)
- a distinct `reason` naming the floor and pointing to emergency truncation as the remaining safety valve

Adapters read the signal to withhold the aggressive compress nudge and stop the thrash. The thrash-avoidance itself lives in the adapter (billion-context-pi) — keeps the kernel as fact-provider, adapter as presentation-decider.

## Why additive (not `shouldInject` suppression)

An earlier draft suppressed `shouldInject` under `emergencyNothingLeft`, but that broke 3 regression tests in `tests/regression-bugfixes.test.ts` that lock in *emergency always injects regardless of compressibility* (their primary intent is ref-correctness / mutation-safety, using emergency as the trigger). Changing that core contract is a design call I deferred to the maintainer; the additive signal delivers the fix at the correct layer without the contract change.

## ISSUE-4 (blocks vs activeBlocks) — investigated, by-design

The report flagged `blocks != activeBlocks` as a desync. Verified `recommend.ts` correctly checks `block.active`, all tier/status logic uses `activeBlocks(state)`, and `status()` reports both as distinct fields. `totalBlocks > activeBlocks` is the intended GC-free design (deactivated blocks accumulate). No change needed.

## Remaining (acp-kernel side, separate work)

- **ISSUE-6** (`tokensCompressed=0`): `applySingleRange` compressed-token sum only counts `.text`; tool-call-only ranges report 0. Needs CoreMessage token accounting work.
- **ISSUE-7** (`minCompressRange` under emergency): largely mitigated once the adapter uses this signal.
- **ISSUE-8** (`minSummaryLength=50`): tester marked OK-for-quality; policy call.

## Verification

- `npm run typecheck` clean
- `npm test` → 213/213 pass (was 212; +1 signal test)
- `npm run build` → dist 99.35 KB