### PR TITLE
release v0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.21",
+    "version": "0.0.23",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.21",
+            "version": "0.0.23",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Release v0.0.23

Version bump. Publishes the reasoning-pairing fix (PR #68) to npm.

### Changes since v0.0.22

- **PR #68** — `fix(compress): keep reasoning paired with its assistant message across compression`
  - New `adjustBoundariesForReasoningPairs` + `stripOrphanedReasoning` + `applyPairBoundaryAdjustments` (mirrors the tool-pair mechanism) so an assistant turn's `reasoning_content` and its companion text/tool-call always compress together.
  - Fixes the root cause of `ranxianglei/billion-context#133` (DeepSeek thinking 400 `"reasoning_content must be passed back"` after compression) and the same latent class on the Anthropic / Responses paths.
  - +13 tests (mechanism + 2 end-to-end breaking regression tests proving the split-compress failure mode).

### Pre-flight (matches release.yml CI)

```
typecheck: clean
test: 272/272 pass
build: success (109.23 KB)
```

Commit touches `package.json` + `package-lock.json` (lockfile version-synced; `npm ci` requires it).