### PR TITLE
feat(wire): protocol codec submodule extracted from proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
         ".": {
             "types": "./dist/index.d.ts",
             "import": "./dist/index.js"
+        },
+        "./wire": {
+            "types": "./dist/wire/index.d.ts",
+            "import": "./dist/wire/index.js"
         }
     },
     "files": [

--- a/src/wire/anthropic.ts
+++ b/src/wire/anthropic.ts
@@ -1,0 +1,224 @@
+import type { BiliMessage } from "./bili-message.js";
+import { hashId } from "./util.js";
+import { ClusterCounter, deriveMessageId } from "./message-id.js";
+
+export type AnthropicTextBlock = { type: "text"; text: string; cache_control?: unknown };
+export type AnthropicToolUse = {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+    cache_control?: unknown;
+};
+export type AnthropicToolResult = {
+    type: "tool_result";
+    tool_use_id: string;
+    content: string | AnthropicTextBlock[];
+    is_error?: boolean;
+    cache_control?: unknown;
+};
+export type AnthropicImage = { type: "image"; source: unknown };
+export type AnthropicThinking = { type: "thinking"; thinking: string; signature?: string };
+export type AnthropicBlock =
+    | AnthropicTextBlock
+    | AnthropicToolUse
+    | AnthropicToolResult
+    | AnthropicImage
+    | AnthropicThinking;
+
+export type AnthropicMessage = {
+    role: "user" | "assistant";
+    content: string | AnthropicBlock[];
+};
+
+export type AnthropicRequestBody = {
+    model?: string;
+    max_tokens?: number;
+    system?: string | AnthropicTextBlock[];
+    messages: AnthropicMessage[];
+    tools?: unknown[];
+    stream?: boolean;
+    temperature?: number;
+    [key: string]: unknown;
+};
+
+
+export function extractSystem(system: AnthropicRequestBody["system"]): string {
+    if (!system) return "";
+    if (typeof system === "string") return system;
+    return system.map((b) => b.text).join("\n\n");
+}
+
+export function buildSystem(text: string, original: AnthropicRequestBody["system"]): string | AnthropicTextBlock[] {
+    if (Array.isArray(original) && original.length > 0) {
+        const ccBlock = original.find((b) => b.cache_control);
+        return [{ type: "text", text, ...(ccBlock ? { cache_control: ccBlock.cache_control } : {}) }];
+    }
+    return text;
+}
+
+type Flat = { msgs: BiliMessage[]; cacheControls: Map<string, unknown> };
+
+export function anthropicToCore(body: AnthropicRequestBody): Flat {
+    const msgs: BiliMessage[] = [];
+    const cacheControls = new Map<string, unknown>();
+    const clusters = new ClusterCounter();
+    for (const m of body.messages) {
+        const blocks = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
+        for (const b of blocks) {
+            switch (b.type) {
+                case "text": {
+                    const base = deriveMessageId(m.role, "text", b.text);
+                    const id = clusters.next(base);
+                    msgs.push({ id, role: m.role, contentType: "text", text: b.text });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
+                    break;
+                }
+                case "tool_use": {
+                    const base = deriveMessageId("assistant", "tool-call", safeStringify(b.input), {
+                        toolCallId: b.id,
+                        toolName: b.name,
+                    });
+                    const id = clusters.next(base);
+                    msgs.push({
+                        id,
+                        role: "assistant",
+                        contentType: "tool-call",
+                        toolName: b.name,
+                        toolCallId: b.id,
+                        text: safeStringify(b.input),
+                    });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
+                    break;
+                }
+                case "tool_result": {
+                    const text = typeof b.content === "string" ? b.content : b.content.map((c) => c.text).join("\n");
+                    const base = deriveMessageId("tool", "tool-result", text, { toolCallId: b.tool_use_id });
+                    const id = clusters.next(base);
+                    msgs.push({
+                        id,
+                        role: "tool",
+                        contentType: "tool-result",
+                        toolCallId: b.tool_use_id,
+                        text,
+                        ...(b.is_error === true ? { toolIsError: true } : {}),
+                    });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
+                    break;
+                }
+                case "thinking": {
+                    const base = deriveMessageId("assistant", "reasoning", b.thinking);
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: "assistant",
+                        contentType: "reasoning",
+                        text: b.thinking,
+                        ...(b.signature ? { thinkingSignature: b.signature } : {}),
+                    });
+                    break;
+                }
+                case "image": {
+                    const base = deriveMessageId(m.role, "text", "[image]");
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: m.role,
+                        contentType: "text",
+                        text: "[image]",
+                        rawAnthropicBlock: b,
+                    });
+                    break;
+                }
+            }
+        }
+    }
+    return { msgs, cacheControls };
+}
+
+export function coreToAnthropic(messages: BiliMessage[], cacheControls?: Map<string, unknown>): AnthropicMessage[] {
+    const out: AnthropicMessage[] = [];
+    let current: { role: "user" | "assistant"; blocks: AnthropicBlock[] } | null = null;
+    const flush = () => {
+        if (current && current.blocks.length > 0) {
+            out.push({ role: current.role, content: current.blocks });
+        }
+        current = null;
+    };
+    const cc = (id: string): { cache_control?: unknown } => {
+        const v = cacheControls?.get(id);
+        return v ? { cache_control: v } : {};
+    };
+    for (const m of messages) {
+        const target: "user" | "assistant" =
+            m.role === "assistant" ? "assistant" : "user";
+        if (!current || current.role !== target) {
+            flush();
+            current = { role: target, blocks: [] };
+        }
+        switch (m.contentType) {
+            case "text": {
+                if (m.rawAnthropicBlock) {
+                    current.blocks.push(m.rawAnthropicBlock as AnthropicBlock);
+                    break;
+                }
+                current.blocks.push({ type: "text", text: m.text ?? "", ...cc(m.id) });
+                break;
+            }
+            case "tool-call":
+                current.blocks.push({
+                    type: "tool_use",
+                    id: m.toolCallId ?? `call_${m.id}`,
+                    name: m.toolName ?? "unknown",
+                    input: safeParse(m.text),
+                    ...cc(m.id),
+                });
+                break;
+            case "tool-result":
+                current.blocks.push({
+                    type: "tool_result",
+                    tool_use_id: m.toolCallId ?? "",
+                    content: m.text ?? "",
+                    ...(m.toolIsError ? { is_error: true } : {}),
+                    ...cc(m.id),
+                });
+                break;
+            case "reasoning":
+                current.blocks.push({
+                    type: "thinking",
+                    thinking: m.text ?? "",
+                    ...(m.thinkingSignature ? { signature: m.thinkingSignature } : {}),
+                });
+                break;
+        }
+    }
+    flush();
+    return out;
+}
+
+/** Extract the conversation dimension for Anthropic: a client-provided
+ *  session header if present, else a content fingerprint of the first user
+ *  message. The protocol+upstream+key dimensions are mixed in by the caller
+ *  (server.ts) via deriveSessionId() — this function contributes only the
+ *  conversation axis. */
+export function conversationSignalAnthropic(body: AnthropicRequestBody, headerValue?: string): string {
+    if (headerValue && headerValue.trim()) return headerValue.trim();
+    const firstUser = body.messages.find((m) => m.role === "user");
+    const seed = firstUser ? JSON.stringify(firstUser.content) : "default";
+    return hashId(seed);
+}
+
+function safeStringify(v: unknown): string {
+    try {
+        return JSON.stringify(v ?? {});
+    } catch {
+        return "{}";
+    }
+}
+
+function safeParse(s: string | undefined): unknown {
+    if (!s) return {};
+    try {
+        return JSON.parse(s);
+    } catch {
+        return {};
+    }
+}

