### PR TITLE
docs: document snapshot-frozen token tags; drop stale test counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ acp-kernel/
 │   ├── keep-markers.ts       # KEEP/REF marker preservation in summaries
 │   ├── types.ts              # All shared types
 │   └── defaults.ts           # defaultConfig, defaultNodes
-├── tests/                    # 295 tests
+├── tests/                    # unit + regression tests (node:test)
 ├── tsup.config.ts
 ├── tsconfig.json
 └── package.json

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ processTurn({ messages, state, config, tokenCount, renderTags: "none" });
 `renderTags` is optional and defaults to `"all"`, so existing call sites keep
 working unchanged.
 
+**Token counts in rendered tags are snapshots.** Each message's
+`<acp tokens="N">` attribute is frozen at the tag's first render (the
+per-message `tokenSnapshot` in state) and is not recomputed when the message
+text is later filtered, truncated, or edited by the host — the number always
+describes what the model originally saw. Nudge/pressure *decisions* are
+unaffected: they recount live text every turn. If you need the legacy
+live-recomputed tags, use `renderVisibleRefs` directly.
+
 ### Standalone modules
 
 | Module | Purpose |
@@ -108,7 +116,7 @@ The nudge system tells the model *when* to compress. It implements:
 
 ## Status
 
-✅ **Engine complete** — 23 source modules, 167 tests, typecheck + build clean. 3-tier compression, growth-gated nudges, emergency truncation,, fork-recovery, batch merge, composable node pipeline. Ready for adapter authoring.
+✅ **Engine complete** — 23 source modules, full suite green (`npm test`), typecheck + build clean. 3-tier compression, growth-gated nudges, emergency truncation, fork-recovery, batch merge, composable node pipeline. Ready for adapter authoring.
 
 > **Protected tool messages:** protected tool calls (per `config.protectedTools`) and their paired tool-results are hard-excluded from compression — they are dropped from the compressible set and from the new block's `effectiveMessageIds`, so they stay fully visible and are never folded into a summary. This matches opencode-acp's Bug 39 fix. The soft-protected recent zone (`preserveRecentMessages` / last user message) is handled separately: messages there are excluded from the range but do not fail it (an entirely-protected range fails with a clear error).
 


### PR DESCRIPTION
## What

Follow-up from the 48h regression review (#79 / #75 aftermath):

1. **Document the snapshot default.** #79 made `createRenderRefsNode` always render via snapshot, changing the semantics of `<acp tokens="N">` for every existing host: the attribute is now **frozen at first render** and does not track later host-side edits/filters/truncations. That behavioral change shipped silently — this documents it where adapters look (the `renderTags` section), notes that nudge decisions are unaffected (they recount live text each turn), and points legacy consumers at `renderVisibleRefs`.
2. **Drop hardcoded test counts.** README said *167 tests*, AGENTS.md said *295* — actual is 335+. Both drift every PR; replaced with drift-proof phrasing (`full suite green (npm test)`).
3. Trivial: double comma in the README Status line.

Docs only — no code changes. `npm test` green.