### PR TITLE
release v0.0.20: two-tier usage gating (maxContextLimitPct 75% + emergency 95%)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -841,6 +841,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
 
   const nudgeGrowthTokens = resolveAdaptiveGrowth(limit, config.nudge);
 
+  const overLimit = usage >= config.nudge.maxContextLimitPct;
   const emergencyOverride = usage >= config.nudge.emergencyThresholdPct;
 
   const baseline = state.nudge.lastPerMessageNudgeTokens;
@@ -880,7 +881,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   // non-emergency injection. This keeps the first turn (growth 0) from firing
   // immediately even if a lot is compressible — it just establishes baseline.
   const growthReady = growthSinceReference >= growthFloor;
-  if (!emergencyOverride && growthReady) {
+  if (!overLimit && growthReady) {
     for (const tier of [1, 2, 3] as const) {
       if (!config.tiers.enabled && tier > 1) break;
       const info = tiers[tier];
@@ -896,13 +897,33 @@ function decideNudge(input: NudgeInput): NudgeDecision {
         : `T${tier} distill ready: ${info.targetBlocks.length} tier-${tier - 1} blocks (${info.pending} tokens) >= ${nudgeGrowthTokens}, usage ${Math.round(usage * 100)}%`;
       break;
     }
+  } else if (overLimit) {
+    // Over maxContextLimitPct: bypass growth gate + cadence, accept any tier
+    // with pending >= 1. emergencyThresholdPct is the stronger tier that also
+    // trips the truncate node (see truncate.threshold, default 0.95).
+    for (const tier of [1, 2, 3] as const) {
+      if (!config.tiers.enabled && tier > 1) break;
+      const info = tiers[tier];
+      if (!info || info.pending < 1) continue;
+      injectedTier = tier;
+      injectedReason = emergencyOverride
+        ? `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}%, T${tier} pending ${info.pending}`
+        : `OVER-LIMIT: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.maxContextLimitPct * 100)}%, T${tier} pending ${info.pending}`;
+      break;
+    }
   }
 
-  const shouldInject = emergencyOverride || injectedTier !== null;
+  const shouldInject = overLimit || injectedTier !== null;
 
   let reason: string;
-  if (emergencyOverride) {
-    reason = `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}%`;
+  if (emergencyOverride && injectedTier !== null) {
+    reason = injectedReason;
+  } else if (emergencyOverride) {
+    reason = `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}% (no compressible content)`;
+  } else if (overLimit && injectedTier !== null) {
+    reason = injectedReason;
+  } else if (overLimit) {
+    reason = `OVER-LIMIT: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.maxContextLimitPct * 100)}% (no compressible content)`;
   } else if (injectedTier !== null) {
     reason = injectedReason;
   } else {
@@ -948,6 +969,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       nudgeGrowthTokens,
       growthFloor,
       hasPendingNudge: hasPendingNudge ? 1 : 0,
+      overLimit: overLimit ? 1 : 0,
       emergencyOverride: emergencyOverride ? 1 : 0,
       pendingT1: tiers[1]!.pending,
       pendingT2: tiers[2]!.pending,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export function defaultConfig(
   const base: Config = {
     tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
     nudge: {
-      maxContextLimitPct: 0.55,
+      maxContextLimitPct: 0.75,
       minContextLimitPct: 0.45,
       frequency: 5,
       iterationThreshold: 15,
@@ -17,10 +17,10 @@ export function defaultConfig(
       growthCap: 50000,
       minGrowthFloor: 20000,
       minGrowthRatio: 0.45,
-      emergencyThresholdPct: 0.80,
+      emergencyThresholdPct: 0.95,
     },
     promotionThreshold: 5,
-    truncate: { threshold: 1 },
+    truncate: { threshold: 0.95 },
     compress: {
       minCompressRange: 5000,
       maxSummaryLength: 20000,
@@ -52,6 +52,11 @@ export function validateConfig(config: Config): string[] {
   if (config.nudge.minContextLimitPct > config.nudge.maxContextLimitPct) {
     errors.push(
       "nudge.minContextLimitPct must not exceed nudge.maxContextLimitPct",
+    );
+  }
+  if (config.nudge.maxContextLimitPct > config.nudge.emergencyThresholdPct) {
+    errors.push(
+      "nudge.maxContextLimitPct must not exceed nudge.emergencyThresholdPct",
     );
   }
   if (config.promotionThreshold < 1) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,7 @@ export interface NudgeBreakdown {
   nudgeGrowthTokens: number;
   growthFloor: number;
   hasPendingNudge: number;
+  overLimit: number;
   emergencyOverride: number;
   pendingT1: number;
   pendingT2: number;

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -258,7 +258,7 @@ test("integration: tiny ranges are suppressed — fixes the 19-token compression
     messages,
     state,
     config: config({ modelContextLimit: 12000 }),
-    tokenCount: 9000,
+    tokenCount: 5000,
   });
   assert.equal(result.nudge!.shouldInject, false, "turn 1: growth=0, no nudge");
   assert.ok(result.nudge!.reason.includes("growth"), `reason: ${result.nudge!.reason}`);

--- a/tests/sync-config.test.ts
+++ b/tests/sync-config.test.ts
@@ -61,8 +61,9 @@ test("defaultConfig provides sensible production defaults", () => {
   const cfg = defaultConfig(200000);
   assert.equal(cfg.modelContextLimit, 200000);
   assert.equal(cfg.promotionThreshold, 5);
-  assert.equal(cfg.truncate.threshold, 1);
-  assert.equal(cfg.nudge.maxContextLimitPct, 0.55);
+  assert.equal(cfg.truncate.threshold, 0.95);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.75);
+  assert.equal(cfg.nudge.emergencyThresholdPct, 0.95);
   assert.ok(cfg.tiers.tier3Trigger > cfg.tiers.tier2Trigger);
 });
 

--- a/tests/truncate-keep-filter.test.ts
+++ b/tests/truncate-keep-filter.test.ts
@@ -6,6 +6,8 @@ import {
     clearMessageFilters,
     registerMessageFilter,
 } from "../src/filter/index.js";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
 import { defaultConfig } from "../src/config.js";
 import type { CoreMessage } from "../src/types.js";
 
@@ -97,4 +99,63 @@ test("applyMessageFilters keepLastOnly keeps only the last match", () => {
     assert.equal(result.messages[1]!.text, "normal");
     assert.equal(result.messages[2]!.text, "REPEAT:directive-updated");
     clearMessageFilters();
+});
+
+test("emergency-truncate node fires at default 0.95 threshold via processTurn", () => {
+    const core = createCore();
+    const cfg = defaultConfig(100000);
+    const big = "L".repeat(40000);
+    const messages: CoreMessage[] = [
+        msg("a", big, "tool-result"),
+        msg("b", big, "tool-result"),
+        msg("c", big, "tool-result"),
+        msg("d", "recent", "tool-result"),
+        msg("e", "recent", "tool-result"),
+        msg("f", "recent", "tool-result"),
+        msg("g", "recent", "tool-result"),
+        msg("h", "recent", "tool-result"),
+    ];
+    const result = core.processTurn({
+        messages,
+        state: createInitialState(),
+        config: cfg,
+        tokenCount: 96000,
+    });
+    const truncated = result.messages.filter((m) =>
+        m.text?.includes("[truncated for context space"),
+    );
+    assert.ok(
+        truncated.length >= 1,
+        `expected >= 1 truncated msg at 96% usage (default truncate.threshold 0.95), got ${truncated.length}`,
+    );
+});
+
+test("emergency-truncate node is a no-op below default 0.95 threshold", () => {
+    const core = createCore();
+    const cfg = defaultConfig(100000);
+    const big = "L".repeat(40000);
+    const messages: CoreMessage[] = [
+        msg("a", big, "tool-result"),
+        msg("b", big, "tool-result"),
+        msg("c", big, "tool-result"),
+        msg("d", "recent", "tool-result"),
+        msg("e", "recent", "tool-result"),
+        msg("f", "recent", "tool-result"),
+        msg("g", "recent", "tool-result"),
+        msg("h", "recent", "tool-result"),
+    ];
+    const result = core.processTurn({
+        messages,
+        state: createInitialState(),
+        config: cfg,
+        tokenCount: 80000,
+    });
+    const truncated = result.messages.filter((m) =>
+        m.text?.includes("[truncated for context space"),
+    );
+    assert.equal(
+        truncated.length,
+        0,
+        `expected 0 truncated msgs at 80% usage (below default 0.95), got ${truncated.length}`,
+    );
 });


### PR DESCRIPTION
## release v0.0.20 — minimal two-tier nudge gating (no renames)

**Goal**: split the old single emergency threshold (0.80) into two tiers — a lossless force-nudge at 75% and a lossy hard-truncate at 95% — while **keeping all kernel parameter names unchanged** so downstream adapters need zero migration.

### Changes (minimal diff from v0.0.19, +100/-10 across 6 files)

| field | v0.0.19 | v0.0.20 | role |
|-------|---------|---------|------|
| `nudge.maxContextLimitPct` | 0.55 (dead) | **0.75 + activated** | usage≥75% → force-nudge (bypass growth gate + cadence) |
| `nudge.emergencyThresholdPct` | 0.80 | **0.95** | usage≥95% → emergency (stronger reason; trips truncate node) |
| `truncate.threshold` | 1.0 (never fired) | **0.95** | usage≥95% → hard-truncate large tool outputs (lossy) |

**No renames.** `maxContextLimitPct`, `emergencyThresholdPct`, `emergencyOverride`, `TruncateConfig`, `truncate.threshold` all keep their original names. Dead fields (`minContextLimitPct`, `tier2Trigger`, `tier3Trigger`) left untouched.

### Escalation model
- **0–75%**: growth-driven soft nudge (`nudgeGrowthTokens` = 50000, unchanged).
- **75–95%** (`maxContextLimitPct`): force-nudge — bypass growth gate + cadence, accept any tier with pending ≥ 1. Lossless.
- **95%+** (`emergencyThresholdPct` + `truncate.threshold`): emergency force-nudge + hard-truncate of large tool outputs. Lossy.

### Files
- `src/config.ts`: 3 default values + validation `maxContextLimitPct ≤ emergencyThresholdPct`.
- `src/compress.ts` `decideNudge`: add `overLimit` force path (keeps `emergencyOverride`).
- `src/types.ts`: add `overLimit` to `NudgeBreakdown` (`emergencyOverride` retained).
- `tests/`: 2 new integration tests (truncate fires/no-op at default 0.95 via `processTurn`); sync-config defaults updated; tiny-ranges tokenCount lowered below 0.55.

### Pre-flight
typecheck clean / **227 tests pass** (225 + 2 new) / build success.
