### PR TITLE
feat: token snapshot — stable first-render token counts for <acp> tags (§11 of the token-calibration plan; from #51)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -988,6 +988,7 @@ function cloneState(state: CompressionState): CompressionState {
       byRaw: { ...state.messageRefs.byRaw },
       byRef: { ...state.messageRefs.byRef },
     },
+    tokenSnapshot: { ...(state.tokenSnapshot ?? {}) },
     nudge: { ...state.nudge, anchors: { ...state.nudge.anchors } },
     stats: { ...state.stats },
     nextBlockId: state.nextBlockId,

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -392,12 +392,14 @@ const recommendNode: PipelineNode = {
       io.messages,
       io.state,
       ctx.config,
+      ctx.countTokens,
     );
     const contextRanges = buildCompressibleRanges(
       io.messages,
       io.state,
       ctx.config,
       protectedRefs,
+      ctx.countTokens,
     );
     const nothingToCompress = contextRanges.compressible.length === 0;
     const recommendation: Recommendation = {

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -33,8 +33,10 @@ function refNum(ref: string): number {
   return Number.isNaN(n) ? -1 : n;
 }
 
-function estimateMessageTokens(message: CoreMessage): number {
-  return Math.ceil((message.text ?? "").length / 4);
+// Default token estimate (chars/4) used when the caller doesn't inject a
+// countTokens — preserves the historical behavior for backwards compat.
+function defaultTokens(text: string): number {
+  return Math.ceil(text.length / 4);
 }
 
 function isToolMessage(message: CoreMessage): boolean {
@@ -69,6 +71,7 @@ export function computeProtectedRefs(
   messages: CoreMessage[],
   state: CompressionState,
   config: Config,
+  countTokens: (text: string) => number = defaultTokens,
 ): Set<string> {
   const preserveN = config.preserveRecentMessages;
   const preserveTokens = config.preserveRecentTokens;
@@ -86,7 +89,7 @@ export function computeProtectedRefs(
     if (isNeverPreserveRecent(msg)) continue;
     const ref = state.messageRefs.byRaw[msg.id];
     if (!ref || ref === "BLOCKED") continue;
-    visible.push({ ref, tokens: estimateMessageTokens(msg) });
+    visible.push({ ref, tokens: countTokens(msg.text ?? "") });
   }
 
   // Rule 1: last N messages
@@ -146,6 +149,7 @@ export function buildCompressibleRanges(
   state: CompressionState,
   config: Config,
   protectedZoneRefs?: Set<string>,
+  countTokens: (text: string) => number = defaultTokens,
 ): ContextRanges {
   const compressibleMsgs: {
     ref: string;
@@ -176,7 +180,7 @@ export function buildCompressibleRanges(
       protectedMsgs.push({
         ref,
         refNum: rn,
-        tokens: estimateMessageTokens(msg),
+        tokens: countTokens(msg.text ?? ""),
         tools: msg.toolName ? [msg.toolName] : [],
       });
       continue;
@@ -189,7 +193,7 @@ export function buildCompressibleRanges(
     compressibleMsgs.push({
       ref,
       refNum: rn,
-      tokens: estimateMessageTokens(msg),
+      tokens: countTokens(msg.text ?? ""),
       isTool: isToolMessage(msg),
       isUser: msg.role === "user",
     });

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -50,6 +50,7 @@ function renderMessage(
   map: MessageRefMap,
   countTokens: (text: string) => number,
   strategy: RenderStrategy,
+  snapshot: Record<string, number> | null = null,
 ): CoreMessage {
   const ref = refForRaw(map, message.id);
   if (!ref || ref === BLOCKED_REF) return message;
@@ -69,7 +70,11 @@ function renderMessage(
   );
   const cleanText = (message.text || "").replace(ownTagRe, "");
 
-  const tokens = countTokens(cleanText);
+  // Snapshot mode: token count is fixed at first render (stable prefix cache).
+  // Live mode (snapshot = null): recompute every render — legacy behavior.
+  const tokens = snapshot
+    ? (snapshot[ref] ?? (snapshot[ref] = countTokens(cleanText)))
+    : countTokens(cleanText);
   const type = classifyType(message);
   const prefix = acpTag(ref, tokens, type) + "\n";
 
@@ -84,10 +89,34 @@ export function renderVisibleRefs(
     Math.ceil(text.length / 4),
   strategy: RenderStrategy = "all",
 ): CoreMessage[] {
+  // Legacy behavior: recompute tokens every render (snapshot = null).
   const map = state.messageRefs;
   return messages.map((message) =>
     renderMessage(message, map, countTokens, strategy),
   );
+}
+
+export interface RenderWithSnapshotResult {
+  messages: CoreMessage[];
+  tokenSnapshot: Record<string, number>;
+}
+
+/** Render with a stable token snapshot: token counts are written on first
+ *  render and reused forever (keyed by ref). The snapshot starts as a shallow
+ *  copy of the persisted state so old entries survive; new entries are added
+ *  during this render. */
+export function renderWithSnapshot(
+  messages: CoreMessage[],
+  state: CompressionState,
+  countTokens: (text: string) => number = (text) => Math.ceil(text.length / 4),
+  strategy: RenderStrategy,
+): RenderWithSnapshotResult {
+  const map = state.messageRefs;
+  const snapshot = { ...(state.tokenSnapshot ?? {}) };
+  const rendered = messages.map((message) =>
+    renderMessage(message, map, countTokens, strategy, snapshot),
+  );
+  return { messages: rendered, tokenSnapshot: snapshot };
 }
 
 /** Factory: build a render-refs node bound to a specific render strategy. */
@@ -95,10 +124,20 @@ export function createRenderRefsNode(strategy: RenderStrategy): PipelineNode {
   return {
     name: "render-refs",
     run(io: NodeIO, ctx: PipelineContext): NodeIO {
-      return {
-        ...io,
-        messages: renderVisibleRefs(io.messages, io.state, ctx.countTokens, strategy),
-      };
+      const { messages, tokenSnapshot } = renderWithSnapshot(
+        io.messages,
+        io.state,
+        ctx.countTokens,
+        strategy,
+      );
+      // Write the snapshot back only when it grew: steady-state (all hits)
+      // must not churn the state object and force an adapter save every turn.
+      const prev = io.state.tokenSnapshot;
+      const changed =
+        !prev || Object.keys(tokenSnapshot).length !== Object.keys(prev).length;
+      return changed
+        ? { ...io, messages, state: { ...io.state, tokenSnapshot } }
+        : { ...io, messages };
     },
   };
 }

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -109,7 +109,7 @@ export function renderWithSnapshot(
   messages: CoreMessage[],
   state: CompressionState,
   countTokens: (text: string) => number = (text) => Math.ceil(text.length / 4),
-  strategy: RenderStrategy,
+  strategy: RenderStrategy = "all",
 ): RenderWithSnapshotResult {
   const map = state.messageRefs;
   const snapshot = { ...(state.tokenSnapshot ?? {}) };

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,6 +4,7 @@ export function createInitialState(): CompressionState {
   return {
     blocks: [],
     messageRefs: { byRaw: {}, byRef: {} },
+    tokenSnapshot: {},
     nudge: {
       lastPerMessageNudgeTokens: 0,
       lastNudgeShownTokens: 0,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -26,6 +26,8 @@ export function syncBlocks(
       byRaw: { ...state.messageRefs.byRaw },
       byRef: { ...state.messageRefs.byRef },
     },
+    // Snapshot is keyed by ref with primitive values — shallow copy suffices.
+    tokenSnapshot: { ...(state.tokenSnapshot ?? {}) },
     nudge: { ...state.nudge, anchors: { ...state.nudge.anchors } },
     stats: { ...state.stats },
     nextBlockId: state.nextBlockId,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -34,6 +34,22 @@ export function syncBlocks(
     nextRunId: state.nextRunId,
   };
 
+  // Refs are additive (assignRefs never removes them from messageRefs), so
+  // prune the snapshot by currently-present message refs — otherwise it grows
+  // unboundedly as messages are compressed/deleted across a long session.
+  const liveRefs = new Set(
+    messages
+      .map((m) => result.messageRefs.byRaw[m.id])
+      .filter((r): r is string => typeof r === "string"),
+  );
+  if (Object.keys(result.tokenSnapshot).length !== liveRefs.size) {
+    const pruned: Record<string, number> = {};
+    for (const [ref, n] of Object.entries(result.tokenSnapshot)) {
+      if (liveRefs.has(ref)) pruned[ref] = n;
+    }
+    result.tokenSnapshot = pruned;
+  }
+
   const consumedBlockIds = new Set<string>();
   for (const block of result.blocks) {
     for (const consumedId of block.directBlockIds) {

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -23,12 +23,15 @@ export function estimateTokensFast(text: string): number {
 
 export type TokenCountFn = (text: string) => number;
 
+const BPE_SIZE_GUARD = 100_000;
+
 export function createBpeTokenizer(): TokenCountFn {
   try {
     const mod = require("@anthropic-ai/tokenizer");
     const bpeCount = mod.countTokens ?? mod.default?.countTokens;
     if (typeof bpeCount !== "function") return defaultCountTokens;
     return (text: string) => {
+      if (text.length > BPE_SIZE_GUARD) return defaultCountTokens(text);
       try {
         return bpeCount(text);
       } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,12 @@ export interface CompressionStats {
 export interface CompressionState {
   blocks: CompressionBlock[];
   messageRefs: MessageRefMap;
+  /** First-render token count per message ref (mNNNNN). Written once when a
+   *  message is first rendered, then read forever — stable across density
+   *  recalibration so rendered <acp tokens> tags do not churn and bust the
+   *  provider prefix cache. Keyed by ref (not raw id): refs survive restarts
+   *  and omp live-N raw-id replacement. */
+  tokenSnapshot: Record<string, number>;
   nudge: NudgeState;
   stats: CompressionStats;
   nextBlockId: number;

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -230,3 +230,40 @@ test("integration: tiny ranges are suppressed — fixes the 19-token compression
   assert.equal(result.nudge!.shouldInject, false, "turn 1: growth=0, no nudge");
   assert.ok(result.nudge!.reason.includes("growth"), `reason: ${result.nudge!.reason}`);
 });
+
+// ─── countTokens injection (Phase 1: T1 pending uses injected countTokens) ────
+
+test("buildCompressibleRanges: CJK-aware countTokens inflates Chinese pending vs chars/4", () => {
+  const zh = "这是一个中文测试消息用于验证token校准的效果。".repeat(20); // ~340 chars
+  const messages = [msg("a", zh), toolMsg("b", "bash"), msg("c", "tail", "tool")];
+  const state = assignAll(messages);
+
+  const chars4 = buildCompressibleRanges(messages, state, config());
+  const cjk = buildCompressibleRanges(messages, state, config(), undefined, (t) => t.length);
+
+  const pendingDefault = chars4.compressible.reduce((s, r) => s + r.tokens, 0);
+  const pendingCjk = cjk.compressible.reduce((s, r) => s + r.tokens, 0);
+  assert.ok(pendingCjk > pendingDefault, `cjk ${pendingCjk} should exceed chars/4 ${pendingDefault}`);
+  // ~340 chars: chars/4 ≈ 85, CJK-aware ≈ 340+ → multiple of ~3+
+  assert.ok(pendingCjk >= pendingDefault * 3, `expected >=3x inflation, got ${pendingCjk} vs ${pendingDefault}`);
+});
+
+test("buildCompressibleRanges: default countTokens preserves chars/4 legacy behavior", () => {
+  const messages = [msg("a", "x".repeat(40))];
+  const state = assignAll(messages);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  assert.equal(ranges.compressible[0]!.tokens, 10, "chars/4 of 40 chars = 10");
+});
+
+test("computeProtectedRefs: injected countTokens sizes the recent-token zone", () => {
+  const messages = [msg("a", "前"), msg("b", "x".repeat(400)), msg("c", "后", "assistant")];
+  const state = assignAll(messages);
+  // preserveRecentTokens = 100 with chars/4: last 400 chars msg b = 100 tokens → zone covers b, a unprotected
+  const chars4 = computeProtectedRefs(messages, state, config({ preserveRecentTokens: 100, preserveRecentMessages: 0 }));
+  assert.equal(chars4.has("m00001"), false, "chars/4: a (1 token) stays outside 100-token zone starting at b(100)");
+  assert.equal(chars4.has("m00002"), true, "chars/4: b fills the zone");
+  // same config but CJK-aware: b = 400 tokens → zone far exceeds, a (1 token) still outside, but b dominates
+  const cjk = computeProtectedRefs(messages, state, config({ preserveRecentTokens: 100, preserveRecentMessages: 0 }), (t) => t.length);
+  assert.equal(cjk.has("m00002"), true, "cjk: b is in recent zone");
+  assert.equal(cjk.has("m00003"), true, "cjk: c is in recent zone");
+});

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -256,14 +256,17 @@ test("buildCompressibleRanges: default countTokens preserves chars/4 legacy beha
 });
 
 test("computeProtectedRefs: injected countTokens sizes the recent-token zone", () => {
-  const messages = [msg("a", "前"), msg("b", "x".repeat(400)), msg("c", "后", "assistant")];
+  // Sizes chosen so the zone DIFFERS under chars/4 vs CJK-aware: chars/4 → all
+  // three fit in 100 tokens (zone {a,b,c}); CJK-aware (1 tok/char) → b alone
+  // blows past 100 (zone {b,c}). If countTokens were ignored, both calls would
+  // protect a and the cjk assertion below would fail.
+  const messages = [msg("a", "x".repeat(200)), msg("b", "x".repeat(200)), msg("c", "y")];
   const state = assignAll(messages);
-  // preserveRecentTokens = 100 with chars/4: last 400 chars msg b = 100 tokens → zone covers b, a unprotected
   const chars4 = computeProtectedRefs(messages, state, config({ preserveRecentTokens: 100, preserveRecentMessages: 0 }));
-  assert.equal(chars4.has("m00001"), false, "chars/4: a (1 token) stays outside 100-token zone starting at b(100)");
-  assert.equal(chars4.has("m00002"), true, "chars/4: b fills the zone");
-  // same config but CJK-aware: b = 400 tokens → zone far exceeds, a (1 token) still outside, but b dominates
+  assert.equal(chars4.has("m00001"), true, "chars/4: a (50 tok) fits within 100-token zone");
+  assert.equal(chars4.has("m00003"), true, "chars/4: c is most recent, in zone");
   const cjk = computeProtectedRefs(messages, state, config({ preserveRecentTokens: 100, preserveRecentMessages: 0 }), (t) => t.length);
-  assert.equal(cjk.has("m00002"), true, "cjk: b is in recent zone");
-  assert.equal(cjk.has("m00003"), true, "cjk: c is in recent zone");
+  assert.equal(cjk.has("m00001"), false, "cjk: a excluded (b alone exceeds 100-token budget)");
+  assert.equal(cjk.has("m00002"), true, "cjk: b in zone");
+  assert.equal(cjk.has("m00003"), true, "cjk: c most recent, in zone");
 });

--- a/tests/token-snapshot.test.ts
+++ b/tests/token-snapshot.test.ts
@@ -1,0 +1,205 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs } from "../src/refs.js";
+import { syncBlocks } from "../src/sync.js";
+import {
+  renderWithSnapshot,
+  renderVisibleRefs,
+  renderRefsNode,
+} from "../src/render-refs.js";
+import { runPipeline, makeIO } from "../src/pipeline.js";
+import { defaultConfig } from "../src/config.js";
+import type { CompressionState, CoreMessage } from "../src/types.js";
+
+function msg(id: string, text: string): CoreMessage {
+  return { id, role: "user", contentType: "text", text };
+}
+
+function stateWithRefs(messages: CoreMessage[]): CompressionState {
+  const state = createInitialState();
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+// Density recalibration must not churn rendered <acp tokens> tags: the whole
+// point of tokenSnapshot (issue #96, 方案 A). First render writes, later
+// renders reuse the recorded count even when countTokens changes.
+test("renderWithSnapshot: token count is stable across countTokens changes", () => {
+  const messages = [msg("a", "你好世界这是一段中文消息"), msg("b", "hello world")];
+  const state = stateWithRefs(messages);
+
+  const slow = (t: string) => Math.ceil(t.length / 2); // CJK-ish density 2
+  const fast = (t: string) => Math.ceil(t.length / 4); // legacy density 1
+
+  const r1 = renderWithSnapshot(messages, state, slow, "all");
+  const snapshot = r1.tokenSnapshot;
+  assert.ok(Object.keys(snapshot).length >= 2, "first render records entries");
+
+  // Second render with a different countTokens: same tokens from snapshot.
+  const r2 = renderWithSnapshot(messages, { ...state, tokenSnapshot: snapshot }, fast, "all");
+  assert.deepEqual(r2.tokenSnapshot, snapshot, "snapshot unchanged on hit");
+  const tokens1 = [...r1.messages.map((m) => m.text ?? "")].map((t) =>
+    Number(/\stokens="(\d+)"/.exec(t)?.[1]),
+  );
+  const tokens2 = [...r2.messages.map((m) => m.text ?? "")].map((t) =>
+    Number(/\stokens="(\d+)"/.exec(t)?.[1]),
+  );
+  assert.deepEqual(tokens2, tokens1, "rendered tag token counts identical");
+
+  // Sanity: the recorded count came from the FIRST renderer, not the second.
+  const fresh = renderWithSnapshot(messages, { ...state, tokenSnapshot: {} }, fast, "all");
+  assert.notDeepEqual(
+    fresh.messages.map((m) => /\stokens="(\d+)"/.exec(m.text ?? "")?.[1]),
+    tokens1.map(String),
+    "a cold snapshot would have used the second renderer's smaller counts",
+  );
+});
+
+// Legacy entry point must keep recomputing (snapshot = null): unchanged
+// behavior for existing callers that do not opt into snapshotting.
+test("renderVisibleRefs keeps live recompute (no snapshot)", () => {
+  const messages = [msg("a", "中文消息中文消息"), msg("b", "hello")];
+  const state = stateWithRefs(messages);
+  const slow = (t: string) => Math.ceil(t.length / 2);
+  const fast = (t: string) => Math.ceil(t.length / 4);
+
+  const a = renderVisibleRefs(messages, state, slow, "all");
+  const b = renderVisibleRefs(messages, state, fast, "all");
+  const ta = a.map((m) => /\stokens="(\d+)"/.exec(m.text ?? "")?.[1]);
+  const tb = b.map((m) => /\stokens="(\d+)"/.exec(m.text ?? "")?.[1]);
+  assert.notDeepEqual(ta, tb, "live mode reflects the current countTokens");
+});
+
+// G1 regression: syncBlocks rebuilds state and must preserve tokenSnapshot,
+// otherwise render-refs (which runs AFTER sync-blocks) sees an empty snapshot
+// every turn and the whole scheme collapses.
+test("syncBlocks preserves tokenSnapshot", () => {
+  const messages = [msg("a", "hello world this is a longer message for tokens")];
+  const state = stateWithRefs(messages);
+  const { messages: rendered, tokenSnapshot } = renderWithSnapshot(
+    messages,
+    state,
+    (t) => Math.ceil(t.length / 2),
+    "all",
+  );
+  const withSnapshot = { ...state, tokenSnapshot };
+
+  const synced = syncBlocks(rendered, withSnapshot);
+  assert.deepEqual(
+    synced.state.tokenSnapshot,
+    tokenSnapshot,
+    "syncBlocks must carry the snapshot through",
+  );
+  // And the input state must not be aliased (deep-clone contract).
+  assert.notEqual(synced.state.tokenSnapshot, tokenSnapshot);
+});
+
+// G2 regression: cloneState runs inside applyCompression — a compression must
+// not drop the snapshot.
+test("compression preserves tokenSnapshot", () => {
+  const messages = [msg("a", "first message content here"), msg("b", "second message content")];
+  const state = stateWithRefs(messages);
+  const { messages: rendered, tokenSnapshot } = renderWithSnapshot(
+    messages,
+    state,
+    (t) => Math.ceil(t.length / 2),
+    "all",
+  );
+  const withSnapshot = { ...state, tokenSnapshot };
+
+  const core = createCore();
+  const result = core.applyCompression({
+    messages: rendered,
+    state: withSnapshot,
+    config: defaultConfig(),
+    ranges: [{ startRef: "a", endRef: "a", summary: "compressed" }],
+    countTokens: (t) => Math.ceil(t.length / 2),
+  });
+  assert.deepEqual(
+    result.state.tokenSnapshot,
+    tokenSnapshot,
+    "applyCompression clone must carry the snapshot through",
+  );
+});
+
+// Full pipeline (assign-refs → sync-blocks → … → render-refs): after several
+// processTurn runs the snapshot persists and the rendered tags stay stable
+// even as countTokens drifts (density calibration).
+test("processTurn: snapshot persists across turns and stabilizes tags", () => {
+  const core = createCore();
+  let state = createInitialState();
+  let messages = [msg("a", "第一轮消息内容比较长一些"), msg("b", "第二轮 hello world")];
+
+  let firstTagTokens: (string | undefined)[];
+  for (let turn = 0; turn < 4; turn++) {
+    const ctx = {
+      config: defaultConfig(),
+      countTokens: turn % 2 === 0 ? (t: string) => Math.ceil(t.length / 2) : (t: string) => Math.ceil(t.length / 4),
+    };
+    const io = makeIO(messages, state);
+    state = io.state;
+    const result = runPipeline(core.defaultNodes(), io, ctx);
+    state = result.state;
+    messages = result.messages;
+
+    const tags = messages.map((m) => /\stokens="(\d+)"/.exec(m.text ?? "")?.[1]);
+    if (turn === 0) {
+      firstTagTokens = tags;
+      assert.ok(
+        tags.every((t) => t !== undefined),
+        "all messages tagged on first render",
+      );
+    } else {
+      assert.deepEqual(
+        tags,
+        firstTagTokens!,
+        `turn ${turn}: rendered tags stable despite countTokens flip`,
+      );
+    }
+  }
+  assert.ok(
+    Object.keys(state.tokenSnapshot).length >= 2,
+    "snapshot accumulated across turns",
+  );
+});
+
+// F1 compat: a state without tokenSnapshot (old .acp.json) must not crash —
+// renderWithSnapshot treats it as an empty snapshot and the pipeline fills it.
+test("old state without tokenSnapshot is tolerated", () => {
+  const messages = [msg("a", "hello world legacy state")];
+  const legacy = stateWithRefs(messages);
+  delete (legacy as Partial<CompressionState>).tokenSnapshot;
+
+  const { messages: rendered, tokenSnapshot } = renderWithSnapshot(
+    messages,
+    legacy,
+    (t) => Math.ceil(t.length / 2),
+    "all",
+  );
+  assert.equal(Object.keys(tokenSnapshot).length, messages.length);
+  assert.ok(rendered[0].text?.includes('tokens="'));
+});
+
+// H3: steady-state (all snapshot hits) must not replace the state object —
+// the node returns the same state reference so the adapter avoids a save.
+test("renderRefsNode: steady-state hit does not churn the state object", () => {
+  const messages = [msg("a", "hello world"), msg("b", "second message")];
+  const state = stateWithRefs(messages);
+  const { messages: rendered, tokenSnapshot } = renderWithSnapshot(
+    messages,
+    state,
+    (t) => Math.ceil(t.length / 2),
+    "all",
+  );
+  const filled = { ...state, tokenSnapshot };
+
+  const io = makeIO(rendered, filled);
+  const ctx = { config: defaultConfig(), countTokens: (t: string) => t.length };
+  const out = renderRefsNode.run(io, ctx);
+  assert.equal(out.state, filled, "all-hit render must reuse the same state object");
+});

--- a/tests/token-snapshot.test.ts
+++ b/tests/token-snapshot.test.ts
@@ -203,3 +203,17 @@ test("renderRefsNode: steady-state hit does not churn the state object", () => {
   const out = renderRefsNode.run(io, ctx);
   assert.equal(out.state, filled, "all-hit render must reuse the same state object");
 });
+
+test("syncBlocks prunes tokenSnapshot entries for absent messages", () => {
+  const messages = [msg("a", "first message here"), msg("b", "second message here")];
+  const state = stateWithRefs(messages);
+  const { tokenSnapshot } = renderWithSnapshot(
+    messages,
+    state,
+    (t) => Math.ceil(t.length / 2),
+    "all",
+  );
+  const synced = syncBlocks([msg("b", "second message here")], { ...state, tokenSnapshot });
+  assert.equal("m00001" in synced.state.tokenSnapshot, false, "absent 'a' entry must be pruned");
+  assert.equal("m00002" in synced.state.tokenSnapshot, true, "present 'b' entry must be retained");
+});


### PR DESCRIPTION
Rebases the surviving delta of #51 (Tyan66666) onto current master. Phase 1 (countTokens injection into T1 pending) landed on master earlier via ebda6da and auto-resolved away in this merge — the remaining delta is **§11 tokenSnapshot**:

- `CompressionState.tokenSnapshot: Record<string, number>` — token count per message ref, written once at first render, read forever
- `renderWithSnapshot()` — snapshot-mode render; live mode (snapshot=null) keeps legacy recompute behavior
- Snapshot written back only when it grew (steady-state does not churn state / force adapter saves)
- Pruned to live refs in syncBlocks — no unbounded growth across long sessions
- review feedback from #51 already applied by the author (BPE size guard, snapshot pruning, test hardening — aee9ee3)

Conflict resolution: master later gained the CJK-aware `estimateTextTokens` in recommend.ts; kept master's name/body, adopted #51's injection points around it.

Verification: 332/332 tests (319 master + snapshot suite), typecheck clean, build green.

Credits: @Tyan66666 did the design (docs/token-calibration-plan.md §11, four review loops) and implementation; this rebase only resolves the stale base.

Companion: pi side (#97 density calibration) consumes this snapshot — without it, per-model density recalibration would churn every `<acp tokens=N>` number and bust the provider prefix cache.