### PR TITLE
fix(recommend): use ctx.countTokens instead of hardcoded chars/4

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -115,7 +115,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
     // default; applySingleRange enforces it as a hard backstop.
     const protectedMessageIds =
       input.protectedMessageIds ??
-      computeProtectedRefs(input.messages, input.state, input.config);
+      computeProtectedRefs(input.messages, input.state, input.config, countTokens);
 
     const preExistingCoverage = collectCoverage(state);
 
@@ -392,12 +392,14 @@ const recommendNode: PipelineNode = {
       io.messages,
       io.state,
       ctx.config,
+      ctx.countTokens,
     );
     const contextRanges = buildCompressibleRanges(
       io.messages,
       io.state,
       ctx.config,
       protectedRefs,
+      ctx.countTokens,
     );
     const nothingToCompress = contextRanges.compressible.length === 0;
     const recommendation: Recommendation = {

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -33,8 +33,8 @@ function refNum(ref: string): number {
   return Number.isNaN(n) ? -1 : n;
 }
 
-function estimateMessageTokens(message: CoreMessage): number {
-  return Math.ceil((message.text ?? "").length / 4);
+function estimateTextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
 }
 
 function isToolMessage(message: CoreMessage): boolean {
@@ -69,6 +69,7 @@ export function computeProtectedRefs(
   messages: CoreMessage[],
   state: CompressionState,
   config: Config,
+  countTokens: (text: string) => number = estimateTextTokens,
 ): Set<string> {
   const preserveN = config.preserveRecentMessages;
   const preserveTokens = config.preserveRecentTokens;
@@ -86,7 +87,7 @@ export function computeProtectedRefs(
     if (isNeverPreserveRecent(msg)) continue;
     const ref = state.messageRefs.byRaw[msg.id];
     if (!ref || ref === "BLOCKED") continue;
-    visible.push({ ref, tokens: estimateMessageTokens(msg) });
+    visible.push({ ref, tokens: countTokens(msg.text ?? "") });
   }
 
   // Rule 1: last N messages
@@ -146,6 +147,7 @@ export function buildCompressibleRanges(
   state: CompressionState,
   config: Config,
   protectedZoneRefs?: Set<string>,
+  countTokens: (text: string) => number = estimateTextTokens,
 ): ContextRanges {
   const compressibleMsgs: {
     ref: string;
@@ -176,7 +178,7 @@ export function buildCompressibleRanges(
       protectedMsgs.push({
         ref,
         refNum: rn,
-        tokens: estimateMessageTokens(msg),
+        tokens: countTokens(msg.text ?? ""),
         tools: msg.toolName ? [msg.toolName] : [],
       });
       continue;
@@ -189,7 +191,7 @@ export function buildCompressibleRanges(
     compressibleMsgs.push({
       ref,
       refNum: rn,
-      tokens: estimateMessageTokens(msg),
+      tokens: countTokens(msg.text ?? ""),
       isTool: isToolMessage(msg),
       isUser: msg.role === "user",
     });

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -112,6 +112,18 @@ test("computeProtectedRefs: respects injected countTokens for the preserveRecent
   assert.ok(!refs.has("m00001"), "a falls outside the CJK-aware token budget");
 });
 
+test("buildCompressibleRanges: range tokens follow injected countTokens (feeds pendingByTier)", () => {
+  // Regression guard for the 2nd call site of the countTokens fix.
+  // range.tokens sums into pendingByTier (compress.ts:829) → decideNudge
+  // tier-1 arbitration; a chars/4 revert would undercount CJK ~4×.
+  const messages = [msg("a", "x".repeat(100)), msg("b", "y".repeat(100))];
+  const state = assignAll(messages);
+  const mock = (t: string): number => t.length * 7;
+  const ranges = buildCompressibleRanges(messages, state, config(), undefined, mock);
+  assert.equal(ranges.compressible.length, 1);
+  assert.equal(ranges.compressible[0]!.tokens, 1400, "range.tokens must follow injected countTokens, not chars/4");
+});
+
 test("computeProtectedRefs: combines count + token rules (union)", () => {
   const messages = [
     msg("a", "x".repeat(1200)),

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -8,6 +8,7 @@ import { createCore } from "../src/compress.js";
 import { createInitialState } from "../src/state.js";
 import { assignRefs } from "../src/refs.js";
 import type { Config, CoreMessage } from "../src/types.js";
+import { defaultCountTokens } from "../src/tokenize.js";
 
 function config(overrides: Partial<Config> = {}): Config {
   return {
@@ -89,6 +90,26 @@ test("computeProtectedRefs: preserves last N tokens expanding backward", () => {
   assert.ok(refs.has("m00003"));
   assert.ok(refs.has("m00002"));
   assert.ok(!refs.has("m00001"), "a is outside the 500-token window");
+});
+
+test("computeProtectedRefs: respects injected countTokens for the preserveRecentTokens zone (CJK-aware)", () => {
+  // Regression guard: threshold 150 → chars/4 (25/msg) protects {a,b,c},
+  // CJK-aware (100/msg) protects {b,c}. The zone must follow the injected tokenizer.
+  const messages = [
+    msg("a", "文".repeat(100)),
+    msg("b", "文".repeat(100)),
+    msg("c", "文".repeat(100)),
+  ];
+  const state = assignAll(messages);
+  const refs = computeProtectedRefs(
+    messages,
+    state,
+    config({ preserveRecentTokens: 150 }),
+    defaultCountTokens,
+  );
+  assert.ok(refs.has("m00003"), "c is always within the recent-token zone");
+  assert.ok(refs.has("m00002"), "b is within the CJK-aware token budget");
+  assert.ok(!refs.has("m00001"), "a falls outside the CJK-aware token budget");
 });
 
 test("computeProtectedRefs: combines count + token rules (union)", () => {


### PR DESCRIPTION
## What

Fixes a token-counting inconsistency in the recommend engine: `computeProtectedRefs` / `buildCompressibleRanges` estimated every message's tokens as `Math.ceil(text.length / 4)` (hardcoded `chars/4`), while the rest of the pipeline already used `ctx.countTokens` (which defaults to the CJK-aware `defaultCountTokens`). The recommend engine and the nudge threshold therefore disagreed by ~4× on CJK content, skewing protect-zone / compressible-range sizing.

## The bug

- `src/recommend.ts`: `estimateMessageTokens(msg) = ceil(text.length / 4)` — hardcoded, used at all three sizing call sites (lines 89, 179, 192 on master).
- `src/compress.ts:101`: pipeline `countTokens = ports.countTokens ?? defaultCountTokens` (CJK-aware), consumed by `computeContextBreakdown` / nudge.
- Net: a 100-char Chinese message counts as **25 tokens** to the recommend engine but **100 tokens** to the nudge threshold. The protect zone and the nudge threshold disagree on message size → CJK protect/compress decisions are skewed.

This is the minimal fix for the root cause behind the "token calibration" discussion (also surfaced in #51, which wraps this in a broader feature).

## The fix (minimal)

Thread the **existing** `ctx.countTokens` into `computeProtectedRefs` + `buildCompressibleRanges`:

- `recommend.ts`: add a `countTokens: (text: string) => number = estimateTextTokens` param to both functions; replace the 3 `estimateMessageTokens(msg)` call sites with `countTokens(msg.text ?? "")`. The default preserves the legacy `chars/4` behavior for direct/test callers (no behavior change unless a tokenizer is passed).
- `compress.ts`: pass `countTokens` / `ctx.countTokens` at the 3 call sites (the `protectedMessageIds` fallback at L118, and both `recommendNode` calls at L391/L396).

No new public API surface, no new state, no `tokenSnapshot`, no injection-as-a-feature — just routing the tokenizer the pipeline already has into the one module that was ignoring it.

## Test

+1 regression guard in `tests/recommend.test.ts`: with `preserveRecentTokens: 150` and three 100-char CJK messages, the protect zone must be `{b,c}` under the CJK-aware tokenizer (100 tok/msg) but `{a,b,c}` under the legacy `chars/4` (25 tok/msg). Verified to **fail on master** (engine ignores the injected tokenizer → `chars/4` → `a` is wrongly protected) and **pass with the fix**.

## Verification

- `tsc --noEmit` clean
- `node --import tsx --test tests/*.test.ts` → **222 pass / 0 fail** (was 221)
- `scripts/ci/check-pr.sh` → all checks pass

## Scope vs #51

This is the minimal, standalone bug fix. #51 bundles the same recommend threading with the `tokenSnapshot` feature and a broader "injectable countTokens" API. Either can land independently; if both land, the overlapping recommend.ts changes reconcile trivially (identical intent).
