### PR TITLE
release v0.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release acp-kernel 0.0.22 — publishes the already-merged features (npm 0.0.21 predates them):

- **#62** `feat(prompts): overridable Prompts interface (Layer 0)` — new `src/prompts.ts` exporting `Prompts` / `defaultPrompts` / `resolvePrompts(overrides, {acknowledgeRisk})`; `renderNudgeText` now prompt-driven. Unblocks billion-context-pi #128 (prompts Layer 2).
- **#65** `fix(compress): attribute batch errors per-range` — `BoundaryNotFoundError` typed errors, per-range error attribution, "already compressed" guidance (fixes the model retry-death-loop from billion-context-pi #135).

`package.json` 0.0.21 → 0.0.22 (+ `package-lock.json` refresh).

Pre-flight: `npm run typecheck` ✓ · `npm test` ✓ (0 fail) · `npm run build` ✓ (106.82 KB).

Merge → CI auto-publishes 0.0.22. (PR merge is human-only per AGENTS.md §4.)