--- a/src/wire/bili-message.ts
+++ b/src/wire/bili-message.ts
@@ -1,0 +1,73 @@
+/**
+ * Lossless message bridge between protocol-specific message formats and the
+ * kernel's CoreMessage.
+ *
+ * Problem: `anthropicToCore` / `openaiToCore` / `responsesToCore` flatten
+ * rich protocol blocks (images, thinking signatures, tool_result.is_error,
+ * developer-role messages, image_url) into plain `{ text }` placeholders.
+ * The reverse `coreToX` then can't reconstruct them — `is_error` is lost
+ * (upstream can't tell a tool error from a result), `thinking.signature` is
+ * lost (Anthropic rejects thinking blocks without a matching signature),
+ * images become "[image]" (the model never sees the picture).
+ *
+ * Solution: `BiliMessage` extends CoreMessage with optional sidecar fields.
+ * The kernel only reads `{ ...message }` (spread copy) and known fields, so
+ * the extra fields survive the compression pipeline unchanged and arrive back
+ * at `coreToX`, which prefers them over the flattened `text`. No `as any`
+ * needed — TypeScript array covariance lets `BiliMessage[]` satisfy a
+ * `CoreMessage[]` parameter.
+ */
+
+import type { CoreMessage } from "acp-kernel";
+
+/** A message that carries its original protocol block(s) verbatim, so the
+ *  reverse conversion can reconstruct losslessly. Every field is optional —
+ *  plain text messages (the common case) have none set. */
+export interface BiliMessage extends CoreMessage {
+    /** Anthropic: the original content block for an image or a structured
+     *  tool_result. Restored verbatim by coreToAnthropic. */
+    rawAnthropicBlock?: unknown;
+    /** OpenAI chat: the original content part for an image_url, or the
+     *  original message object for a developer-role message. */
+    rawOpenaiContent?: unknown;
+    /** Responses API: the original input item (for input_image, or a raw
+     *  function_call / function_call_output we pass through). */
+    rawResponsesItem?: unknown;
+    /** Anthropic thinking signature. Anthropic verifies thinking+signature
+     *  pairs; without it the request is rejected. Stored alongside the
+     *  reasoning text so coreToAnthropic can reattach it. */
+    thinkingSignature?: string;
+    /** OpenAI reasoning_content (chain-of-thought from DeepSeek-R1, GLM-4.6
+     *  thinking, Qwen-QwQ). These models require reasoning_content be echoed
+     *  back on subsequent requests or the API returns HTTP 400; stored so
+     *  coreToOpenai can reattach it. */
+    reasoningContent?: string;
+    /** Anthropic tool_result.is_error. Marks the tool result as an error so
+     *  the model knows the tool failed (not just returned an error string). */
+    toolIsError?: boolean;
+    /** OpenAI: original role was "developer" (reconstructed as "system" by
+     *  openaiToCore for the kernel; coreToOpenai restores "developer"). */
+    originalRole?: "system" | "developer";
+    /** The original media type for an image (image/png, image/jpeg, image/gif,
+     *  image/webp). Lets coreToOpenai/coreToResponses rebuild image_url /
+     *  input_image with the right data URL. */
+    imageMediaType?: string;
+    /** The base64 data of an image (without the data: prefix). Lets the
+     *  reverse conversion rebuild the full image payload. */
+    imageBase64?: string;
+}
+
+/** Narrow a BiliMessage[] to CoreMessage[] for the kernel. The sidecar fields
+ *  are transparently carried along — the kernel's `{ ...msg }` copies them. */
+export function toCoreMessages(msgs: BiliMessage[]): CoreMessage[] {
+    return msgs as CoreMessage[];
+}
+
+/** Re-decode a base64 data URL into media type + data. Returns undefined if
+ *  the input is not a recognized data URL. Used by openaiToCore/responsesToCore
+ *  to split image_url/input_image into the sidecar fields. */
+export function parseDataUrl(url: string): { mediaType: string; base64: string } | undefined {
+    const m = /^data:([^;,]+)(?:;base64)?,(.+)$/i.exec(url);
+    if (!m) return undefined;
+    return { mediaType: m[1]!, base64: m[2]! };
+}

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -1,0 +1,6 @@
+export * from "./anthropic.js";
+export * from "./openai.js";
+export * from "./responses.js";
+export * from "./bili-message.js";
+export * from "./message-id.js";
+export * from "./util.js";

--- a/src/wire/message-id.ts
+++ b/src/wire/message-id.ts
@@ -1,0 +1,58 @@
+import { hashId } from "./util.js";
+
+/**
+ * Derive a stable, content-based message id.
+ *
+ * PROBLEM: none of the three wire protocols (Anthropic Messages, OpenAI Chat
+ * Completions, OpenAI Responses) attach a stable id to request-side message
+ * items. Historically each converter used `raw-${idx}` — a *position* index,
+ * not an identity. As soon as a client deletes/reorders messages (other plugins
+ * summarizing away old turns, multi-agent setups, etc.) the index drifts:
+ * downstream ids shift, so
+ *   - assignRefs reuses stale `byRaw` entries, hiding new messages, and
+ *   - compression `effectiveMessageIds` start pointing at the *wrong* messages,
+ *     silently swallowing live content under an unrelated summary.
+ *
+ * FIX: derive the id from a SHA-256 of the message identity:
+ *   role + contentType + toolCallId + toolName + text
+ * Two messages with identical identity collide. To keep duplicates distinct
+ * (and avoid `covered` sets collapsing unrelated turns onto one id) we append a
+ * within-conversation *cluster index* `_N`: the Nth occurrence of the same
+ * identity, counting from 0 in arrival order.
+ *
+ * Trade-off vs a real client id:
+ *   - deleting a duplicated message only disturbs the cluster of that identity
+ *     (local damage), never the whole downstream (global damage like position).
+ *   - fully distinct messages are completely immune to reordering/deletion.
+ *
+ * `idx` is passed purely to break ties *within a single conversion pass*; it is
+ * not part of the identity, so two passes over the same content produce the
+ * same cluster numbering (deterministic).
+ */
+export function deriveMessageId(
+    role: string,
+    contentType: string,
+    text: string,
+    options: {
+        toolCallId?: string;
+        toolName?: string;
+    } = {},
+): string {
+    const seed = `${role}|${contentType}|${options.toolCallId ?? ""}|${options.toolName ?? ""}|${text}`;
+    return "h_" + hashId(seed);
+}
+
+/**
+ * Stateful cluster counter. Each converter instantiates one per conversion
+ * pass; it tracks how many times each base identity has been seen so that the
+ * Nth duplicate gets a `_${N}` suffix.
+ */
+export class ClusterCounter {
+    private counts = new Map<string, number>();
+
+    next(baseId: string): string {
+        const n = this.counts.get(baseId) ?? 0;
+        this.counts.set(baseId, n + 1);
+        return n === 0 ? baseId : `${baseId}_${n}`;
+    }
+}

