### PR TITLE
fix(compress): keep reasoning paired with its assistant message across compression

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -22,6 +22,7 @@ import { createRenderRefsNode } from "./render-refs.js";
 import type { RenderStrategy } from "./render-refs.js";
 import { isMessageProtected } from "./protected.js";
 import { adjustBoundariesForToolPairs } from "./tool-pairs.js";
+import { adjustBoundariesForReasoningPairs } from "./reasoning-pairs.js";
 import {
   computeProtectedRefs,
   buildCompressibleRanges,
@@ -569,7 +570,7 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
     state: input.state,
   });
 
-  const rangeMessageIds = applyToolPairAdjustment(
+  const rangeMessageIds = applyPairBoundaryAdjustments(
     resolved,
     input.messages,
   );
@@ -722,26 +723,45 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
   return { tokens: compressedTokens, warnings };
 }
 
-function applyToolPairAdjustment(
+function applyPairBoundaryAdjustments(
   resolved: { startIndex: number; endIndex: number; messageIds: string[]; boundaryKind: string },
   messages: CoreMessage[],
 ): string[] {
   if (resolved.boundaryKind === "block") {
     return resolved.messageIds;
   }
-  const adjusted = adjustBoundariesForToolPairs(
-    resolved.startIndex,
-    resolved.endIndex,
-    messages,
-  );
+  // Compose tool-pair and reasoning-pair boundary adjustments to a fixpoint
+  // (≤2 passes). Reasoning may pull in a tool-call whose result tool-pairs
+  // then extends for; tool-pairs may pull in a tool-call whose preceding
+  // reasoning is then drawn in. Both only ever WIDEN the range.
+  let startIndex = resolved.startIndex;
+  let endIndex = resolved.endIndex;
+  for (let pass = 0; pass < 2; pass++) {
+    const reasoningAdjusted = adjustBoundariesForReasoningPairs(
+      startIndex,
+      endIndex,
+      messages,
+    );
+    const toolAdjusted = adjustBoundariesForToolPairs(
+      reasoningAdjusted.startIndex,
+      reasoningAdjusted.endIndex,
+      messages,
+    );
+    const changed =
+      toolAdjusted.startIndex !== startIndex ||
+      toolAdjusted.endIndex !== endIndex;
+    startIndex = toolAdjusted.startIndex;
+    endIndex = toolAdjusted.endIndex;
+    if (!changed) break;
+  }
   if (
-    adjusted.startIndex === resolved.startIndex &&
-    adjusted.endIndex === resolved.endIndex
+    startIndex === resolved.startIndex &&
+    endIndex === resolved.endIndex
   ) {
     return resolved.messageIds;
   }
   const ids: string[] = [];
-  for (let i = adjusted.startIndex; i <= adjusted.endIndex; i++) {
+  for (let i = startIndex; i <= endIndex; i++) {
     const msg = messages[i];
     if (msg) ids.push(msg.id);
   }

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -25,9 +25,11 @@ export function prune(
 
   const anchors = inject ? collectSummaryAnchors(state, indexById) : [];
 
-  return stripOrphanedToolResults(
-    stripOrphanedToolCalls(
-      rebuildMessages(messages, covered, firstUserIndex, anchors),
+  return stripOrphanedReasoning(
+    stripOrphanedToolResults(
+      stripOrphanedToolCalls(
+        rebuildMessages(messages, covered, firstUserIndex, anchors),
+      ),
     ),
   );
 }
@@ -134,4 +136,42 @@ function stripOrphanedToolCalls(messages: CoreMessage[]): CoreMessage[] {
       m.toolName === "compress" ||
       knownResultIds.has(m.toolCallId),
   );
+}
+
+/**
+ * Defense-in-depth for reasoning/text pairing (analogue of
+ * {@link stripOrphanedToolCalls}). A `reasoning` message is only meaningful
+ * when immediately followed — after any same-run reasoning — by its companion
+ * assistant text/tool-call; strict thinking models (DeepSeek et al.) reject
+ * reasoning_content that has lost its response with HTTP 400. Compress-time
+ * boundary expansion normally keeps the pair in one block, so this only fires
+ * for degenerate straddles (block-boundary ranges, malformed input, or a
+ * reasoning that never had a companion): drop the dangling run rather than
+ * ship a 400-triggering half-pair. Runs AFTER tool stripping, since removing
+ * an orphaned tool-call can leave its preceding reasoning dangling too.
+ */
+function stripOrphanedReasoning(messages: CoreMessage[]): CoreMessage[] {
+  const drop = new Set<number>();
+  for (let i = 0; i < messages.length; i++) {
+    if (drop.has(i)) continue;
+    if (messages[i]!.contentType !== "reasoning") continue;
+    let j = i;
+    while (
+      j + 1 < messages.length &&
+      messages[j + 1]!.contentType === "reasoning"
+    ) {
+      j++;
+    }
+    const companion = messages[j + 1];
+    const hasCompanion =
+      companion !== undefined &&
+      companion.role === "assistant" &&
+      (companion.contentType === "text" ||
+        companion.contentType === "tool-call");
+    if (!hasCompanion) {
+      for (let k = i; k <= j; k++) drop.add(k);
+    }
+  }
+  if (drop.size === 0) return messages;
+  return messages.filter((_, i) => !drop.has(i));
 }

--- a/src/reasoning-pairs.ts
+++ b/src/reasoning-pairs.ts
@@ -1,0 +1,90 @@
+import type { CoreMessage } from "./types.js";
+
+/**
+ * Adjust compression range boundaries to keep a `reasoning` message together
+ * with the assistant text/tool-call it belongs to.
+ *
+ * Reasoning models (DeepSeek-R1, GLM-4.6 thinking, Qwen-QwQ, Anthropic
+ * thinking) emit a `reasoning_content` / thinking block that strict providers
+ * require to be echoed back alongside the response on every subsequent
+ * request. In acp-kernel that block is a separate `contentType: "reasoning"`
+ * message immediately preceding the assistant text/tool-call of the same turn.
+ * If a compression range covers only one half of the pair, the rebuilt
+ * conversation ships reasoning without its response (or vice versa) and the
+ * provider returns HTTP 400 (DeepSeek: "reasoning_content in the thinking mode
+ * must be passed back to the API").
+ *
+ * This is the reasoning analogue of {@link adjustBoundariesForToolPairs}:
+ * before a range is applied, pull the orphan half INTO the range so the pair
+ * compresses together — zero information loss. Only MESSAGE-boundary ranges
+ * are adjusted (block-boundary ranges are left untouched, like tool pairs).
+ *
+ * Pairing is adjacency-based — there is no shared id (unlike toolCallId). A
+ * `reasoning` message pairs with the assistant text/tool-call immediately
+ * following its reasoning run, and an assistant text/tool-call pairs with the
+ * reasoning run immediately preceding it. This matches the round-trip contract
+ * every adapter relies on when reconstructing reasoning_content.
+ *
+ * @returns Adjusted { startIndex, endIndex } — may be wider than input.
+ */
+export function adjustBoundariesForReasoningPairs(
+  startIndex: number,
+  endIndex: number,
+  messages: CoreMessage[],
+): { startIndex: number; endIndex: number } {
+  if (startIndex > endIndex) {
+    return { startIndex, endIndex };
+  }
+  let newStartIndex = startIndex;
+  let newEndIndex = endIndex;
+
+  for (let i = startIndex; i <= endIndex && i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg) continue;
+
+    if (msg.contentType === "reasoning") {
+      // Forward: pull the companion assistant text/tool-call that follows
+      // this reasoning run into the range.
+      let j = i;
+      while (
+        j + 1 < messages.length &&
+        messages[j + 1]!.contentType === "reasoning"
+      ) {
+        j++;
+      }
+      const companion = messages[j + 1];
+      if (
+        companion !== undefined &&
+        companion.role === "assistant" &&
+        (companion.contentType === "text" ||
+          companion.contentType === "tool-call") &&
+        j + 1 > newEndIndex
+      ) {
+        newEndIndex = j + 1;
+      }
+    }
+
+    if (
+      msg.role === "assistant" &&
+      (msg.contentType === "text" || msg.contentType === "tool-call")
+    ) {
+      // Backward: pull the reasoning run immediately preceding this assistant
+      // message into the range.
+      let k = i - 1;
+      while (k >= 0 && messages[k]!.contentType === "reasoning") {
+        k--;
+      }
+      const runStart = k + 1;
+      if (
+        runStart < i &&
+        runStart >= 0 &&
+        messages[runStart]!.contentType === "reasoning" &&
+        runStart < newStartIndex
+      ) {
+        newStartIndex = runStart;
+      }
+    }
+  }
+
+  return { startIndex: newStartIndex, endIndex: newEndIndex };
+}

--- a/tests/reasoning-pairs.test.ts
+++ b/tests/reasoning-pairs.test.ts
@@ -1,0 +1,375 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { adjustBoundariesForReasoningPairs } from "../src/reasoning-pairs.js";
+import type { CoreMessage } from "../src/types.js";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { defaultConfig } from "../src/config.js";
+import { prune } from "../src/prune.js";
+import { createInitialState as emptyState } from "../src/state.js";
+
+function reasoning(id: string): CoreMessage {
+  return {
+    id,
+    role: "assistant",
+    contentType: "reasoning",
+    text: `reasoning-${id}`,
+  };
+}
+function assistantText(id: string): CoreMessage {
+  return { id, role: "assistant", contentType: "text", text: `text-${id}` };
+}
+function toolCall(id: string, callId: string, toolName = "read"): CoreMessage {
+  return {
+    id,
+    role: "assistant",
+    contentType: "tool-call",
+    toolName,
+    toolCallId: callId,
+    text: `call-${callId}`,
+  };
+}
+function toolResult(
+  id: string,
+  callId: string,
+  toolName = "read",
+): CoreMessage {
+  return {
+    id,
+    role: "user",
+    contentType: "tool-result",
+    toolName,
+    toolCallId: callId,
+    text: `result-${callId}`,
+  };
+}
+function textMsg(id: string, role: "user" | "assistant" = "user"): CoreMessage {
+  return { id, role, contentType: "text", text: `text-${id}` };
+}
+
+describe("adjustBoundariesForReasoningPairs", () => {
+  it("no-op when range has no reasoning", () => {
+    const messages = [textMsg("a"), textMsg("b"), textMsg("c"), textMsg("d")];
+    const result = adjustBoundariesForReasoningPairs(0, 2, messages);
+    assert.deepEqual(result, { startIndex: 0, endIndex: 2 });
+  });
+
+  it("extends forward to include companion text after reasoning in range", () => {
+    const messages = [
+      textMsg("a"),
+      reasoning("b"),
+      assistantText("c"),
+      textMsg("d"),
+    ];
+    const result = adjustBoundariesForReasoningPairs(1, 1, messages);
+    assert.deepEqual(result, { startIndex: 1, endIndex: 2 });
+  });
+
+  it("extends backward to include reasoning before companion text in range", () => {
+    const messages = [
+      textMsg("a"),
+      reasoning("b"),
+      assistantText("c"),
+      textMsg("d"),
+    ];
+    const result = adjustBoundariesForReasoningPairs(2, 2, messages);
+    assert.deepEqual(result, { startIndex: 1, endIndex: 2 });
+  });
+
+  it("extends both directions when two pairs straddle the range", () => {
+    const messages = [
+      reasoning("a"),
+      assistantText("b"),
+      textMsg("c"),
+      reasoning("d"),
+      assistantText("e"),
+    ];
+    const result = adjustBoundariesForReasoningPairs(1, 3, messages);
+    assert.deepEqual(result, { startIndex: 0, endIndex: 4 });
+  });
+
+  it("treats a tool-call as the companion of preceding reasoning", () => {
+    const messages = [
+      textMsg("a"),
+      reasoning("b"),
+      toolCall("c", "call1"),
+      toolResult("d", "call1"),
+      textMsg("e"),
+    ];
+    const result = adjustBoundariesForReasoningPairs(1, 1, messages);
+    assert.deepEqual(result, { startIndex: 1, endIndex: 2 });
+  });
+
+  it("does not extend when reasoning is followed by a non-assistant message (no companion)", () => {
+    const messages = [textMsg("a"), reasoning("b"), textMsg("c")];
+    const result = adjustBoundariesForReasoningPairs(1, 1, messages);
+    assert.deepEqual(result, { startIndex: 1, endIndex: 1 });
+  });
+
+  it("handles a multi-message reasoning run as one unit", () => {
+    const messages = [
+      textMsg("a"),
+      reasoning("r1"),
+      reasoning("r2"),
+      assistantText("c"),
+      textMsg("d"),
+    ];
+    const result = adjustBoundariesForReasoningPairs(1, 1, messages);
+    assert.deepEqual(result, { startIndex: 1, endIndex: 3 });
+  });
+});
+
+describe("compression with reasoning-pair protection", () => {
+  const cfg = {
+    ...defaultConfig(100000),
+    compress: { ...defaultConfig(100000).compress, minCompressRange: 0 },
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+  };
+
+  it("compression auto-includes companion text after reasoning", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      assistantText("m3"),
+      textMsg("m4"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00002",
+          endRef: "m00002",
+          summary:
+            "Compress just the reasoning; its companion text must be auto-included to keep the pair atomic.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    assert.equal(result.result.blocksCreated, 1);
+    const block = result.state.blocks.find((b) => b.active);
+    assert.ok(block);
+    assert.ok(
+      block!.effectiveMessageIds.includes("m2"),
+      "reasoning m2 should be in block",
+    );
+    assert.ok(
+      block!.effectiveMessageIds.includes("m3"),
+      "companion text m3 should be auto-included",
+    );
+  });
+
+  it("compression auto-includes reasoning before companion text", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      assistantText("m3"),
+      textMsg("m4"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00003",
+          endRef: "m00003",
+          summary:
+            "Compress just the companion text; its preceding reasoning must be auto-included.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    assert.equal(result.result.blocksCreated, 1);
+    const block = result.state.blocks.find((b) => b.active);
+    assert.ok(block);
+    assert.ok(
+      block!.effectiveMessageIds.includes("m2"),
+      "reasoning m2 should be auto-included",
+    );
+    assert.ok(
+      block!.effectiveMessageIds.includes("m3"),
+      "companion text m3 should be in block",
+    );
+  });
+
+  it("reasoning + tool-call pair also pulls the tool-result (composed adjustment)", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      toolCall("m3", "c1"),
+      toolResult("m4", "c1"),
+      textMsg("m5"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00002",
+          endRef: "m00002",
+          summary:
+            "Compress just the reasoning; fixpoint pulls in the tool-call then its result.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    assert.equal(result.result.blocksCreated, 1);
+    const block = result.state.blocks.find((b) => b.active);
+    assert.ok(block);
+    assert.ok(
+      block!.effectiveMessageIds.includes("m2"),
+      "reasoning m2 in block",
+    );
+    assert.ok(
+      block!.effectiveMessageIds.includes("m3"),
+      "tool-call m3 pulled by reasoning companion",
+    );
+    assert.ok(
+      block!.effectiveMessageIds.includes("m4"),
+      "tool-result m4 pulled by tool-pair fixpoint",
+    );
+  });
+
+  it("uncompressed reasoning pair survives intact when another range is compressed", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      assistantText("m3"),
+      textMsg("m4"),
+      reasoning("m5"),
+      assistantText("m6"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00005",
+          endRef: "m00006",
+          summary:
+            "Compress the second reasoning pair. The first pair must survive intact.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    const pruned = core.processTurn({
+      messages,
+      state: result.state,
+      config: cfg,
+      tokenCount: 500,
+    }).messages;
+
+    const ids = pruned.map((m) => m.id);
+    assert.ok(ids.includes("m2"), "uncompressed reasoning m2 survives");
+    assert.ok(ids.includes("m3"), "uncompressed companion text m3 survives");
+    assert.ok(!ids.includes("m5"), "compressed reasoning m5 removed");
+    assert.ok(!ids.includes("m6"), "compressed companion text m6 removed");
+  });
+});
+
+describe("prune stripOrphanedReasoning (defense-in-depth)", () => {
+  it("strips a dangling reasoning whose companion was removed", () => {
+    const messages: CoreMessage[] = [
+      { id: "u0", role: "user", contentType: "text", text: "ask" },
+      {
+        id: "r1",
+        role: "assistant",
+        contentType: "reasoning",
+        text: "thinking",
+      },
+      { id: "a1", role: "assistant", contentType: "text", text: "answer" },
+      { id: "u1", role: "user", contentType: "text", text: "next" },
+    ];
+
+    // Degenerate straddle: the companion text a1 is covered but the reasoning
+    // r1 is not. After rebuild r1 is followed by a user message → dangling.
+    const state = {
+      ...emptyState(),
+      blocks: [
+        {
+          blockId: "b0",
+          runId: "r0",
+          tier: 1 as const,
+          summary: "covered the answer",
+          directMessageIds: ["a1"],
+          effectiveMessageIds: ["a1"],
+          directBlockIds: [],
+          compressedTokens: 10,
+          createdAt: 0,
+          survivedCount: 0,
+          generation: "young" as const,
+          active: true,
+          compressCallId: undefined,
+          startRef: undefined,
+          endRef: undefined,
+        },
+      ],
+    };
+
+    const result = prune(messages, state);
+    const ids = result.map((m) => m.id);
+    assert.ok(!ids.includes("r1"), "dangling reasoning r1 stripped");
+    assert.ok(!ids.includes("a1"), "covered companion a1 pruned");
+    assert.ok(ids.includes("u0"), "first user message preserved");
+    assert.ok(ids.includes("u1"), "trailing user message preserved");
+  });
+
+  it("keeps a reasoning pair when neither half is covered", () => {
+    const messages: CoreMessage[] = [
+      { id: "u0", role: "user", contentType: "text", text: "ask" },
+      {
+        id: "r1",
+        role: "assistant",
+        contentType: "reasoning",
+        text: "thinking",
+      },
+      { id: "a1", role: "assistant", contentType: "text", text: "answer" },
+    ];
+
+    const result = prune(messages, emptyState());
+    const ids = result.map((m) => m.id);
+    assert.ok(ids.includes("r1"), "reasoning kept (companion present)");
+    assert.ok(ids.includes("a1"), "companion text kept");
+  });
+});

--- a/tests/reasoning-pairs.test.ts
+++ b/tests/reasoning-pairs.test.ts
@@ -373,3 +373,117 @@ describe("prune stripOrphanedReasoning (defense-in-depth)", () => {
     assert.ok(ids.includes("a1"), "companion text kept");
   });
 });
