### PR TITLE
release v0.0.21: fix over-limit nudge spam + voice (review MAJOR-1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.20",
+    "version": "0.0.21",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -899,12 +899,13 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     }
   } else if (overLimit) {
     // Over maxContextLimitPct: bypass growth gate + cadence, accept any tier
-    // with pending >= 1. emergencyThresholdPct is the stronger tier that also
-    // trips the truncate node (see truncate.threshold, default 0.95).
+    // with pending >= minCompressRange. emergencyThresholdPct and
+    // truncate.threshold are independent knobs — the truncate node fires on
+    // truncate.threshold regardless of emergencyThresholdPct.
     for (const tier of [1, 2, 3] as const) {
       if (!config.tiers.enabled && tier > 1) break;
       const info = tiers[tier];
-      if (!info || info.pending < 1) continue;
+      if (!info || info.pending < config.compress.minCompressRange) continue;
       injectedTier = tier;
       injectedReason = emergencyOverride
         ? `EMERGENCY: usage ${Math.round(usage * 100)}% >= ${Math.round(config.nudge.emergencyThresholdPct * 100)}%, T${tier} pending ${info.pending}`
@@ -913,7 +914,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     }
   }
 
-  const shouldInject = overLimit || injectedTier !== null;
+  const shouldInject = injectedTier !== null || (overLimit && (rec?.recommendedRanges?.length ?? 0) > 0);
 
   let reason: string;
   if (emergencyOverride && injectedTier !== null) {

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -146,7 +146,7 @@ export function renderNudgeText(decision: NudgeDecision): RenderedNudge {
     };
   }
 
-  const isEmergency = !!decision.breakdown?.emergencyOverride;
+  const isEmergency = !!decision.breakdown?.emergencyOverride || !!decision.breakdown?.overLimit;
 
   if (isEmergency) {
     return {

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -139,3 +139,14 @@ test("dangerous flag appears in range listing", () => {
   const result = renderNudgeText(makeDecision({ compressibleRanges: ranges }));
   assert.ok(result.text.includes("⚠️"), "should show dangerous flag");
 });
+
+test("over-limit renders with emergency voice (MAJOR-2 fix)", () => {
+  const result = renderNudgeText(
+    makeDecision({
+      contextUsage: 0.85,
+      breakdown: { overLimit: 1 },
+    }),
+  );
+  assert.equal(result.voice, "emergency", "over-limit should use emergency voice, not gentle");
+  assert.ok(!result.text.includes("not an overflow warning"), "should NOT contain gentle reassurance");
+});

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -297,3 +297,34 @@ test("nudge: compressible ranges exclude messages covered by active blocks", () 
     );
   }
 });
+
+test("over-limit fires force-nudge when compressible content exists", () => {
+  const core = createCore();
+  const config = buildConfig({
+    nudge: { ...buildConfig().nudge, maxContextLimitPct: 0.75 },
+    compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 },
+    preserveRecentMessages: 0,
+  });
+  const messages = makeMessages(10);
+  const turn = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 80000 });
+  assert.equal(turn.nudge.shouldInject, true, "force-nudge should fire with compressible content");
+  assert.equal(turn.nudge.breakdown!.overLimit, 1, "overLimit flag set");
+  assert.ok(turn.nudge.reason.includes("OVER-LIMIT"), `reason: ${turn.nudge.reason}`);
+});
+
+test("over-limit does NOT inject when nothing is compressible (MAJOR-1 fix)", () => {
+  const core = createCore();
+  const config = buildConfig({
+    nudge: { ...buildConfig().nudge, maxContextLimitPct: 0.75 },
+    compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 },
+    preserveRecentMessages: 5,
+  });
+  const messages = [
+    textMessage("user", "a", "hello"),
+    textMessage("assistant", "b", "world"),
+  ];
+  const turn = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 80000 });
+  assert.equal(turn.nudge.shouldInject, false, "no spam when nothing to compress");
+  assert.equal(turn.nudge.breakdown!.overLimit, 1, "overLimit flag still set for reporting");
+  assert.ok(turn.nudge.reason.includes("OVER-LIMIT"), `reason: ${turn.nudge.reason}`);
+});


### PR DESCRIPTION
## Fixes for review findings on 0.0.20 (MAJOR-1, MAJOR-2, MINOR-1, MINOR-2)

Oracle review of 0.0.20 found 4 issues in the `decideNudge` over-limit force path. This PR fixes all 4 + adds test coverage.

### MAJOR-1: perpetual nudge spam when nothing is compressible
`compress.ts:916` — `shouldInject = overLimit || injectedTier !== null` fired even when all content was protected/already compressed (`injectedTier=null` but `overLimit=true`).

**Fix**: gate on actionable target:
```ts
const shouldInject = injectedTier !== null
  || (overLimit && (rec?.recommendedRanges?.length ?? 0) > 0);
```
Now `shouldInject` is `false` when there's truly nothing to compress — the truncate node (at `truncate.threshold`) is the safety valve for that case, not a nudge.

### MAJOR-2: over-limit nudge rendered as gentle
`nudge-text.ts:149` — voice decided by `emergencyOverride` only; the new `[0.75, 0.95)` force-nudge band rendered gentle with header "not an overflow warning" — self-contradicting at 94% usage.

**Fix**: `isEmergency = !!breakdown?.emergencyOverride || !!breakdown?.overLimit` — over-limit now uses emergency voice.

### MINOR-1: force loop accepted sub-minCompressRange ranges
`compress.ts:907` — `info.pending < 1` accepted any non-zero tier, including ranges below `minCompressRange` that `applyCompression` would reject.

**Fix**: `info.pending < config.compress.minCompressRange`.

### MINOR-2: misleading comment
Comment claimed `emergencyThresholdPct` "trips the truncate node" — they're independent knobs.

**Fix**: rewritten to state independence.

### Tests added (3 new, 230 total)
- `nudge.test.ts`: "over-limit fires force-nudge when compressible content exists" + "over-limit does NOT inject when nothing is compressible (MAJOR-1 fix)"
- `nudge-text.test.ts`: "over-limit renders with emergency voice (MAJOR-2 fix)"

### Pre-flight
typecheck clean / 230 tests pass / build success
