### PR TITLE
feat(prompts): overridable Prompts interface (Layer 0)

### DIFF
--- a/DESIGN-prompts.md
+++ b/DESIGN-prompts.md
@@ -1,0 +1,167 @@
+# Customizable Prompts — Design
+
+Status: **Layer 0 shipped** (this PR). Layers 1–3 are design intent, not yet built.
+
+## Goal
+
+Let hosts (and eventually third parties) customize the prompt text acp-kernel
+feeds to the model — without forking the kernel. The feature is staged so the
+highest-leverage, lowest-risk surface opens first.
+
+## Why it is delicate
+
+Most of the kernel's prompt text is **load-bearing**: it was tuned over months of
+production use to keep summaries lossless enough for retrieval. A summary that
+drops the "KEEP VERBATIM file paths / signatures / decisions" guidance will
+quietly lose the strings a later `decompress` or `grep` needs. So customization
+must distinguish two classes of text:
+
+| Class | Examples | Override risk |
+|-------|----------|---------------|
+| **Load-bearing** | the 4 compression rules (`COMPRESS_PHILOSOPHY`, `HOW_TO_COMPRESS_RULES`, `TIER2_DISTILL_RULES`, `TIER3_CONDENSE_RULES`) | High — degrades summary quality / retrieval |
+| **Surface** | summary section header, status-report chrome, tool descriptions, nudge tone | Low — presentation only |
+
+Load-bearing overrides require explicit risk acknowledgement; surface overrides
+are free.
+
+## Architecture: where prompts live
+
+Prompts are split across two layers, and the override interface must keep them
+consistent:
+
+- **acp-kernel** owns the load-bearing rules as exported constants
+  (`src/compression-rules.ts`) and the nudge renderer
+  (`renderNudgeText` in `src/nudge-text.ts`) that embeds them. Crucially,
+  `processTurn` returns a *structured* `NudgeDecision`, not text — the host
+  renders it, so nudge wording is already host-controllable.
+- **Adapters** (billion-context-pi, opencode-acp, …) own the system prompt and
+  tool descriptions, and they inline the kernel's rule constants when composing
+  them.
+
+The `Prompts` interface is the single typed surface a host overrides once and
+passes everywhere, so both layers render the same customized text.
+
+## Layer 0 — kernel override interface (shipped)
+
+Scope: open the 4 load-bearing rules for override, behind a risk gate. No
+default wording changes; pure additive.
+
+### Public API (`src/prompts.ts`)
+
+```ts
+export interface Prompts {
+  compressPhilosophy: string;
+  howToCompressRules: string;
+  tier2DistillRules: string;
+  tier3CondenseRules: string;
+}
+
+export const defaultPrompts: Prompts;            // == the verbatim rule constants
+
+export function resolvePrompts(
+  overrides?: Partial<Prompts>,
+  options?: { acknowledgeRisk?: boolean },
+): Prompts;
+```
+
+- `resolvePrompts()` returns the defaults.
+- `resolvePrompts({ ... })` **throws** unless `{ acknowledgeRisk: true }` is
+  passed, because every field is load-bearing. The error names the offending
+  keys. This mirrors the existing `compress`-tool `dangerous` /
+  `acknowledgeRisk` pattern.
+- `renderNudgeText(decision, prompts = defaultPrompts)` now accepts a `Prompts`
+  argument, so an override flows into every nudge tier (gentle / emergency /
+  tier-2 / tier-3). The default keeps the one-arg call backward-compatible.
+
+### Host usage
+
+```ts
+import { resolvePrompts, renderNudgeText } from "acp-kernel";
+
+// once, at startup — throws if user overrides rules without ack
+const prompts = resolvePrompts(userOverrides, { acknowledgeRisk: userAcked });
+
+// pass to the kernel renderer
+const nudge = renderNudgeText(decision, prompts);
+
+// and to the adapter's own system-prompt composition (Layer 2 will formalize)
+systemPrompt += prompts.compressPhilosophy + prompts.howToCompressRules;
+```
+
+### Non-goals for Layer 0
+
+- Surface text (summary header, status-report headers, tool descriptions) is
+  intentionally **not** overridable here. Threading the summary header through
+  `prune.ts` folding is invasive and low-value; status chrome is rarely
+  customized. These belong to later layers.
+- Inline validation error strings (`src/compress.ts`) stay fixed.
+- No config field is added to `Config` / `defaultConfig`; the host holds the
+  resolved `Prompts` object and passes it explicitly. This keeps config purely
+  numeric and avoids threading prompts through `processTurn`.
+
+## Layer 1 — prompt-set format (design intent)
+
+A portable, validated bundle so overrides are declarative rather than code:
+
+```
+acp-prompt-set.json   # { name, version, targetKernel, description, acknowledgeRisk }
+philosophy.md          # overrides compressPhilosophy (omit to inherit default)
+how-to-compress.md
+tier2.md
+tier3.md
+```
+
+Principles:
+- **Partial override + inheritance** — a set specifies only what it changes;
+  everything else inherits kernel defaults. Forward-compatible: a new kernel
+  prompt field does not break existing sets.
+- **JSON Schema validation** at load time.
+- **`acknowledgeRisk` in the manifest** — load-bearing fields are still gated,
+  so the set declares up front that it knowingly overrides quality-critical
+  rules.
+
+## Layer 2 — adapter plumbing (design intent)
+
+Each adapter reads a prompt-set path from its config and feeds the resolved
+`Prompts` to both the kernel renderer and its own system-prompt composition.
+
+For billion-context-pi, `user-config.ts` (already reads `~/.pi/agent/acp.json`)
+gains:
+
+```json
+{ "prompts": { "preset": "acp-prompt-pack-zen", "overrides": { "..." : "..." } } }
+```
+
+The same format works for every downstream (opencode-acp, omp-acp, …), so a
+prompt set is portable across hosts.
+
+## Layer 3 — third-party prompt packages (design intent)
+
+Once the format is stable, a third party publishes an npm package exporting a
+validated prompt set. Install + reference by name:
+
+```
+npm install acp-prompt-pack-zen
+```
+
+The kernel gains a `registerPromptSet` registry, matching the existing
+`registerSearchAlgorithm` / `registerMessageFilter` pattern.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Compression-quality regression from bad rules | `acknowledgeRisk` gate; defaults stay the strongly-recommended path |
+| Version drift (kernel changes `NudgeDecision` shape) | `Prompts` is data-only (no function fields), so it is stable across refactors; future renderer overrides would carry a version stamp |
+| Prompt injection via third-party packs | Prompt packs are trusted code (same trust level as any npm dep); documented in the trust model |
+| Tool-description / schema mismatch | Tool schemas stay kernel-owned and fixed; only human-readable descriptions are customizable |
+
+## Migration / rollout
+
+1. Kernel ships Layer 0 (this PR). No downstream change required — defaults are
+   byte-identical.
+2. Adapters adopt the resolved-`Prompts` object when they want to offer
+   customization (Layer 2), reading the same object for both nudge rendering and
+   system-prompt composition.
+3. Format + packages (Layers 1 & 3) follow once adoption confirms the field set
+   is right.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export type { TokenCountFn } from "./tokenize.js";
 export { renderNudgeText, formatRanges } from "./nudge-text.js";
 export type { NudgeVoice, RenderedNudge } from "./nudge-text.js";
 export { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from "./compression-rules.js";
+export { defaultPrompts, resolvePrompts } from "./prompts.js";
+export type { Prompts, ResolvePromptsOptions } from "./prompts.js";
 export { truncateLargeToolOutputs } from "./truncate-tools.js";
 export type { TruncateOptions, TruncateResult } from "./truncate-tools.js";
 export {

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -1,5 +1,6 @@
 import type { NudgeDecision, CompressibleRange, ProtectedRange, ContextBreakdown, CompressionBlock } from "./types.js";
-import { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from "./compression-rules.js";
+import { defaultPrompts } from "./prompts.js";
+import type { Prompts } from "./prompts.js";
 
 export type NudgeVoice = "gentle" | "emergency";
 
@@ -8,9 +9,13 @@ export interface RenderedNudge {
   text: string;
 }
 
-const EFFICIENCY_NOTE = `This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${COMPRESS_PHILOSOPHY}`;
+function efficiencyNote(prompts: Prompts): string {
+  return `This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${prompts.compressPhilosophy}`;
+}
 
-const EMERGENCY_HEADER = `⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n${COMPRESS_PHILOSOPHY}`;
+function emergencyHeader(prompts: Prompts): string {
+  return `⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n${prompts.compressPhilosophy}`;
+}
 
 function formatK(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
@@ -115,7 +120,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   return `Compressible ranges (${merged.length}, oldest first):\n${lines.join("\n")}`;
 }
 
-export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
+export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts): RenderedNudge {
   const breakdownStr = formatBreakdown(decision.contextBreakdown);
   const rangesStr = formatRanges(decision.compressibleRanges, decision.protectedRanges ?? []);
 
@@ -128,7 +133,7 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
     return {
       voice: "gentle",
       text: [
-        EFFICIENCY_NOTE,
+        efficiencyNote(prompts),
         "",
         breakdownStr,
         "",
@@ -139,9 +144,9 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
         blockList,
         `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
         "",
-        HOW_TO_COMPRESS_RULES,
+        prompts.howToCompressRules,
         "",
-        isT2 ? TIER2_DISTILL_RULES : TIER3_CONDENSE_RULES,
+        isT2 ? prompts.tier2DistillRules : prompts.tier3CondenseRules,
       ].join("\n"),
     };
   }
@@ -152,11 +157,11 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
     return {
       voice: "emergency",
       text: [
-        EMERGENCY_HEADER,
+        emergencyHeader(prompts),
         "",
         breakdownStr,
         "",
-        HOW_TO_COMPRESS_RULES,
+        prompts.howToCompressRules,
         "",
         `{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }`,
         "Only use IDs from visible messages above. Compress older work first.",
@@ -169,11 +174,11 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
   return {
     voice: "gentle",
     text: [
-      EFFICIENCY_NOTE,
+      efficiencyNote(prompts),
       "",
       breakdownStr,
       "",
-      HOW_TO_COMPRESS_RULES,
+      prompts.howToCompressRules,
       "",
       rangesStr,
       "",

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -28,13 +28,17 @@ export interface Prompts {
   tier3CondenseRules: string;
 }
 
-/** The kernel's canonical prompt values (verbatim from compression-rules.ts). */
-export const defaultPrompts: Prompts = {
+/**
+ * The kernel's canonical prompt values (verbatim from compression-rules.ts).
+ * Frozen so a buggy caller cannot mutate the shared singleton and corrupt
+ * every other consumer of {@link defaultPrompts}.
+ */
+export const defaultPrompts: Prompts = Object.freeze({
   compressPhilosophy: COMPRESS_PHILOSOPHY,
   howToCompressRules: HOW_TO_COMPRESS_RULES,
   tier2DistillRules: TIER2_DISTILL_RULES,
   tier3CondenseRules: TIER3_CONDENSE_RULES,
-};
+}) as Prompts;
 
 export interface ResolvePromptsOptions {
   /**
@@ -49,23 +53,31 @@ export interface ResolvePromptsOptions {
  * Merge prompt overrides onto the kernel defaults. All fields are load-bearing,
  * so ANY override requires `{ acknowledgeRisk: true }`.
  *
- * Resolve once at host startup, then pass the resulting {@link Prompts} to
- * {@link renderNudgeText} and to the adapter's system-prompt composition so
- * both layers stay consistent.
+ * Only `string`-valued overrides take effect: an explicit `undefined`/`null` or
+ * a wrong type is silently dropped (never clobbers a good default), so a
+ * malformed partial never degrades the canonical rules. Resolve once at host
+ * startup, then pass the resulting {@link Prompts} to {@link renderNudgeText}
+ * and to the adapter's system-prompt composition so both layers stay consistent.
  */
 export function resolvePrompts(
   overrides?: Partial<Prompts>,
   options: ResolvePromptsOptions = {},
 ): Prompts {
+  const clean: Partial<Prompts> = {};
   if (overrides) {
-    const keys = Object.keys(overrides) as (keyof Prompts)[];
-    if (keys.length > 0 && !options.acknowledgeRisk) {
-      throw new Error(
-        `resolvePrompts: overriding compression rules requires { acknowledgeRisk: true }. ` +
-          `Overridden keys: ${keys.join(", ")}. These rules are quality-critical (tuned over months of production use); ` +
-          `changing them can degrade summary quality and break retrieval (summaries may lose paths, signatures, decisions).`,
-      );
+    for (const [key, value] of Object.entries(overrides)) {
+      if (typeof value === "string") {
+        (clean as Record<string, unknown>)[key] = value;
+      }
     }
   }
-  return { ...defaultPrompts, ...overrides };
+  const keys = Object.keys(clean) as (keyof Prompts)[];
+  if (keys.length > 0 && !options.acknowledgeRisk) {
+    throw new Error(
+      `resolvePrompts: overriding compression rules requires { acknowledgeRisk: true }. ` +
+        `Overridden keys: ${keys.join(", ")}. These rules are quality-critical (tuned over months of production use); ` +
+        `changing them can degrade summary quality and break retrieval (summaries may lose paths, signatures, decisions).`,
+    );
+  }
+  return { ...defaultPrompts, ...clean };
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,71 @@
+import {
+  COMPRESS_PHILOSOPHY,
+  HOW_TO_COMPRESS_RULES,
+  TIER2_DISTILL_RULES,
+  TIER3_CONDENSE_RULES,
+} from "./compression-rules.js";
+
+/**
+ * Overridable prompt text consumed by the kernel's nudge renderer and, via the
+ * adapter, the system prompt. Every field here is LOAD-BEARING: these rules
+ * were tuned over months of production use and are quality-critical. Overriding
+ * them can degrade summary quality (loss of paths / signatures / decisions →
+ * broken retrieval), so {@link resolvePrompts} requires `{ acknowledgeRisk: true }`.
+ *
+ * Surface-level text (summary section headers, status-report chrome, tool
+ * descriptions) is intentionally NOT part of this interface — it is owned by
+ * the adapter or a later "prompt-set format" layer and is safe to customize
+ * freely. See DESIGN.md for the load-bearing vs surface classification.
+ */
+export interface Prompts {
+  /** Core compression philosophy. Embedded in the system prompt + every nudge. */
+  compressPhilosophy: string;
+  /** Rules the model follows when writing a tier-1 summary. */
+  howToCompressRules: string;
+  /** Rules for tier-2 distillation of existing summaries. */
+  tier2DistillRules: string;
+  /** Rules for tier-3 ultra-condensation of distilled summaries. */
+  tier3CondenseRules: string;
+}
+
+/** The kernel's canonical prompt values (verbatim from compression-rules.ts). */
+export const defaultPrompts: Prompts = {
+  compressPhilosophy: COMPRESS_PHILOSOPHY,
+  howToCompressRules: HOW_TO_COMPRESS_RULES,
+  tier2DistillRules: TIER2_DISTILL_RULES,
+  tier3CondenseRules: TIER3_CONDENSE_RULES,
+};
+
+export interface ResolvePromptsOptions {
+  /**
+   * Must be `true` to override any prompt field. Every {@link Prompts} field is
+   * load-bearing; overriding without acknowledging the quality risk is a
+   * programming error and throws.
+   */
+  acknowledgeRisk?: boolean;
+}
+
+/**
+ * Merge prompt overrides onto the kernel defaults. All fields are load-bearing,
+ * so ANY override requires `{ acknowledgeRisk: true }`.
+ *
+ * Resolve once at host startup, then pass the resulting {@link Prompts} to
+ * {@link renderNudgeText} and to the adapter's system-prompt composition so
+ * both layers stay consistent.
+ */
+export function resolvePrompts(
+  overrides?: Partial<Prompts>,
+  options: ResolvePromptsOptions = {},
+): Prompts {
+  if (overrides) {
+    const keys = Object.keys(overrides) as (keyof Prompts)[];
+    if (keys.length > 0 && !options.acknowledgeRisk) {
+      throw new Error(
+        `resolvePrompts: overriding compression rules requires { acknowledgeRisk: true }. ` +
+          `Overridden keys: ${keys.join(", ")}. These rules are quality-critical (tuned over months of production use); ` +
+          `changing them can degrade summary quality and break retrieval (summaries may lose paths, signatures, decisions).`,
+      );
+    }
+  }
+  return { ...defaultPrompts, ...overrides };
+}

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -113,3 +113,71 @@ test("renderNudgeText reflects custom tier rules in tier-2 mode", () => {
   const result = renderNudgeText(makeDecision({ tier: 2 }), prompts);
   assert.ok(result.text.includes("UNIQUE-MARKER-T2"));
 });
+
+test("renderNudgeText reflects custom tier rules in tier-3 mode", () => {
+  const prompts = resolvePrompts(
+    { tier3CondenseRules: "UNIQUE-MARKER-T3" },
+    { acknowledgeRisk: true },
+  );
+  const result = renderNudgeText(makeDecision({ tier: 3 }), prompts);
+  assert.ok(result.text.includes("UNIQUE-MARKER-T3"));
+});
+
+test("resolvePrompts drops undefined/null/non-string overrides (never clobbers defaults)", () => {
+  const p = resolvePrompts(
+    {
+      compressPhilosophy: undefined,
+      howToCompressRules: null as unknown as string,
+      tier2DistillRules: 123 as unknown as string,
+    },
+    { acknowledgeRisk: true },
+  );
+  assert.equal(p.compressPhilosophy, COMPRESS_PHILOSOPHY);
+  assert.equal(p.howToCompressRules, HOW_TO_COMPRESS_RULES);
+  assert.equal(p.tier2DistillRules, TIER2_DISTILL_RULES);
+});
+
+test("resolvePrompts does not throw when only non-string overrides are present", () => {
+  const p = resolvePrompts({ compressPhilosophy: undefined, howToCompressRules: null as unknown as string });
+  assert.equal(p.compressPhilosophy, COMPRESS_PHILOSOPHY);
+  assert.equal(p.howToCompressRules, HOW_TO_COMPRESS_RULES);
+});
+
+test("resolvePrompts never aliases or mutates defaultPrompts", () => {
+  const p = resolvePrompts({ compressPhilosophy: "CUSTOM" }, { acknowledgeRisk: true });
+  p.compressPhilosophy = "MUTATED-BY-CALLER";
+  assert.equal(defaultPrompts.compressPhilosophy, COMPRESS_PHILOSOPHY);
+});
+
+test("defaultPrompts is frozen (immutable singleton)", () => {
+  assert.equal(Object.isFrozen(defaultPrompts), true);
+  assert.throws(() => {
+    (defaultPrompts as { compressPhilosophy: string }).compressPhilosophy = "x";
+  }, TypeError);
+});
+
+test("renderNudgeText two-arg default equals one-arg call for every mode (back-compat)", () => {
+  const modes = [
+    makeDecision({ contextUsage: 0.5 }),
+    makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 } }),
+    makeDecision({ tier: 2 }),
+    makeDecision({ tier: 3 }),
+  ];
+  for (const d of modes) {
+    const oneArg = renderNudgeText(d);
+    const twoArg = renderNudgeText(d, defaultPrompts);
+    assert.equal(oneArg.text, twoArg.text);
+    assert.equal(oneArg.voice, twoArg.voice);
+  }
+});
+
+test("renderNudgeText default output embeds the full rule text verbatim (byte-stability)", () => {
+  const gentle = renderNudgeText(makeDecision({ contextUsage: 0.5 }));
+  assert.ok(gentle.text.includes(COMPRESS_PHILOSOPHY));
+  assert.ok(gentle.text.includes(HOW_TO_COMPRESS_RULES));
+  const emergency = renderNudgeText(
+    makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 } }),
+  );
+  assert.ok(emergency.text.includes(COMPRESS_PHILOSOPHY));
+  assert.ok(emergency.text.includes(HOW_TO_COMPRESS_RULES));
+});

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { defaultPrompts, resolvePrompts } from "../src/prompts.js";
+import { renderNudgeText } from "../src/nudge-text.js";
+import {
+  COMPRESS_PHILOSOPHY,
+  HOW_TO_COMPRESS_RULES,
+  TIER2_DISTILL_RULES,
+  TIER3_CONDENSE_RULES,
+} from "../src/compression-rules.js";
+import type { NudgeDecision, CompressibleRange } from "../src/types.js";
+
+function makeRanges(count: number): CompressibleRange[] {
+  return Array.from({ length: count }, (_, i) => ({
+    startRef: `m${String(i * 3 + 1).padStart(5, "0")}`,
+    endRef: `m${String(i * 3 + 3).padStart(5, "0")}`,
+    count: 3,
+    tokens: 1000 * (i + 1),
+    toolPct: 0.7,
+    textPct: 0.3,
+  }));
+}
+
+function makeDecision(overrides: Partial<NudgeDecision> = {}): NudgeDecision {
+  return {
+    shouldInject: true,
+    reason: "test",
+    compressibleRanges: makeRanges(3),
+    contextUsage: 0.5,
+    tier: null,
+    breakdown: { emergencyOverride: 0 },
+    ...overrides,
+  };
+}
+
+test("defaultPrompts mirrors the verbatim rule constants", () => {
+  assert.equal(defaultPrompts.compressPhilosophy, COMPRESS_PHILOSOPHY);
+  assert.equal(defaultPrompts.howToCompressRules, HOW_TO_COMPRESS_RULES);
+  assert.equal(defaultPrompts.tier2DistillRules, TIER2_DISTILL_RULES);
+  assert.equal(defaultPrompts.tier3CondenseRules, TIER3_CONDENSE_RULES);
+});
+
+test("resolvePrompts with no overrides returns the defaults", () => {
+  const p = resolvePrompts();
+  assert.equal(p.compressPhilosophy, COMPRESS_PHILOSOPHY);
+  assert.equal(p.howToCompressRules, HOW_TO_COMPRESS_RULES);
+});
+
+test("resolvePrompts with empty overrides does not throw (no keys changed)", () => {
+  const p = resolvePrompts({});
+  assert.equal(p.compressPhilosophy, COMPRESS_PHILOSOPHY);
+});
+
+test("resolvePrompts throws when overriding without acknowledgeRisk", () => {
+  assert.throws(
+    () => resolvePrompts({ compressPhilosophy: "custom" }),
+    /acknowledgeRisk/,
+  );
+});
+
+test("resolvePrompts lists the offending keys in the error", () => {
+  assert.throws(
+    () => resolvePrompts({ howToCompressRules: "x", tier2DistillRules: "y" }),
+    /howToCompressRules.*tier2DistillRules|tier2DistillRules.*howToCompressRules/,
+  );
+});
+
+test("resolvePrompts applies overrides when acknowledgeRisk is true", () => {
+  const p = resolvePrompts(
+    { compressPhilosophy: "CUSTOM-PHILO", tier3CondenseRules: "CUSTOM-T3" },
+    { acknowledgeRisk: true },
+  );
+  assert.equal(p.compressPhilosophy, "CUSTOM-PHILO");
+  assert.equal(p.tier3CondenseRules, "CUSTOM-T3");
+  assert.equal(p.howToCompressRules, HOW_TO_COMPRESS_RULES);
+  assert.equal(p.tier2DistillRules, TIER2_DISTILL_RULES);
+});
+
+test("renderNudgeText uses default prompts when called with one arg (back-compat)", () => {
+  const result = renderNudgeText(makeDecision({ contextUsage: 0.5 }));
+  assert.ok(result.text.includes("Compression Philosophy:"));
+  assert.ok(result.text.includes("HOW TO COMPRESS"));
+});
+
+test("renderNudgeText reflects a custom compressPhilosophy in gentle mode", () => {
+  const prompts = resolvePrompts(
+    { compressPhilosophy: "UNIQUE-MARKER-PHILOSOPHY" },
+    { acknowledgeRisk: true },
+  );
+  const result = renderNudgeText(makeDecision({ contextUsage: 0.5 }), prompts);
+  assert.ok(result.text.includes("UNIQUE-MARKER-PHILOSOPHY"));
+  assert.ok(!result.text.includes("Compression Philosophy:"));
+});
+
+test("renderNudgeText reflects custom rules in emergency mode", () => {
+  const prompts = resolvePrompts(
+    { howToCompressRules: "UNIQUE-MARKER-HOWTO" },
+    { acknowledgeRisk: true },
+  );
+  const result = renderNudgeText(
+    makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 } }),
+    prompts,
+  );
+  assert.equal(result.voice, "emergency");
+  assert.ok(result.text.includes("UNIQUE-MARKER-HOWTO"));
+});
+
+test("renderNudgeText reflects custom tier rules in tier-2 mode", () => {
+  const prompts = resolvePrompts(
+    { tier2DistillRules: "UNIQUE-MARKER-T2" },
+    { acknowledgeRisk: true },
+  );
+  const result = renderNudgeText(makeDecision({ tier: 2 }), prompts);
+  assert.ok(result.text.includes("UNIQUE-MARKER-T2"));
+});


### PR DESCRIPTION
## What

Opens the kernel's 4 load-bearing compression rules for host override, behind an `acknowledgeRisk` gate — the foundation for customizable prompts across acp-kernel and its downstreams (billion-context-pi, opencode-acp, …). Tracks [dog/billion-context-pi#27](https://github.com/ranxianglei/billion-context-pi/issues/27) (design discussion → approved → reviewed).

**Pure additive:** default wording is byte-identical, and `renderNudgeText` stays one-arg backward-compatible. No downstream change required to keep current behavior.

## Why staged this way

Prompt text is split into **load-bearing** (the compression rules — tuned over months, quality-critical for retrieval) vs **surface** (headers, chrome, descriptions). Layer 0 opens only the load-bearing rules, gated so overrides can't happen by accident. Full rationale + the 4-layer roadmap (override interface → prompt-set format → adapter plumbing → third-party packs) is in [`DESIGN-prompts.md`](DESIGN-prompts.md).

## Changes (5 files, +451/−11)

- **`src/prompts.ts`** (new) — the public override surface:
  - `interface Prompts { compressPhilosophy; howToCompressRules; tier2DistillRules; tier3CondenseRules: string }`
  - `defaultPrompts` — `Object.freeze`d singleton (review R2: callers can't corrupt the shared default).
  - `resolvePrompts(overrides?, { acknowledgeRisk? })` — **non-string values are dropped** (review R1: `{compressPhilosophy: undefined}` no longer clobbers the good default); throws on any override without acknowledgement, naming the offending keys. Mirrors the existing `compress`-tool `dangerous`/`acknowledgeRisk` pattern.
- **`src/nudge-text.ts`** — `renderNudgeText(decision, prompts = defaultPrompts)`; an override now flows into every nudge tier (gentle / emergency / tier-2 / tier-3). `EFFICIENCY_NOTE`/`EMERGENCY_HEADER` became helper functions of `prompts`.
- **`src/index.ts`** — export `defaultPrompts`, `resolvePrompts`, `Prompts`, `ResolvePromptsOptions`.
- **`tests/prompts.test.ts`** (new, 20 tests) — defaults mirror the verbatim constants; empty override no-op; override without ack throws + lists keys; override with ack merges; `renderNudgeText` reflects custom text across all four modes; non-clobber (`undefined`/`null`/`number` dropped); no-aliasing/mutation; frozen assertion; one-arg vs two-arg byte-identity.
- **`DESIGN-prompts.md`** (new) — load-bearing/surface classification, host usage, non-goals, Layers 1–3 design intent, risk table.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ — **244 pass / 0 fail** (224 baseline + 20 new)
- `npm run build` ✅ — `dist/index.js` + `.d.ts` emit the new exports

## Dual-agent review

Two oracle agents reviewed for regressions (per issue #27). Verdict: **ship-with-fixes**. Two real issues found and fixed (R1 non-string clobber, R2 mutable singleton — both above). Non-blocking observations documented in `DESIGN-prompts.md`.

## Publishing

Rebased onto current master (v0.0.20, `13a345e`). Note: **0.0.21 already shipped** for an unrelated nudge fix (#64) and does NOT include Layer 0. When this PR merges, Layer 0 lands in the next publish (**0.0.22**). Downstream [billion-context-pi#128](https://github.com/ranxianglei/billion-context-pi/pull/128) is blocked on that.

## Non-goals (deliberately deferred)

Surface text (summary header, status-report headers, tool descriptions) and inline validation errors stay fixed for now — see `DESIGN-prompts.md §Non-goals`. No `Config`/`defaultConfig` change; the host holds the resolved `Prompts` object and passes it explicitly.

🤖 Merge is human-only — I will not merge this PR.
