### PR TITLE
release v0.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release `acp-kernel` **v0.0.18**.

## Changes since v0.0.17

Bug-fix release bundling 4 merged PRs (all already on master). No API changes.

| PR | Type | Summary |
|----|------|---------|
| #52 | fix | `hide-consumed` per-block — stops summary leak in batched compress calls (#288) |
| #54 | fix | T2/T3 distillation nudge warns that span raw messages are absorbed |
| #55 | fix | overlap → warn+skip instead of aborting the whole batch (ISSUE-42) |
| #56 | fix | `recommend` uses `ctx.countTokens` instead of hardcoded chars/4 |

## Not included

- **#57** (nudge overhaul: `mergeRangesToThreshold` + effective T1 pending + tier-aware emergency arbitration) remains open and is intentionally **excluded** from this release. It will ship in a later version once merged.

## Pre-flight (local)

- `npm run typecheck` ✅ clean
- `npm test` ✅ 225 pass / 0 fail
- `npm run build` ✅ 101.44 KB

Commit touches `package.json` only (1 line), per release convention.

---

After merge, CI will tag `v0.0.18` and publish to npm. Verify with:
```
npm view acp-kernel version   # expect 0.0.18
```
