### PR TITLE
fix: T2/T3 distillation nudge clarifies span raw messages are absorbed

### DIFF
--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -134,8 +134,8 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
         "",
         `[TIER ${decision.tier} ${isT2 ? "DISTILLATION" : "CONDENSATION"} TRIGGER]`,
         isT2
-          ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries.`
-          : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries.`,
+          ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`
+          : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`,
         blockList,
         `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
         "",

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -71,6 +71,20 @@ test("tier-3 distillation: text contains tier header", () => {
   assert.ok(result.text.includes("Condense"), "should mention condensation");
 });
 
+test("tier-2 distillation: guidance warns raw messages in span are absorbed", () => {
+  const result = renderNudgeText(makeDecision({ tier: 2 }));
+  assert.ok(result.text.includes("raw"), "should mention raw messages in span");
+  assert.ok(result.text.includes("absorbed"), "should state raw messages are absorbed into the tier-2 block");
+  assert.ok(result.text.includes("HOW TO COMPRESS"), "should direct raw messages to HOW TO COMPRESS rules");
+});
+
+test("tier-3 condensation: guidance warns raw messages in span are absorbed", () => {
+  const result = renderNudgeText(makeDecision({ tier: 3 }));
+  assert.ok(result.text.includes("raw"), "should mention raw messages in span");
+  assert.ok(result.text.includes("absorbed"), "should state raw messages are absorbed into the tier-3 block");
+  assert.ok(result.text.includes("HOW TO COMPRESS"), "should direct raw messages to HOW TO COMPRESS rules");
+});
+
 test("both modes include compressible ranges", () => {
   const gentle = renderNudgeText(makeDecision({ contextUsage: 0.5 }));
   const emergency = renderNudgeText(


### PR DESCRIPTION
## Problem

When the model distills via **contiguous block boundaries** (`startId`/`endId` as `bN`), any **raw (uncompressed) messages sitting between the boundary blocks are absorbed into the higher-tier block too** — they are NOT skipped. The old nudge text only said *"Distill them into a single denser tier-2 summary"*, which risks the model ignoring the intervening raw content and **silently dropping it** from the T2/T3 summary.

## Evidence (master, pre-PR)

`compress({startRef:"b1", endRef:"b2"})` over `[b1(a,b)][raw c][b2(d,e)]`:

```
b3 tier=2 active=true  directMessageIds={c}  effectiveMessageIds={a,b,c,d,e}  directBlockIds={b1,b2}
b1 active=false  b2 active=false
```

The raw message `c` lands in the T2 block's `directMessageIds` and must be summarized — but nothing in the nudge told the model to do so.

## Fix

Add explicit guidance to the T2/T3 trigger instruction in `src/nudge-text.ts` (the kernel-specific rendering — the shared `compression-rules.ts` is left untouched per its *"DO NOT modify the wording"* header):

> Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.

Both rule sets are already injected into the nudge (`HOW_TO_COMPRESS_RULES` + `TIER2/TIER3`), so this just tells the model **when** to apply which.

## Scope

- `src/nudge-text.ts`: 2 instruction lines (T2, T3) — text only, no logic change.
- `tests/nudge-text.test.ts`: +2 tests asserting the new guidance appears for tier-2 and tier-3.

## Context

This is the prompt-only outcome of the design discussion around #41: master already implements contiguous block-boundary distillation that folds intervening raw ("T0") messages into T2/T3 — no `blockIds` / non-contiguous API needed. This PR closes the one real gap: making that folding explicit in the nudge so no raw content is silently lost.

## Verification

- `npm run typecheck` ✅
- `node --import tsx --test tests/nudge-text.test.ts` → 13/13 pass (was 11)
- branch name + version checks pass `scripts/ci/check-pr.sh`
