### PR TITLE
refactor(wire): make subagent-namespace anchor store injectable

### DIFF
--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -403,17 +403,45 @@ export function conversationSignalResponses(body: ResponsesRequestBody, headerVa
 // changes for the conversation, even if the main prompt drifts), and any other
 // instructions value maps to a separate `|sub:` namespace with its own empty
 // compression state. Subagent requests are self-contained replays, so the
-// fresh namespace is lossless. Unbounded growth is fine: one ~100-byte entry
-// per conversation identity.
-const instructionAnchors = new Map<string, string>();
+// fresh namespace is lossless.
+export interface SubagentNamespaces {
+    /** Resolve the compression-state namespace for a request: the identity
+     *  itself for the anchored (main) instructions, `identity|sub:<fp>` for
+     *  any other instructions value. First-seen instructions anchor. */
+    namespaceFor(identityValue: string, instructions: unknown): string;
+}
+
+/** Host-owned subagent-namespace store.
+ *
+ * The anchor map is per-conversation mutable state, so it belongs to the
+ * host — NOT to a library module global. Create one instance and keep it for
+ * the process lifetime (or persist it alongside your session store if you
+ * need namespaces to survive restarts: a fresh instance re-anchors on the
+ * first request it sees, which after a restart may be a subagent request,
+ * orphaning the main conversation's stored compression state). */
+export function createSubagentNamespaces(): SubagentNamespaces {
+    const anchors = new Map<string, string>();
+    return {
+        namespaceFor(identityValue: string, instructions: unknown): string {
+            if (typeof instructions !== "string" || instructions.trim().length === 0) return identityValue;
+            const fp = hashId(instructions);
+            const anchor = anchors.get(identityValue);
+            if (anchor === undefined) {
+                anchors.set(identityValue, fp);
+                return identityValue;
+            }
+            return anchor === fp ? identityValue : `${identityValue}|sub:${fp}`;
+        },
+    };
+}
+
+// Convenience singleton for single-process proxies that don't manage
+// per-session state themselves. Hosts needing isolation between
+// conversations, deterministic namespaces across restarts, or a bound on
+// anchor memory should create their own instance via
+// createSubagentNamespaces() and own its lifecycle.
+const defaultNamespaces = createSubagentNamespaces();
 
 export function subagentNamespace(identityValue: string, instructions: unknown): string {
-    if (typeof instructions !== "string" || instructions.trim().length === 0) return identityValue;
-    const fp = hashId(instructions);
-    const anchor = instructionAnchors.get(identityValue);
-    if (anchor === undefined) {
-        instructionAnchors.set(identityValue, fp);
-        return identityValue;
-    }
-    return anchor === fp ? identityValue : `${identityValue}|sub:${fp}`;
+    return defaultNamespaces.namespaceFor(identityValue, instructions);
 }

--- a/tests/wire-subagent-namespace.test.ts
+++ b/tests/wire-subagent-namespace.test.ts
@@ -24,3 +24,28 @@ test("subagentNamespace: absent or empty instructions never anchor or split", ()
     assert.equal(subagentNamespace(id, "   "), id);
     assert.equal(subagentNamespace(id, "real prompt"), id);
 });
+
+import { createSubagentNamespaces } from "../src/wire/responses.js";
+
+test("createSubagentNamespaces: instances own their anchor state independently", () => {
+    const a = createSubagentNamespaces();
+    const b = createSubagentNamespaces();
+    assert.equal(a.namespaceFor("ns-iso", "main prompt"), "ns-iso");
+    assert.equal(b.namespaceFor("ns-iso", "other prompt"), "ns-iso", "b anchors independently — no shared module state");
+    const subA = a.namespaceFor("ns-iso", "guardian prompt");
+    assert.match(subA, /^ns-iso\|sub:[0-9a-f]{16}$/);
+    assert.equal(a.namespaceFor("ns-iso", "main prompt"), "ns-iso", "a keeps its own anchor");
+    assert.equal(a.namespaceFor("ns-iso", "guardian prompt"), subA, "stable within the instance");
+});
+
+test("createSubagentNamespaces: fresh instance re-anchors (restart semantics documented)", () => {
+    const first = createSubagentNamespaces();
+    assert.equal(first.namespaceFor("ns-restart", "main prompt"), "ns-restart");
+    // Simulated restart: new instance, subagent request arrives FIRST — it
+    // becomes the anchor, so the main prompt lands in a |sub: namespace.
+    // This is the documented first-seen tradeoff; hosts needing
+    // restart-stable namespaces must persist their own instance state.
+    const second = createSubagentNamespaces();
+    assert.equal(second.namespaceFor("ns-restart", "guardian prompt"), "ns-restart");
+    assert.match(second.namespaceFor("ns-restart", "main prompt"), /^ns-restart\|sub:[0-9a-f]{16}$/);
+});


### PR DESCRIPTION
## Problem

Found in the 48h review of #77's `subagentNamespace` (`src/wire/responses.ts`):

```ts
const instructionAnchors = new Map<string, string>(); // module-level mutable global
```

1. **Implicit global in a pure-core library** — the kernel's stated design is "no hidden host state", yet this Map accumulates for the module lifetime with no isolation between conversations, sessions, or tests, and no way for the host to reset or bound it. The old comment asserted "Unbounded growth is fine" on the host's behalf.
2. **Undocumented restart hazard** — first-seen anchoring is process-order-dependent. If the first request after a restart/multi-process handoff is a *subagent* request, it becomes the anchor and the main conversation is pushed into a `|sub:` namespace — **orphaning its stored compression state**. Inherent to first-seen, but previously invisible and unfixable from the host side.

## Fix

- **`createSubagentNamespaces()`** factory → `{ namespaceFor(identityValue, instructions) }`, a host-owned anchor store. Hosts that need isolation, bounding, or restart-stable namespaces create (and may persist) their own instance.
- `subagentNamespace` is now a thin wrapper over a module-level convenience singleton — **zero behavior change** for existing callers (billion-context proxy `server.ts`), just documented as the single-process convenience path.
- Restart semantics documented on the factory (fresh instance re-anchors on whatever it sees first).

## Tests

- instance isolation: two stores anchor independently, no shared module state
- restart simulation: fresh instance re-anchors on a subagent-first sequence (documents the tradeoff)

```
ℹ tests 337   ℹ pass 337   ℹ fail 0   (tsc + build clean)
```

**Follow-up (proxy side):** adopt `createSubagentNamespaces()` per session store in billion-context when convenient — this PR is intentionally non-breaking.