--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -1,0 +1,223 @@
+import { hashId } from "./util.js";
+import { ClusterCounter, deriveMessageId } from "./message-id.js";
+import { parseDataUrl, type BiliMessage } from "./bili-message.js";
+
+export type OpenAIContentPart =
+    | { type: "text"; text: string }
+    | { type: "image_url"; image_url: { url: string } }
+    | { type: string; [k: string]: unknown };
+
+export type OpenAIToolCall = {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+};
+
+export type OpenAIMessage = {
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content?: string | null | OpenAIContentPart[];
+    reasoning_content?: string | null;
+    tool_calls?: OpenAIToolCall[];
+    tool_call_id?: string;
+    name?: string;
+};
+
+export type OpenAITool = {
+    type: "function";
+    function: { name: string; description?: string; parameters?: unknown };
+};
+
+export type OpenAIRequestBody = {
+    model?: string;
+    messages: OpenAIMessage[];
+    tools?: OpenAITool[];
+    stream?: boolean;
+    [key: string]: unknown;
+};
+
+type Flat = { msgs: BiliMessage[] };
+
+export function openaiToCore(body: OpenAIRequestBody): Flat {
+    const msgs: BiliMessage[] = [];
+    const clusters = new ClusterCounter();
+    for (const m of body.messages) {
+        switch (m.role) {
+            case "system":
+            case "developer": {
+                const base = deriveMessageId(m.role, "text", stringContent(m.content));
+                msgs.push({ id: clusters.next(base), role: "system", contentType: "text", text: stringContent(m.content), originalRole: m.role });
+                break;
+            }
+            case "user": {
+                const text = stringContent(m.content);
+                const img = firstImagePart(m.content);
+                const base = deriveMessageId("user", "text", text);
+                msgs.push({
+                    id: clusters.next(base),
+                    role: "user",
+                    contentType: "text",
+                    text,
+                    ...(img ? { rawOpenaiContent: img.part, imageMediaType: img.mediaType, imageBase64: img.base64 } : {}),
+                });
+                break;
+            }
+            case "assistant": {
+                const reasoning = typeof m.reasoning_content === "string" ? m.reasoning_content : "";
+                if (reasoning) {
+                    const base = deriveMessageId("assistant", "reasoning", reasoning);
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: "assistant",
+                        contentType: "reasoning",
+                        text: reasoning,
+                        reasoningContent: reasoning,
+                    });
+                }
+                const text = stringContent(m.content);
+                if (text) {
+                    const base = deriveMessageId("assistant", "text", text);
+                    msgs.push({ id: clusters.next(base), role: "assistant", contentType: "text", text });
+                }
+                if (Array.isArray(m.tool_calls)) {
+                    for (const tc of m.tool_calls) {
+                        const base = deriveMessageId("assistant", "tool-call", tc.function.arguments ?? "", {
+                            toolCallId: tc.id,
+                            toolName: tc.function.name,
+                        });
+                        msgs.push({
+                            id: clusters.next(base),
+                            role: "assistant",
+                            contentType: "tool-call",
+                            toolName: tc.function.name,
+                            toolCallId: tc.id,
+                            text: tc.function.arguments ?? "",
+                        });
+                    }
+                }
+                break;
+            }
+            case "tool": {
+                const base = deriveMessageId("tool", "tool-result", stringContent(m.content), {
+                    toolCallId: m.tool_call_id ?? "",
+                });
+                msgs.push({
+                    id: clusters.next(base),
+                    role: "tool",
+                    contentType: "tool-result",
+                    toolCallId: m.tool_call_id ?? "",
+                    text: stringContent(m.content),
+                });
+                break;
+            }
+        }
+    }
+    return { msgs };
+}
+
+export function coreToOpenai(messages: BiliMessage[]): OpenAIMessage[] {
+    const out: OpenAIMessage[] = [];
+    let pending: { text: string | null; toolCalls: OpenAIToolCall[]; reasoning: string | null } | null = null;
+    const flush = () => {
+        if (!pending) return;
+        const reasoning = pending.reasoning !== null && pending.reasoning.length > 0 ? pending.reasoning : undefined;
+        if (pending.toolCalls.length > 0) {
+            out.push({
+                role: "assistant",
+                content: pending.text ?? null,
+                tool_calls: pending.toolCalls,
+                ...(reasoning ? { reasoning_content: reasoning } : {}),
+            });
+        } else if (pending.text !== null) {
+            out.push({ role: "assistant", content: pending.text, ...(reasoning ? { reasoning_content: reasoning } : {}) });
+        } else if (reasoning) {
+            out.push({ role: "assistant", content: null, reasoning_content: reasoning });
+        }
+        pending = null;
+    };
+    for (const m of messages) {
+        if (m.role === "assistant") {
+            if (!pending) pending = { text: null, toolCalls: [], reasoning: null };
+            if (m.contentType === "reasoning") {
+                pending.reasoning = (pending.reasoning ?? "") + (m.reasoningContent ?? m.text ?? "");
+            } else if (m.contentType === "text") {
+                pending.text = (pending.text ?? "") + (m.text ?? "");
+            } else if (m.contentType === "tool-call") {
+                pending.toolCalls.push({
+                    id: m.toolCallId ?? `call_${m.id}`,
+                    type: "function",
+                    function: { name: m.toolName ?? "unknown", arguments: m.text ?? "" },
+                });
+            }
+        } else {
+            flush();
+            if (m.role === "system") {
+                out.push({ role: m.originalRole === "developer" ? "developer" : "system", content: m.text ?? "" });
+            } else if (m.role === "user") {
+                if (m.rawOpenaiContent || m.imageBase64) {
+                    const parts: OpenAIContentPart[] = [];
+                    if (m.text) parts.push({ type: "text", text: m.text });
+                    if (m.rawOpenaiContent) {
+                        parts.push(m.rawOpenaiContent as OpenAIContentPart);
+                    } else if (m.imageBase64 && m.imageMediaType) {
+                        parts.push({ type: "image_url", image_url: { url: `data:${m.imageMediaType};base64,${m.imageBase64}` } });
+                    }
+                    out.push({ role: "user", content: parts });
+                } else {
+                    out.push({ role: "user", content: m.text ?? "" });
+                }
+            } else if (m.role === "tool") {
+                out.push({ role: "tool", tool_call_id: m.toolCallId ?? "", content: m.text ?? "" });
+            }
+        }
+    }
+    flush();
+    return out;
+}
+
+export function injectOpenaiSystem(messages: OpenAIMessage[], parts: string[]): OpenAIMessage[] {
+    if (parts.length === 0) return messages;
+    const extra = parts.join("\n\n");
+    if (messages.length > 0 && (messages[0]?.role === "system" || messages[0]?.role === "developer")) {
+        const head = messages[0] as OpenAIMessage;
+        const base = stringContent(head.content);
+        const merged = base ? `${base}\n\n---\n\n${extra}` : extra;
+        return [{ ...head, content: merged }, ...messages.slice(1)];
+    }
+    return [{ role: "system", content: extra }, ...messages];
+}
+
+/** Extract the conversation dimension for OpenAI Chat: a client-provided
+ *  session header if present, else a content fingerprint of the first user
+ *  message. See conversationSignalAnthropic for the full rationale. */
+export function conversationSignalOpenai(body: OpenAIRequestBody, headerValue?: string): string {
+    if (headerValue && headerValue.trim()) return headerValue.trim();
+    const firstUser = body.messages.find((m) => m.role === "user");
+    const seed = firstUser ? stringContent(firstUser.content) : "default";
+    return hashId(seed);
+}
+
+function stringContent(content: OpenAIMessage["content"]): string {
+    if (content == null) return "";
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+        return content
+            .map((p) => (typeof p === "string" ? p : p.type === "text" ? (p as { text?: string }).text ?? "" : ""))
+            .join("\n");
+    }
+    return "";
+}
+
+function firstImagePart(content: OpenAIMessage["content"]): { part: OpenAIContentPart; mediaType: string; base64: string } | undefined {
+    if (!Array.isArray(content)) return undefined;
+    for (const p of content) {
+        if (p && typeof p === "object" && p.type === "image_url") {
+            const iu = (p as { image_url?: { url?: string } }).image_url;
+            const url = iu?.url;
+            if (typeof url === "string") {
+                const parsed = parseDataUrl(url);
+                if (parsed) return { part: p, mediaType: parsed.mediaType, base64: parsed.base64 };
+            }
+        }
+    }
+    return undefined;
+}

