### PR TITLE
fix(nudge): reset lastShownByTier in the re-baseline branch

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -502,6 +502,15 @@ const nudgeNode: PipelineNode = {
     ) {
       stamped.lastPerMessageNudgeTokens = ctx.tokenCount;
       stamped.lastNudgeShownTokens = 0;
+      // The context shrank dramatically — host compaction, or a tokenCount
+      // scale switch (an adapter moving from session-tree accounting to
+      // sent-view estimation). Per-tier cadence stamps recorded at the old
+      // scale would otherwise make `tokenCount - lastShownByTier[t] >=
+      // growthFloor` unreachable (a stamp above the window never re-arms),
+      // suppressing mid-band nudges until the absolute overLimit band fires.
+      // Restart tier cadence from the new baseline, mirroring the full stamp
+      // reset a successful applyCompression performs.
+      stamped.lastShownByTier = {};
     }
 
     if (stamped.lastPerMessageNudgeTokens === 0) {

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -612,3 +612,26 @@ test("emergency with effective pending routes to the max-pending tier (post-fix 
   assert.equal(turn.nudge.tier, 1, "T1 has the max pending here");
   assert.ok(turn.nudge.reason.includes("EMERGENCY"), `reason: ${turn.nudge.reason}`);
 });
+
+test("re-baseline after a tokenCount scale drop also resets per-tier cadence stamps", () => {
+  const core = createCore();
+  const config = buildConfig();
+  // A session carried over from an adapter that fed session-tree accounting:
+  // stamps recorded at 366K while the real (sent-view) tokenCount is 40K.
+  // lastPerMessageNudgeTokens triggers the re-baseline branch (drop far
+  // below baseline - nudgeGrowthTokens); lastShownByTier at the old scale
+  // would make `tokenCount - lastShownByTier[t] >= growthFloor` unreachable
+  // (negative forever), suppressing mid-band nudges until the absolute
+  // overLimit band fires.
+  const state = createInitialState();
+  state.nudge.lastPerMessageNudgeTokens = 366_000;
+  state.nudge.lastNudgeShownTokens = 366_000;
+  state.nudge.lastShownByTier = { 1: 366_000, 2: 366_000 };
+
+  const messages = makeMessages(10);
+  const turn = core.processTurn({ messages, state, config, tokenCount: 40_000 });
+  const stamped = turn.state.nudge;
+  assert.equal(stamped.lastPerMessageNudgeTokens, 40_000, "baseline re-anchored at the new scale");
+  assert.equal(stamped.lastNudgeShownTokens, 0, "shared cadence baseline cleared");
+  assert.deepEqual(stamped.lastShownByTier, {}, "per-tier cadence stamps must not survive a scale drop");
+});


### PR DESCRIPTION
## Context

The omp (PR #39, shipped in v0.1.7) and pi (PR #150) adapters switched nudge arbitration from session-tree token accounting to sent-view estimation. Sessions carried over from the buggy version have nudge stamps recorded at the tree scale (e.g. 366K in a 180K window). Review of pi PR #150 traced the stamp migration through the kernel:

- `lastNudgeShownTokens` self-heals: the re-baseline branch (`tokenCount < baseline - nudgeGrowthTokens`) zeroes it and re-anchors the baseline on the first post-switch turn.
- `lastShownByTier` was **not** reset there. A tier stamp above the window makes the per-tier cadence `tokenCount - lastShownByTier[t] >= growthFloor` unreachable forever → mid-band (growth-band) nudges suppressed until the absolute overLimit band (≥75%) fires, or any successful compression resets all stamps.

## Fix

Reset `lastShownByTier = {}` in the re-baseline branch. The branch fires only on a dramatic context drop (host compaction or scale switch) — in both cases the old-scale tier stamps are meaningless, so restarting tier cadence from the new baseline is semantically correct, mirroring the full stamp reset a successful `applyCompression` performs.

## Test

New regression test in `tests/nudge.test.ts` (poisoned 366K stamps → 40K tokenCount → assert all three stamp kinds reset). Red on master, green here. 296/296, tsc clean.

Review: del_mstznskv_csqo (MED-2 follow-up).