### PR TITLE
release v0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export function defaultConfig(
       iterationThreshold: 15,
       force: "soft",
       growthRatio: 0.05,
-      growthFloor: Math.max(20000, Math.round(modelContextLimit * 0.05)),
+      growthFloor: 50000,
       growthCap: 50000,
       minGrowthFloor: 20000,
       minGrowthRatio: 0.45,


### PR DESCRIPTION
## Release v0.0.19

Pin the nudge growth threshold to a fixed **50,000 tokens** (was adaptive: `max(20000, limit×5%)`, clamped to 50000).

### Rationale
Per issue dog/billion-context-pi#26: the computed 5% default is needlessly indirect. For ≥1M-context models it already hit the 50000 cap; for <1M it dropped to the 20000 floor. Flattening to a fixed 50000 makes nudge cadence predictable and consistent across context sizes. The 80% emergency override remains the safety net.

### Change
- `src/config.ts`: `nudge.growthFloor` → `50000` (was `Math.max(20000, round(limit×0.05))`). With `growthCap=50000`, `resolveAdaptiveGrowth` now always returns 50000.
- Override mechanism preserved: callers can still pass a custom `growthFloor`/`growthCap` for adaptive behavior.

### Pre-flight
- `npm run typecheck` ✅ clean
- `npm test` ✅ 225 pass / 0 fail
- `npm run build` ✅ 101.40 KB

### Downstream
billion-context (0.1.34) and billion-context-pi (0.1.34) will bump to this version once published.