--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -1,0 +1,395 @@
+import type { CoreMessage } from "../types.js";
+import { ClusterCounter, deriveMessageId } from "./message-id.js";
+import type { ConversationIdentity } from "./util.js";
+import { hashId } from "./util.js";
+import { parseDataUrl, type BiliMessage } from "./bili-message.js";
+
+export type ResponseContentPart =
+    | { type: "input_text"; text: string; [key: string]: unknown }
+    | { type: "output_text"; text: string; [key: string]: unknown }
+    | { type: "input_image"; image_url: string; [key: string]: unknown }
+    | { type: string; [key: string]: unknown };
+
+export type ResponseInputMessage = {
+    type: "message";
+    role: "system" | "developer" | "user" | "assistant";
+    content: string | ResponseContentPart[];
+    [key: string]: unknown;
+};
+
+export type ResponseFunctionCall = {
+    type: "function_call";
+    id?: string;
+    call_id: string;
+    name: string;
+    arguments: string;
+    [key: string]: unknown;
+};
+
+export type ResponseFunctionCallOutput = {
+    type: "function_call_output";
+    call_id: string;
+    output: string;
+    [key: string]: unknown;
+};
+
+export type ResponseInputItem =
+    | ResponseInputMessage
+    | ResponseFunctionCall
+    | ResponseFunctionCallOutput
+    | { type: string; [key: string]: unknown };
+
+export type ResponsesRequestBody = {
+    model?: string;
+    input: string | ResponseInputItem[];
+    instructions?: string;
+    tools?: unknown[];
+    stream?: boolean;
+    session_id?: string;
+    previous_response_id?: string;
+    prompt_cache_key?: string;
+    metadata?: Record<string, unknown>;
+    [key: string]: unknown;
+};
+
+type ResponseLayoutSlot = {
+    original: ResponseInputItem;
+    coreId?: string;
+};
+
+export type ResponsesProjection = {
+    msgs: BiliMessage[];
+    systemParts: string[];
+    preamble: ResponseInputItem[];
+    customToolCallIds: Set<string>;
+    layout: ResponseLayoutSlot[];
+    stringInput?: { original: string; coreId: string };
+    /** Reasoning items dropped because ACP_REASONING_KEEP=none. 0 by default —
+     *  reasoning is normally routed through the compression pipeline so it is
+     *  hidden automatically once its turn is summarized. */
+    droppedReasoning: number;
+};
+
+/** Item types that are host DIRECTIVES (tool/definition listings), not
+ *  conversation history: preserved verbatim and re-prepended at input[0..].
+ *  `additional_tools` carries the Codex code_mode exec/wait tool definitions
+ *  and MUST stay at input[0]. `mcp_list_tools` is a stable per-session listing.
+ *
+ *  Only definitions belong here. Output/action items from a prior response
+ *  (reasoning, computer_call, function_call, mcp_call, ...) ARE conversation
+ *  history and are routed as tracked BiliMessages, so the compression pipeline
+ *  hides them once their turn is summarized — preserving them verbatim in the
+ *  preamble instead made them accumulate unbounded every turn and broke Codex's
+ *  prompt-cache prefix. */
+const OPAQUE_ITEM_TYPES = new Set([
+    "additional_tools",
+    "mcp_list_tools",
+]);
+
+function isOpaqueItem(item: ResponseInputItem): boolean {
+    return OPAQUE_ITEM_TYPES.has(item.type);
+}
+
+function shouldDropAllReasoning(): boolean {
+    return (process.env.ACP_REASONING_KEEP ?? "").trim().toLowerCase() === "none";
+}
+
+function partText(part: ResponseContentPart): string {
+    if (part.type === "input_text" || part.type === "output_text") {
+        return typeof part.text === "string" ? part.text : "";
+    }
+    return "";
+}
+
+function messageContent(content: string | ResponseContentPart[]): string {
+    return typeof content === "string" ? content : content.map(partText).join("\n");
+}
+
+export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection {
+    const msgs: BiliMessage[] = [];
+    const systemParts: string[] = [];
+    const preamble: ResponseInputItem[] = [];
+    const customToolCallIds = new Set<string>();
+    const layout: ResponseLayoutSlot[] = [];
+    let droppedReasoning = 0;
+    const clusters = new ClusterCounter();
+    let idx = 0;
+    if (typeof body.instructions === "string" && body.instructions.trim()) systemParts.push(body.instructions);
+    if (typeof body.input === "string") {
+        const id = clusters.next(deriveMessageId("user", "text", body.input));
+        msgs.push({ id, role: "user", contentType: "text", text: body.input });
+        return { msgs, systemParts, preamble, customToolCallIds, layout, droppedReasoning, stringInput: { original: body.input, coreId: id } };
+    }
+    for (const item of body.input) {
+        let coreId: string | undefined;
+        if (isOpaqueItem(item)) preamble.push(item);
+        switch (item.type) {
+            case "reasoning": {
+                if (shouldDropAllReasoning()) {
+                    droppedReasoning++;
+                    continue;
+                }
+                const rid =
+                    typeof (item as { id?: unknown }).id === "string"
+                        ? String((item as { id?: string }).id)
+                        : hashId(JSON.stringify(item));
+                coreId = clusters.next(deriveMessageId("assistant", "reasoning", rid));
+                msgs.push({
+                    id: coreId,
+                    role: "assistant",
+                    contentType: "reasoning",
+                    text: rid,
+                    rawResponsesItem: item,
+                });
+                break;
+            }
+            case "message": {
+                const message = item as ResponseInputMessage;
+                const text = messageContent(message.content);
+                if (message.role === "system" || message.role === "developer") {
+                    systemParts.push(text);
+                    idx++;
+                    continue;
+                } else if (message.role === "user" || (message.role === "assistant" && text)) {
+                    const role = message.role;
+                    coreId = clusters.next(deriveMessageId(role, "text", text));
+                    const imageUrl = Array.isArray(message.content)
+                        ? message.content.find((part) => part.type === "input_image" && typeof part.image_url === "string")?.image_url
+                        : undefined;
+                    const image = typeof imageUrl === "string" ? parseDataUrl(imageUrl) : undefined;
+                    msgs.push({
+                        id: coreId,
+                        role,
+                        contentType: "text",
+                        text,
+                        rawResponsesItem: item,
+                        ...(image ? { imageMediaType: image.mediaType, imageBase64: image.base64 } : {}),
+                    });
+                }
+                break;
+            }
+            case "function_call": {
+                const call = item as ResponseFunctionCall;
+                coreId = clusters.next(deriveMessageId("assistant", "tool-call", call.arguments ?? "", {
+                    toolCallId: call.call_id,
+                    toolName: call.name,
+                }));
+                msgs.push({
+                    id: coreId,
+                    role: "assistant",
+                    contentType: "tool-call",
+                    toolName: call.name,
+                    toolCallId: call.call_id,
+                    text: call.arguments ?? "",
+                    rawResponsesItem: item,
+                });
+                break;
+            }
+            case "function_call_output": {
+                const output = item as ResponseFunctionCallOutput;
+                const text = typeof output.output === "string" ? output.output : JSON.stringify(output.output);
+                coreId = clusters.next(deriveMessageId("tool", "tool-result", text, { toolCallId: output.call_id }));
+                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: output.call_id, text, rawResponsesItem: item });
+                break;
+            }
+            case "computer_call":
+            case "computer_call_output":
+            case "file_search_call":
+            case "web_search_call":
+            case "image_generation_call":
+            case "code_interpreter_call":
+            case "mcp_call": {
+                const rid =
+                    typeof (item as { id?: unknown }).id === "string"
+                        ? String((item as { id?: string }).id)
+                        : hashId(JSON.stringify(item));
+                coreId = clusters.next(deriveMessageId("assistant", "responses-call", rid));
+                msgs.push({ id: coreId, role: "assistant", contentType: "reasoning", text: rid, rawResponsesItem: item });
+                break;
+            }
+            case "custom_tool_call": {
+                const ctc = item as { call_id?: string; name?: string; input?: string; arguments?: string };
+                const callId = ctc.call_id ?? `call_${idx}`;
+                customToolCallIds.add(callId);
+                const argText = ctc.input ?? ctc.arguments ?? "";
+                coreId = clusters.next(deriveMessageId("assistant", "tool-call", argText, { toolCallId: callId, toolName: ctc.name ?? "custom" }));
+                msgs.push({ id: coreId, role: "assistant", contentType: "tool-call", toolName: ctc.name ?? "custom", toolCallId: callId, text: argText, rawResponsesItem: item });
+                break;
+            }
+            case "custom_tool_call_output": {
+                const ctco = item as { call_id?: string; output?: string };
+                const callId = ctco.call_id ?? `call_${idx}`;
+                customToolCallIds.add(callId);
+                const outText = typeof ctco.output === "string" ? ctco.output : JSON.stringify(ctco.output ?? "");
+                coreId = clusters.next(deriveMessageId("tool", "tool-result", outText, { toolCallId: callId }));
+                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: callId, text: outText, rawResponsesItem: item });
+                break;
+            }
+            default:
+                if (!isOpaqueItem(item)) preamble.push(item);
+                break;
+        }
+        layout.push({ original: item, coreId });
+        idx++;
+    }
+    return { msgs, systemParts, preamble, customToolCallIds, layout, droppedReasoning };
+}
+
+function patchTextParts(parts: ResponseContentPart[], text: string): ResponseContentPart[] {
+    const textIndexes = parts.flatMap((part, index) =>
+        part.type === "input_text" || part.type === "output_text" ? [index] : [],
+    );
+    if (textIndexes.length === 0) return [{ type: "input_text", text }, ...parts];
+    const first = textIndexes[0];
+    const remaining = new Set(textIndexes.slice(1));
+    return parts.map((part, index) => {
+        if (index === first) return { ...part, text };
+        if (remaining.has(index)) return { ...part, text: "" };
+        return part;
+    });
+}
+
+function patchOriginalItem(original: ResponseInputItem, source: CoreMessage, next: CoreMessage): ResponseInputItem {
+    if (
+        source.text === next.text &&
+        source.toolName === next.toolName &&
+        source.toolCallId === next.toolCallId &&
+        source.role === next.role &&
+        source.contentType === next.contentType
+    ) return original;
+    if (original.type === "message") {
+        const message = original as ResponseInputMessage;
+        const content = typeof message.content === "string" ? next.text ?? "" : patchTextParts(message.content, next.text ?? "");
+        return { ...message, content };
+    }
+    if (original.type === "function_call") {
+        return {
+            ...original,
+            name: next.toolName ?? String(original.name ?? "unknown"),
+            call_id: next.toolCallId ?? String(original.call_id ?? ""),
+            arguments: next.text ?? "",
+        };
+    }
+    if (original.type === "function_call_output") {
+        return { ...original, call_id: next.toolCallId ?? String(original.call_id ?? ""), output: next.text ?? "" };
+    }
+    return original;
+}
+
+export function patchResponsesInput(projection: ResponsesProjection, messages: CoreMessage[]): string | ResponseInputItem[] {
+    if (projection.stringInput) {
+        const original = projection.msgs.find((message) => message.id === projection.stringInput?.coreId);
+        const next = messages.find((message) => message.id === projection.stringInput?.coreId);
+        if (original && next && messages.length === 1 && next.role === "user" && next.contentType === "text") {
+            return next.text === original.text ? projection.stringInput.original : next.text ?? "";
+        }
+        return coreToResponses(messages, projection.customToolCallIds);
+    }
+    const sourceById = new Map(projection.msgs.map((message) => [message.id, message]));
+    const nextById = new Map(messages.map((message) => [message.id, message]));
+    const slotById = new Map<string, number>();
+    projection.layout.forEach((slot, index) => {
+        if (slot.coreId) slotById.set(slot.coreId, index);
+    });
+    const insertions = new Map<number, ResponseInputItem[]>();
+    for (let index = 0; index < messages.length; index++) {
+        const message = messages[index]!;
+        if (sourceById.has(message.id)) continue;
+        let target = projection.layout.length;
+        for (let nextIndex = index + 1; nextIndex < messages.length; nextIndex++) {
+            const slot = slotById.get(messages[nextIndex]!.id);
+            if (slot !== undefined) {
+                target = slot;
+                break;
+            }
+        }
+        const generated = coreToResponses([message], projection.customToolCallIds);
+        if (generated.length > 0) insertions.set(target, [...(insertions.get(target) ?? []), ...generated]);
+    }
+    const out: ResponseInputItem[] = [];
+    projection.layout.forEach((slot, index) => {
+        out.push(...(insertions.get(index) ?? []));
+        if (!slot.coreId) {
+            out.push(slot.original);
+            return;
+        }
+        const source = sourceById.get(slot.coreId);
+        const next = nextById.get(slot.coreId);
+        if (source && next) out.push(patchOriginalItem(slot.original, source, next));
+    });
+    out.push(...(insertions.get(projection.layout.length) ?? []));
+    return out;
+}
+
+export function coreToResponses(
+    messages: CoreMessage[],
+    customToolCallIds: Set<string> = new Set(),
+): ResponseInputItem[] {
+    const out: ResponseInputItem[] = [];
+    for (const message of messages) {
+        const biliMessage = message as BiliMessage;
+        const raw = biliMessage.rawResponsesItem as ResponseInputItem | undefined;
+        if (message.role === "system") {
+            out.push({ type: "message", role: "developer", content: message.text ?? "" });
+        } else if (message.role === "user") {
+            if (raw?.type === "message" && messageContent((raw as ResponseInputMessage).content) === (message.text ?? "")) out.push(raw);
+            else out.push({ type: "message", role: "user", content: message.text ?? "" });
+        } else if (message.role === "assistant") {
+            if (message.contentType === "text") {
+                out.push({ type: "message", role: "assistant", content: message.text ?? "" });
+            } else if (message.contentType === "tool-call") {
+                const callId = message.toolCallId ?? `call_${message.id}`;
+                if (customToolCallIds.has(callId)) {
+                    out.push({ type: "custom_tool_call", call_id: callId, name: message.toolName ?? "unknown", input: message.text ?? "", status: "completed" } as ResponseInputItem);
+                } else {
+                    out.push({ type: "function_call", call_id: callId, name: message.toolName ?? "unknown", arguments: message.text ?? "" });
+                }
+            } else if (message.contentType === "reasoning") {
+                if (raw) out.push(raw);
+            }
+        } else if (message.role === "tool") {
+            const callId = message.toolCallId ?? "";
+            if (customToolCallIds.has(callId)) {
+                out.push({ type: "custom_tool_call_output", call_id: callId, output: message.text ?? "" } as ResponseInputItem);
+            } else {
+                out.push({ type: "function_call_output", call_id: callId, output: message.text ?? "" });
+            }
+        }
+    }
+    return out;
+}
+
+export function injectResponsesDeveloperMessage(
+    input: string | ResponseInputItem[],
+    content: string,
+): ResponseInputItem[] {
+    const items: ResponseInputItem[] = typeof input === "string"
+        ? [{ type: "message", role: "user", content: input }]
+        : [...input];
+    let index = 0;
+    while (items[index]?.type === "additional_tools") index++;
+    items.splice(index, 0, { type: "message", role: "developer", content });
+    return items;
+}
+
+export function conversationIdentityResponses(
+    body: ResponsesRequestBody,
+    headerValue?: string,
+): ConversationIdentity {
+    if (headerValue?.trim()) return { value: headerValue.trim(), source: "header", clientProvided: true };
+    if (typeof body.session_id === "string" && body.session_id.trim()) {
+        return { value: body.session_id.trim(), source: "body-session", clientProvided: true };
+    }
+    const metadataSession = body.metadata?.session_id;
+    if (typeof metadataSession === "string" && metadataSession.trim()) {
+        return { value: metadataSession.trim(), source: "metadata-session", clientProvided: true };
+    }
+    if (typeof body.previous_response_id === "string" && body.previous_response_id.trim()) {
+        return { value: body.previous_response_id.trim(), source: "previous-response", clientProvided: false };
+    }
+    return { value: hashId(JSON.stringify(body.input ?? [])), source: "content-fingerprint", clientProvided: false };
+}
+
+export function conversationSignalResponses(body: ResponsesRequestBody, headerValue?: string): string {
+    return conversationIdentityResponses(body, headerValue).value;
+}