+
+describe("regression: DeepSeek split-compress does not orphan a reasoning pair (#133)", () => {
+  // Reproduces ranxianglei/billion-context#133. An assistant turn is emitted as
+  // two core messages — reasoning then text. A compress range that covers only
+  // ONE half must not leave the other half orphaned in the rebuilt stream.
+  // DeepSeek-thinking returns HTTP 400 ("reasoning_content must be passed back
+  // to the API") when an assistant turn loses its reasoning_content, so the
+  // pair must compress atomically. These tests would FAIL on master (pre-fix):
+  // without adjustBoundariesForReasoningPairs the companion survives as an
+  // orphaned assistant message with no reasoning_content.
+
+  const cfg = {
+    ...defaultConfig(100000),
+    compress: { ...defaultConfig(100000).compress, minCompressRange: 0 },
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+  };
+
+  it("compressing only the reasoning does not orphan the companion assistant text", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      assistantText("m3"),
+      textMsg("m4"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00002",
+          endRef: "m00002",
+          summary:
+            "Compress just the reasoning; its companion text must compress with it.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    const rebuilt = core.processTurn({
+      messages,
+      state: result.state,
+      config: cfg,
+      tokenCount: 500,
+    }).messages;
+    const ids = rebuilt.map((m) => m.id);
+
+    assert.ok(
+      !ids.includes("m2"),
+      "reasoning m2 must be compressed (not survive as orphan)",
+    );
+    assert.ok(
+      !ids.includes("m3"),
+      "companion text m3 must compress WITH its reasoning — an orphaned assistant message with no reasoning_content is the DeepSeek 400 trigger",
+    );
+  });
+
+  it("compressing only the companion text does not orphan the reasoning", () => {
+    const core = createCore();
+    const messages = [
+      textMsg("m1"),
+      reasoning("m2"),
+      assistantText("m3"),
+      textMsg("m4"),
+    ];
+    const state = createInitialState();
+    const stateWithRefs = core.processTurn({
+      messages,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+    }).state;
+
+    const result = core.applyCompression({
+      ranges: [
+        {
+          startRef: "m00003",
+          endRef: "m00003",
+          summary:
+            "Compress just the text; its preceding reasoning must compress with it.",
+        },
+      ],
+      messages,
+      state: stateWithRefs,
+      config: cfg,
+    });
+
+    const rebuilt = core.processTurn({
+      messages,
+      state: result.state,
+      config: cfg,
+      tokenCount: 500,
+    }).messages;
+    const ids = rebuilt.map((m) => m.id);
+
+    assert.ok(
+      !ids.includes("m2"),
+      "reasoning m2 must compress with its companion — an orphaned reasoning with no following assistant text is meaningless",
+    );
+    assert.ok(
+      !ids.includes("m3"),
+      "companion text m3 must be compressed (not survive as orphan)",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Fixes the root cause of ranxianglei/billion-context#133 (DeepSeek thinking mode 400 `"reasoning_content in the thinking mode must be passed back to the API"` after compression), and the same latent class on the Anthropic and Responses paths.

### Root cause

All three protocol adapters (`openai.ts`, `responses.ts`, `anthropic.ts`) emit each assistant turn's `reasoning_content` as a **separate** `contentType: "reasoning"` core message, followed by separate `text`/`tool-call` messages of the same turn. Pairing between reasoning and its companion text is purely positional (the `coreToOpenai` `pending` accumulator assumes a reasoning msg immediately precedes its assistant text).

acp-kernel had a robust **tool-pair** mechanism (`adjustBoundariesForToolPairs` + `stripOrphanedToolCalls`/`stripOrphanedToolResults`) that guarantees a tool-call and its tool-result always compress together — but **no equivalent for reasoning↔text**. So a compress range could cover a reasoning message but not its companion assistant text (or vice versa), leaving an orphaned half that, on rebuild, produces an assistant message missing/extra `reasoning_content`. DeepSeek-thinking strictly requires a byte-consistent historical `reasoning_content` and returns HTTP 400 on mismatch; gpt-5-codex (Responses) and Anthropic are lenient, so the bug is latent there.

## Fix — mirror the tool-pair mechanism

| Layer | Tool-pair (existing) | Reasoning-pair (new) |
|-------|---------------------|----------------------|
| Compress boundary expansion | `adjustBoundariesForToolPairs` | **`adjustBoundariesForReasoningPairs`** |
| Compose both | — | **`applyPairBoundaryAdjustments`** (fixpoint ≤2 passes) |
| Rebuild safety net | `stripOrphanedToolCalls`/`stripOrphanedToolResults` | **`stripOrphanedReasoning`** |

### 1. `src/reasoning-pairs.ts` (new)

`adjustBoundariesForReasoningPairs(startIndex, endIndex, messages)` — scans the in-range messages:
- a `reasoning` msg → pulls its **companion assistant text/tool-call** (the run of assistant messages following the reasoning run, up to a non-assistant boundary) **forward** into the range;
- an assistant text/tool-call → pulls the **preceding reasoning run backward** into the range.

Handles multi-message reasoning runs. No-op when `startIndex > endIndex`.

### 2. `src/compress.ts`

Renamed `applyToolPairAdjustment` → `applyPairBoundaryAdjustments`, which **composes** reasoning-pair and tool-pair adjustment to a fixpoint (≤2 passes). Both adjusters only ever widen the range, so a second pass reaches fixpoint: reasoning may pull in a tool-call whose result tool-pairs then extends for, and vice versa.

### 3. `src/prune.ts`

Added `stripOrphanedReasoning(messages)`, wired as the **outermost** step in `prune()` — runs after `stripOrphanedToolCalls`/`stripOrphanedToolResults`, because removing an orphaned tool-call can leave a reasoning message dangling. Drops a reasoning whose companion assistant text/tool-call is absent (degenerate straddle / malformed input).

## Why in the kernel (not the adapter)

The pairing invariant belongs at the compression boundary, not per-adapter. Doing it here means all three protocol paths (OpenAI chat/completions, Responses/codex, Anthropic) are fixed with one change, and the `ACP_REASONING_KEEP=none` opt-in workaround in `billion-context` PR #139 remains useful only as a token-saving escape hatch — no longer needed for correctness.

## Tests

`tests/reasoning-pairs.test.ts` — 13 new tests, mirroring `tool-pairs.test.ts`:
- 7 unit tests for `adjustBoundariesForReasoningPairs` (no-op, forward pull, backward pull, both-direction straddle, tool-call companion, no-companion-no-extend, multi-reasoning-run)
- 4 compression integration tests (auto-include companion text, auto-include reasoning backward, reasoning+toolcall pulls tool-result via the fixpoint, uncompressed pair survives)
- 2 prune `stripOrphanedReasoning` tests (dangling reasoning stripped, intact pair kept)

```
typecheck: clean
test: 270/270 pass (was 257; +13 new)
build: success (109 KB)
```

## Note

`src/compress.ts` carries some pre-existing prettier drift on `master` (prettier 3.9.6 wants to reformat unrelated lines). This PR does **not** reformat those — it keeps the diff to the logical change only. (`format:check` is not a CI gate; CI runs typecheck/test/build/branch-name.)

## Follow-up (separate)

After this merges and publishes: bump the `acp-kernel` pin in `billion-context` (PR #139's `ACP_REASONING_KEEP=none` stays as an opt-in token-saving escape hatch).