### PR TITLE
release v0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.25",
+            "version": "0.0.26",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -393,3 +393,27 @@ export function conversationIdentityResponses(
 export function conversationSignalResponses(body: ResponsesRequestBody, headerValue?: string): string {
     return conversationIdentityResponses(body, headerValue).value;
 }
+
+// Codex subagents (guardian approval reviewer, etc.) reuse the main
+// conversation's body.session_id, so identity alone collapses their requests
+// onto the main session's compression state — a compressed subagent request
+// loses the verbatim user authorization it must read back (#150). Subagent
+// requests carry their own `instructions` (the agent's role prompt), so the
+// FIRST instructions seen for an identity anchor the main namespace (it never
+// changes for the conversation, even if the main prompt drifts), and any other
+// instructions value maps to a separate `|sub:` namespace with its own empty
+// compression state. Subagent requests are self-contained replays, so the
+// fresh namespace is lossless. Unbounded growth is fine: one ~100-byte entry
+// per conversation identity.
+const instructionAnchors = new Map<string, string>();
+
+export function subagentNamespace(identityValue: string, instructions: unknown): string {
+    if (typeof instructions !== "string" || instructions.trim().length === 0) return identityValue;
+    const fp = hashId(instructions);
+    const anchor = instructionAnchors.get(identityValue);
+    if (anchor === undefined) {
+        instructionAnchors.set(identityValue, fp);
+        return identityValue;
+    }
+    return anchor === fp ? identityValue : `${identityValue}|sub:${fp}`;
+}

--- a/tests/wire-subagent-namespace.test.ts
+++ b/tests/wire-subagent-namespace.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { subagentNamespace } from "../src/wire/responses.js";
+
+test("subagentNamespace: first-seen instructions anchor the identity; identical instructions reuse it", () => {
+    const id = "ns-unit-a";
+    assert.equal(subagentNamespace(id, "You are Codex, the main agent."), id);
+    assert.equal(subagentNamespace(id, "You are Codex, the main agent."), id);
+});
+
+test("subagentNamespace: differing instructions map to a stable separate |sub: namespace", () => {
+    const id = "ns-unit-b";
+    assert.equal(subagentNamespace(id, "main prompt"), id);
+    const sub = subagentNamespace(id, "guardian prompt");
+    assert.match(sub, /^ns-unit-b\|sub:[0-9a-f]{16}$/);
+    assert.equal(subagentNamespace(id, "guardian prompt"), sub, "same subagent instructions reuse the sub namespace");
+    assert.notEqual(subagentNamespace(id, "reviewer prompt"), sub, "a different subagent gets its own namespace");
+    assert.equal(subagentNamespace(id, "main prompt"), id, "main conversation keeps the anchored namespace");
+});
+
+test("subagentNamespace: absent or empty instructions never anchor or split", () => {
+    const id = "ns-unit-c";
+    assert.equal(subagentNamespace(id, undefined), id);
+    assert.equal(subagentNamespace(id, "   "), id);
+    assert.equal(subagentNamespace(id, "real prompt"), id);
+});


### PR DESCRIPTION
Releases #77 (subagentNamespace, #150 port) as v0.0.26. Required by billion-context #160.

Includes a2e06fd (feat: subagentNamespace) + version bump. 324/324 tests, typecheck/build clean locally.

Merging this also merges #77's commits (it contains them); merge order does not matter — either merge #77 first then this, or just this one (closes #77).