--- a/src/wire/util.ts
+++ b/src/wire/util.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+/** SHA-256-derived short id — kept verbatim from the proxy so message ids
+ *  stay byte-identical across the extraction (re-keying would orphan every
+ *  downstream map keyed on these ids). */
+export function hashId(s: string): string {
+    return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
+}
+
+/** How a conversation's identity was derived (kept verbatim from the proxy's
+ *  session-id.ts — only the TYPE moves; session-key derivation stays in the
+ *  proxy, which owns multi-tenant state). */
+export type ConversationIdentity = {
+    value: string;
+    source: "header" | "body-session" | "metadata-session" | "previous-response" | "content-fingerprint" | "generated";
+    clientProvided: boolean;
+};

--- a/tests/wire-bili-message-roundtrip.test.ts
+++ b/tests/wire-bili-message-roundtrip.test.ts
@@ -1,0 +1,399 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { anthropicToCore, coreToAnthropic } from "../src/wire/anthropic.js";
+import { openaiToCore, coreToOpenai } from "../src/wire/openai.js";
+import { responsesToCore, coreToResponses } from "../src/wire/responses.js";
+import type { AnthropicBlock, AnthropicRequestBody } from "../src/wire/anthropic.js";
+import type { OpenAIRequestBody } from "../src/wire/openai.js";
+import type { ResponsesRequestBody } from "../src/wire/responses.js";
+
+const IMG_DATA = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+const DATA_URL = `data:image/png;base64,${IMG_DATA}`;
+
+function block(rebuilt: { content: string | AnthropicBlock[] }, i: number): Record<string, unknown> {
+    return (rebuilt.content as unknown[])[i] as Record<string, unknown>;
+}
+
+// 1. Anthropic image block round-trips losslessly (source.base64 + media_type).
+test("anthropic: image block is restored verbatim via rawAnthropicBlock", () => {
+    const source = { type: "base64", media_type: "image/png", data: IMG_DATA };
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [{ role: "user", content: [{ type: "image", source }] }],
+    };
+    const { msgs } = anthropicToCore(body);
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0]?.contentType, "text");
+    assert.equal(msgs[0]?.text, "[image]");
+    assert.ok(msgs[0]?.rawAnthropicBlock, "sidecar rawAnthropicBlock stored");
+    const rebuilt = coreToAnthropic(msgs);
+    assert.equal(rebuilt.length, 1);
+    const img = block(rebuilt[0]!, 0);
+    assert.equal(img.type, "image", "image block reconstructed (not a text placeholder)");
+    assert.deepEqual(img.source, source, "source preserved verbatim (base64 + media_type)");
+});
+
+// 2. Anthropic thinking + signature round-trips (signature was previously dropped).
+test("anthropic: thinking signature is restored", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "thinking", thinking: "let me consider", signature: "sig_EqMAC" }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    assert.equal(msgs[0]?.contentType, "reasoning");
+    assert.equal(msgs[0]?.thinkingSignature, "sig_EqMAC", "thinkingSignature sidecar stored");
+    const rebuilt = coreToAnthropic(msgs);
+    const th = block(rebuilt[0]!, 0);
+    assert.equal(th.type, "thinking");
+    assert.equal(th.thinking, "let me consider");
+    assert.equal(th.signature, "sig_EqMAC", "signature reattached (Anthropic rejects thinking without it)");
+});
+
+// 3. Anthropic tool_result.is_error round-trips (was previously dropped).
+test("anthropic: tool_result.is_error is restored", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }] },
+            { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "boom", is_error: true }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    const result = msgs.find((m) => m.contentType === "tool-result");
+    assert.equal(result?.toolIsError, true, "toolIsError sidecar stored");
+    const rebuilt = coreToAnthropic(msgs);
+    const userMsg = rebuilt.find((m) => m.role === "user")!;
+    const tr = block(userMsg, 0);
+    assert.equal(tr.type, "tool_result");
+    assert.equal(tr.is_error, true, "is_error reconstructed");
+});
+
+// 3b. Sanity: a non-error tool_result does NOT gain is_error.
+test("anthropic: tool_result without is_error stays clean", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }] },
+            { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    const result = msgs.find((m) => m.contentType === "tool-result");
+    assert.equal(result?.toolIsError, undefined);
+    const rebuilt = coreToAnthropic(msgs);
+    const userMsg = rebuilt.find((m) => m.role === "user")!;
+    const tr = block(userMsg, 0);
+    assert.equal(tr.is_error, undefined, "no spurious is_error");
+});
+
+// 4. OpenAI developer role round-trips (was collapsed to system).
+test("openai: developer role is restored", () => {
+    const body: OpenAIRequestBody = { messages: [{ role: "developer", content: "you are a dev" }] };
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs[0]?.role, "system", "kernel sees system");
+    assert.equal(msgs[0]?.originalRole, "developer", "originalRole sidecar stored");
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt[0]?.role, "developer", "developer role reconstructed");
+    assert.equal(rebuilt[0]?.content, "you are a dev");
+});
+
+// 4b. Sanity: a plain system role is NOT promoted to developer.
+test("openai: system role stays system", () => {
+    const body: OpenAIRequestBody = { messages: [{ role: "system", content: "sys" }] };
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs[0]?.originalRole, "system");
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt[0]?.role, "system");
+});
+
+// 5. OpenAI image_url round-trips (image was previously dropped entirely).
+test("openai: user image_url content part is restored", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "what is this?" },
+                    { type: "image_url", image_url: { url: DATA_URL } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(msgs[0]?.text?.startsWith("what is this?"), "text preserved");
+    assert.equal(msgs[0]?.imageMediaType, "image/png");
+    assert.equal(msgs[0]?.imageBase64, IMG_DATA);
+    assert.ok(msgs[0]?.rawOpenaiContent, "rawOpenaiContent sidecar stored");
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    assert.equal(u.role, "user");
+    assert.ok(Array.isArray(u.content), "content rebuilt as array (text + image)");
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    const text = parts.find((p) => p.type === "text");
+    assert.ok(typeof text?.text === "string" && text.text.startsWith("what is this?"));
+    const img = parts.find((p) => p.type === "image_url");
+    assert.ok(img, "image_url part reconstructed");
+    assert.deepEqual((img as unknown as { image_url: { url: string } }).image_url.url, DATA_URL, "image data URL restored");
+});
+
+// 6. Responses API input_image round-trips (image was previously dropped).
+test("responses: user input_image is restored via rawResponsesItem", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            {
+                type: "message",
+                role: "user",
+                content: [
+                    { type: "input_text", text: "see this" },
+                    { type: "input_image", image_url: DATA_URL },
+                ],
+            },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    assert.ok(msgs[0]?.text?.startsWith("see this"), "text preserved");
+    assert.equal(msgs[0]?.imageMediaType, "image/png");
+    assert.equal(msgs[0]?.imageBase64, IMG_DATA);
+    assert.ok(msgs[0]?.rawResponsesItem, "rawResponsesItem sidecar stored");
+    const rebuilt = coreToResponses(msgs);
+    assert.equal(rebuilt.length, 1);
+    const m = rebuilt[0] as { type: string; content: unknown };
+    assert.equal(m.type, "message");
+    assert.ok(Array.isArray(m.content), "message content rebuilt as array");
+    const parts = m.content as unknown as { type: string; [k: string]: unknown }[];
+    const img = parts.find((p) => p.type === "input_image");
+    assert.ok(img, "input_image reconstructed");
+    assert.equal(img?.image_url, DATA_URL, "image url restored");
+});
+
+// 7. Responses reasoning is routed into the compression pipeline (NOT the
+// opaque preamble) so the kernel hides it once its turn is summarized. The raw
+// item — including encrypted_content — round-trips verbatim via
+// rawResponsesItem while the turn is still live.
+test("responses: reasoning enters msgs[] as a tracked reasoning message (not preamble)", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "thinking" }], encrypted_content: "ENC_BLOB" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.equal(preamble.length, 0, "reasoning is NOT in the opaque preamble");
+    const r = msgs.find((m) => m.contentType === "reasoning");
+    assert.ok(r, "reasoning entered msgs[] as contentType reasoning");
+    assert.ok(r?.rawResponsesItem, "raw reasoning item carried in rawResponsesItem");
+    const rebuilt = coreToResponses(msgs);
+    const out = rebuilt.find((i) => (i as { id?: string }).id === "rs_abc") as { type: string; encrypted_content?: string };
+    assert.ok(out, "reasoning item rebuilt");
+    assert.equal(out.type, "reasoning");
+    assert.equal(out.encrypted_content, "ENC_BLOB", "encrypted_content preserved verbatim");
+});
+
+// 8. additional_tools (and other opaque host directives) still go to the
+// preamble verbatim — only reasoning was promoted into compression.
+test("responses: additional_tools stays in the opaque preamble", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "additional_tools", tools: [{ name: "exec" }] },
+            { type: "reasoning", id: "rs_1" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.equal(preamble.length, 1, "only additional_tools is opaque");
+    assert.equal(preamble[0]?.type, "additional_tools");
+    assert.ok(msgs.find((m) => m.contentType === "reasoning"), "reasoning went to msgs[], not preamble");
+});
+
+// 9. ACP_REASONING_KEEP=none drops reasoning entirely (escape hatch).
+test("responses: ACP_REASONING_KEEP=none drops all reasoning", () => {
+    const prev = process.env.ACP_REASONING_KEEP;
+    process.env.ACP_REASONING_KEEP = "none";
+    try {
+        const body: ResponsesRequestBody = {
+            input: [
+                { type: "reasoning", id: "rs_abc", encrypted_content: "ENC" },
+                { type: "message", role: "user", content: "hi" },
+            ],
+        };
+        const { msgs, preamble, droppedReasoning } = responsesToCore(body);
+        assert.equal(preamble.length, 0);
+        assert.ok(!msgs.find((m) => m.contentType === "reasoning"), "no reasoning in msgs[]");
+        assert.equal(droppedReasoning, 1, "droppedReasoning counted");
+    } finally {
+        if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
+        else process.env.ACP_REASONING_KEEP = prev;
+    }
+});
+
+// 10. Reasoning VANISHES from the rebuilt input once its turn is covered by a
+// compression block — the central guarantee of the fix (issue #15). The kernel
+// drops covered message ids before coreToResponses runs; simulating that prune
+// here, the reasoning item must disappear while ordinary messages survive.
+test("responses: reasoning is dropped from output after its turn is compressed", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_abc", encrypted_content: "ENC" },
+            { type: "message", role: "user", content: "hi" },
+            { type: "message", role: "assistant", content: "hello" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const reasoningId = msgs.find((m) => m.contentType === "reasoning")!.id;
+    const pruned = msgs.filter((m) => m.id !== reasoningId);
+    const rebuilt = coreToResponses(pruned);
+    const gone = rebuilt.find((i) => (i as { type?: string }).type === "reasoning");
+    assert.equal(gone, undefined, "reasoning item disappears once its turn is compressed");
+    assert.equal(rebuilt.length, 2, "user + assistant messages survive");
+});
+
+// 11. Reasoning id is stable across turns — Codex re-sends the same reasoning
+// items every turn, so the same input item must yield the same BiliMessage id
+// or the kernel would accumulate phantom duplicates.
+test("responses: reasoning id is stable across turns (same item → same id)", () => {
+    const body = (): ResponsesRequestBody => ({
+        input: [
+            { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "t" }] },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    });
+    const a = responsesToCore(body()).msgs.find((m) => m.contentType === "reasoning")!.id;
+    const b = responsesToCore(body()).msgs.find((m) => m.contentType === "reasoning")!.id;
+    assert.equal(a, b, "same reasoning item yields the same message id across turns");
+});
+
+// 12. Multiple reasoning items in one turn each get distinct ids and survive
+// round-trip in order.
+test("responses: multiple reasoning items keep distinct ids and order", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_1", encrypted_content: "A" },
+            { type: "reasoning", id: "rs_2", encrypted_content: "B" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const rs = msgs.filter((m) => m.contentType === "reasoning");
+    assert.equal(rs.length, 2);
+    assert.notEqual(rs[0]!.id, rs[1]!.id, "distinct ids");
+    const rebuilt = coreToResponses(msgs);
+    const ids = rebuilt
+        .filter((i) => (i as { type?: string }).type === "reasoning")
+        .map((i) => (i as { id?: string }).id);
+    assert.deepEqual(ids, ["rs_1", "rs_2"], "order + ids preserved on rebuild");
+});
+
+// 13. Reasoning without encrypted_content (older API shape) still round-trips
+// via rawResponsesItem.
+test("responses: reasoning without encrypted_content round-trips", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_x", summary: [{ type: "summary_text", text: "t" }] },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const rebuilt = coreToResponses(msgs);
+    const out = rebuilt.find((i) => (i as { id?: string }).id === "rs_x") as
+        | { type: string; encrypted_content?: string }
+        | undefined;
+    assert.ok(out, "reasoning without encrypted_content still rebuilt");
+    assert.equal(out!.type, "reasoning");
+    assert.equal(out!.encrypted_content, undefined);
+});
+
+// 14. Prior-response ACTION items (computer_call, mcp_call, ...) are routed
+// through the compression pipeline (NOT the opaque preamble) so they don't
+// accumulate unbounded every turn and break the prompt-cache prefix. They
+// round-trip verbatim via rawResponsesItem while their turn is live.
+test("responses: call items (computer_call/mcp_call) enter msgs[] not preamble", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "additional_tools", tools: [] } as ResponseInputItem,
+            { type: "mcp_list_tools", server_label: "s" } as ResponseInputItem,
+            { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+            { type: "mcp_call", id: "mc_1", name: "search", arguments: "{}" } as ResponseInputItem,
+            { type: "message", role: "user", content: "go" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.deepEqual(
+        preamble.map((p) => p.type),
+        ["additional_tools", "mcp_list_tools"],
+        "only definitions stay in the preamble",
+    );
+    const calls = msgs.filter((m) => m.contentType === "reasoning" && m.rawResponsesItem);
+    assert.equal(calls.length, 2, "both call items routed into msgs[]");
+    const rebuilt = coreToResponses(msgs);
+    const types = rebuilt.map((i) => i.type);
+    assert.ok(types.includes("computer_call"), "computer_call round-trips verbatim");
+    assert.ok(types.includes("mcp_call"), "mcp_call round-trips verbatim");
+});
+
+// 15. Call items are hidden once their turn is compressed (same prune
+// semantics as reasoning).
+test("responses: call items drop from output after their turn is compressed", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const callMsg = msgs.find((m) => m.contentType === "reasoning" && (m.rawResponsesItem as { type?: string }).type === "computer_call");
+    assert.ok(callMsg, "computer_call entered msgs[]");
+    const pruned = msgs.filter((m) => m.id !== callMsg!.id);
+    const rebuilt = coreToResponses(pruned);
+    assert.equal(
+        rebuilt.find((i) => i.type === "computer_call"),
+        undefined,
+        "computer_call disappears once its turn is compressed",
+    );
+});
+
+// 16. A call item is given a distinct id namespace from reasoning, so the two
+// never collide even when present in the same turn.
+test("responses: call item and reasoning keep distinct ids in the same turn", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "shared", encrypted_content: "E" },
+            { type: "mcp_call", id: "shared", name: "n", arguments: "{}" } as ResponseInputItem,
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const ids = msgs.filter((m) => m.contentType === "reasoning").map((m) => m.id);
+    assert.equal(ids.length, 2);
+    assert.notEqual(ids[0], ids[1], "same raw id does not collide across kinds");
+});
+
+// 17. ACP_REASONING_KEEP=none drops chain-of-thought but MUST preserve call
+// items: call items reuse the "reasoning" contentType only as a compression
+// bucket, not because they are reasoning. Dropping a computer_call would
+// corrupt the Responses conversation replay.
+test("responses: ACP_REASONING_KEEP=none drops reasoning but keeps call items", () => {
+    const prev = process.env.ACP_REASONING_KEEP;
+    process.env.ACP_REASONING_KEEP = "none";
+    try {
+        const body: ResponsesRequestBody = {
+            input: [
+                { type: "reasoning", id: "rs_1", encrypted_content: "E" },
+                { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+                { type: "mcp_call", id: "mc_1", name: "n", arguments: "{}" } as ResponseInputItem,
+            ],
+        };
+        const { msgs } = responsesToCore(body);
+        const reasoning = msgs.filter((m) => (m.rawResponsesItem as { type?: string }).type === "reasoning");
+        const calls = msgs.filter((m) => (m.rawResponsesItem as { type?: string }).type !== "reasoning" && m.contentType === "reasoning");
+        assert.equal(reasoning.length, 0, "chain-of-thought is dropped under ACP_REASONING_KEEP=none");
+        assert.equal(calls.length, 2, "computer_call + mcp_call survive (replay-critical)");
+    } finally {
+        if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
+        else process.env.ACP_REASONING_KEEP = prev;
+    }
+});

--- a/tests/wire-proxy-message-id.test.ts
+++ b/tests/wire-proxy-message-id.test.ts
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { anthropicToCore } from "../src/wire/anthropic.js";
+import { openaiToCore } from "../src/wire/openai.js";
+import { responsesToCore } from "../src/wire/responses.js";
+import type { AnthropicMessage, AnthropicRequestBody } from "../src/wire/anthropic.js";
+import type { OpenAIRequestBody } from "../src/wire/openai.js";
+import type { ResponsesRequestBody } from "../src/wire/responses.js";
+
+// --- Anthropic ---
+
+function anthropicBody(...messages: AnthropicMessage[]): AnthropicRequestBody {
+    return { model: "claude", max_tokens: 100, messages };
+}
+
+test("fingerprint ids are stable: identical content across two conversions yields the same id", () => {
+    const body = anthropicBody(
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "do something" },
+    );
+    const a = anthropicToCore(body).msgs;
+    const b = anthropicToCore(body).msgs;
+    assert.equal(a.length, b.length);
+    for (let i = 0; i < a.length; i++) {
+        assert.equal(a[i].id, b[i].id, `id stable across conversions at index ${i}`);
+        assert.ok(a[i].id.startsWith("h_"), "fingerprint prefix");
+    }
+});
+
+test("fingerprint ids survive client reordering (reordering keeps ids bound to content, not position)", () => {
+    // A realistic case: another plugin summarized away a middle message, and
+    // the client reorders the rest. With raw-${idx} the ids would shift and
+    // downstream compression effectiveMessageIds would point at the wrong
+    // messages. With content fingerprints each message keeps its own id.
+    const bodyA = anthropicBody(
+        { role: "user", content: "alpha" },
+        { role: "assistant", content: "beta" },
+        { role: "user", content: "gamma" },
+        { role: "assistant", content: "delta" },
+        { role: "user", content: "epsilon" },
+    );
+    // Drop "beta" and "delta", reorder epsilon before gamma.
+    const bodyB = anthropicBody(
+        { role: "user", content: "alpha" },
+        { role: "user", content: "epsilon" },
+        { role: "user", content: "gamma" },
+    );
+    const idsA = new Map(anthropicToCore(bodyA).msgs.map((m) => [m.text, m.id]));
+    const msgsB = anthropicToCore(bodyB).msgs;
+    for (const m of msgsB) {
+        assert.equal(m.id, idsA.get(m.text), `id for "${m.text}" follows the content, not the position`);
+    }
+});
+
+test("duplicate messages get distinct cluster ids (not collapsed onto one id)", () => {
+    // Two identical "ok" turns must not share an id — otherwise a compression
+    // `covered` set keyed on that id would swallow BOTH (losing recent content).
+    const body = anthropicBody(
+        { role: "user", content: "ok" },
+        { role: "user", content: "do work" },
+        { role: "user", content: "ok" },
+    );
+    const msgs = anthropicToCore(body).msgs;
+    const ids = msgs.filter((m) => m.text === "ok").map((m) => m.id);
+    assert.equal(ids.length, 2, "both ok messages present");
+    assert.notEqual(ids[0], ids[1], "duplicates get distinct cluster suffixes");
+    // The first is the bare hash, the second is the hash with _1.
+    assert.ok(!/_\d+$/.test(ids[0]), "first occurrence has no cluster suffix");
+    assert.ok(/_1$/.test(ids[1]), "second occurrence gets _1 suffix");
+});
+
+// --- OpenAI Chat ---
+
+test("openaiToCore: fingerprint ids distinct from mNNNNN and stable", () => {
+    const body: OpenAIRequestBody = {
+        model: "gpt",
+        messages: [
+            { role: "user", content: "ping" },
+            { role: "assistant", content: "pong" },
+        ],
+    };
+    const ids = openaiToCore(body).msgs.map((m) => m.id);
+    for (const id of ids) {
+        assert.ok(id.startsWith("h_"), `id ${id} has h_ prefix`);
+        assert.ok(!/^m\d+$/.test(id), "does not collide with kernel mNNNNN");
+    }
+    // Stable across conversions.
+    const ids2 = openaiToCore(body).msgs.map((m) => m.id);
+    assert.deepEqual(ids, ids2, "stable across conversions");
+});
+
+// --- Responses ---
+
+test("responsesToCore: fingerprint ids stable + duplicates distinct", () => {
+    const body: ResponsesRequestBody = {
+        model: "gpt",
+        input: [
+            { type: "message", role: "user", content: "hello" },
+            { type: "message", role: "user", content: "hello" },
+            { type: "message", role: "assistant", content: "world" },
+        ],
+    };
+    const msgs = responsesToCore(body).msgs;
+    assert.equal(msgs.length, 3);
+    const helloIds = msgs.filter((m) => m.text === "hello").map((m) => m.id);
+    assert.notEqual(helloIds[0], helloIds[1], "duplicate hellos distinct");
+    assert.ok(helloIds[0].startsWith("h_"));
+    assert.ok(helloIds[1].endsWith("_1"));
+    // Stable.
+    const ids2 = responsesToCore(body).msgs.map((m) => m.id);
+    assert.deepEqual(msgs.map((m) => m.id), ids2);
+});
+
+test("responsesToCore: tool call + result ids bind to call_id, not position", () => {
+    // Same function name/args in two distinct calls must differ via call_id.
+    const body: ResponsesRequestBody = {
+        model: "gpt",
+        input: [
+            { type: "message", role: "user", content: "run it twice" },
+            { type: "function_call", name: "exec", call_id: "c1", arguments: "{}" },
+            { type: "function_call_output", call_id: "c1", output: "done1" },
+            { type: "function_call", name: "exec", call_id: "c2", arguments: "{}" },
+            { type: "function_call_output", call_id: "c2", output: "done2" },
+        ],
+    };
+    const msgs = responsesToCore(body).msgs;
+    const callIds = msgs.filter((m) => m.contentType === "tool-call").map((m) => m.id);
+    assert.equal(callIds.length, 2);
+    assert.notEqual(callIds[0], callIds[1], "two same-name same-args calls differ via call_id");
+    const resultIds = msgs.filter((m) => m.contentType === "tool-result").map((m) => m.id);
+    assert.notEqual(resultIds[0], resultIds[1], "two results differ via call_id");
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/wire/index.ts"],
     format: ["esm"],
     dts: false,
     clean: false,


### PR DESCRIPTION
Closes #74 (extraction milestone).

## What

~1000 lines of production-verified protocol codecs move from the proxy (billion-context) into `acp-kernel/wire` as a subpath export:

- **anthropic**: `anthropicToCore`/`coreToAnthropic`, cache_control breakpoint preservation, system rebuild
- **openai**: `openaiToCore`/`coreToOpenai`, system injection, conversation signal
- **responses** (codex): full round-trip + conversation identity derivation
- **bili-message**: lossless bridge preserving is_error / thinking signatures / images
- **message-id**: SHA-256 content-hash identity + duplicate cluster index (production cure for position-id drift)

Extraction is verbatim: `hashId` kept byte-identical so downstream ids do not re-key. The two small dependencies (`hashId`, `ConversationIdentity` type) moved into `wire/util.ts`; proxy-specific session-key derivation stays in the proxy.

## Packaging

- `exports['./wire']` subpath, tsup second entry, dts emitted
- Consumed as `import { coreToAnthropic } from 'acp-kernel/wire'`

## Verification

- kernel: 321/321 (296 existing + 25 ported codec tests: bili-message-roundtrip, proxy-message-id)
- clean-room install smoke: subpath import + anthropic double round-trip OK
- tsc clean

## Consumers (follow-ups, in order)

1. proxy reverse adoption (delete ~1000 local lines → import from kernel)
2. omp Plan B: context event becomes observer; `before_provider_request` mutates the final wire body via kernel/wire — kills the feedback-view defect class (omp #52) at the root