### PR TITLE
feat(wire): subagentNamespace — separate compression namespace for Codex subagent requests (#150 port)

### DIFF
--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -393,3 +393,27 @@ export function conversationIdentityResponses(
 export function conversationSignalResponses(body: ResponsesRequestBody, headerValue?: string): string {
     return conversationIdentityResponses(body, headerValue).value;
 }
+
+// Codex subagents (guardian approval reviewer, etc.) reuse the main
+// conversation's body.session_id, so identity alone collapses their requests
+// onto the main session's compression state — a compressed subagent request
+// loses the verbatim user authorization it must read back (#150). Subagent
+// requests carry their own `instructions` (the agent's role prompt), so the
+// FIRST instructions seen for an identity anchor the main namespace (it never
+// changes for the conversation, even if the main prompt drifts), and any other
+// instructions value maps to a separate `|sub:` namespace with its own empty
+// compression state. Subagent requests are self-contained replays, so the
+// fresh namespace is lossless. Unbounded growth is fine: one ~100-byte entry
+// per conversation identity.
+const instructionAnchors = new Map<string, string>();
+
+export function subagentNamespace(identityValue: string, instructions: unknown): string {
+    if (typeof instructions !== "string" || instructions.trim().length === 0) return identityValue;
+    const fp = hashId(instructions);
+    const anchor = instructionAnchors.get(identityValue);
+    if (anchor === undefined) {
+        instructionAnchors.set(identityValue, fp);
+        return identityValue;
+    }
+    return anchor === fp ? identityValue : `${identityValue}|sub:${fp}`;
+}

--- a/tests/wire-subagent-namespace.test.ts
+++ b/tests/wire-subagent-namespace.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { subagentNamespace } from "../src/wire/responses.js";
+
+test("subagentNamespace: first-seen instructions anchor the identity; identical instructions reuse it", () => {
+    const id = "ns-unit-a";
+    assert.equal(subagentNamespace(id, "You are Codex, the main agent."), id);
+    assert.equal(subagentNamespace(id, "You are Codex, the main agent."), id);
+});
+
+test("subagentNamespace: differing instructions map to a stable separate |sub: namespace", () => {
+    const id = "ns-unit-b";
+    assert.equal(subagentNamespace(id, "main prompt"), id);
+    const sub = subagentNamespace(id, "guardian prompt");
+    assert.match(sub, /^ns-unit-b\|sub:[0-9a-f]{16}$/);
+    assert.equal(subagentNamespace(id, "guardian prompt"), sub, "same subagent instructions reuse the sub namespace");
+    assert.notEqual(subagentNamespace(id, "reviewer prompt"), sub, "a different subagent gets its own namespace");
+    assert.equal(subagentNamespace(id, "main prompt"), id, "main conversation keeps the anchored namespace");
+});
+
+test("subagentNamespace: absent or empty instructions never anchor or split", () => {
+    const id = "ns-unit-c";
+    assert.equal(subagentNamespace(id, undefined), id);
+    assert.equal(subagentNamespace(id, "   "), id);
+    assert.equal(subagentNamespace(id, "real prompt"), id);
+});


### PR DESCRIPTION
Companion to billion-context #160 (adopt kernel/wire): master's #150 fix (5c64384) landed in the proxy's `src/responses.ts` — the file #160 deletes. Ported verbatim so the proxy can consume it from `acp-kernel/wire`.

## What

`subagentNamespace(identityValue, instructions)` in `src/wire/responses.ts`: Codex subagents (guardian approval reviewer, etc.) reuse the main conversation's `body.session_id`, so identity alone collapses their requests onto the main session's compression state — a compressed subagent request loses the verbatim user authorization it must read back. First-seen `instructions` anchor the main namespace; any other instructions value maps to a stable `|sub:<fp>` namespace (hashId fingerprint, byte-identical to the proxy).

## Verification

- kernel: 324/324 (321 existing + 3 ported unit tests)
- typecheck clean, build clean

## Follow-up

Release as v0.0.26, then billion-context #160 bumps to it and resolves its master merge conflict (src/responses.ts deleted vs #150 modified; server.ts both sides).