### PR TITLE
feat(wire): add wire-format detection and transform-channel policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ live-recomputed tags, use `renderVisibleRefs` directly.
 | `mergeMarkedBlocks` / `collectOldGenBlocks` | Batch merge old-gen blocks into one summary |
 | `rebuildCompressionState` | Fork-recovery: replay historical compress calls |
 | `applyMessageFilters` | Pluggable message-filter framework |
+| `resolveTransformChannel` | Channel-selection policy: an explicit preference wins; the default is the wire channel only when the caller reports it viable |
 
 ### Nudge system
 
@@ -113,6 +114,19 @@ The nudge system tells the model *when* to compress. It implements:
 - **Tier-distillation triggers**: when active tier-1 blocks pile up past `tiers.tier2Trigger`, emit a tier-2 distillation nudge; tier-3 analogously.
 - **Compressible-range computation**: reports the actual compressible ranges (excluding covered + preserved-recent messages) so the model knows what to target.
 - **Baseline reset on compress**: `applyCompression` clears the growth baseline on success, preventing the feedback-loop bug where the nudge re-fires post-compress.
+
+## Wire codec (`acp-kernel/wire`)
+
+The `acp-kernel/wire` subpath ships the provider wire-body codecs (lossless
+round-trip via the `BiliMessage` sidecar): `anthropicToCore`/`coreToAnthropic`,
+`openaiToCore`/`coreToOpenai`, `responsesToCore`/`coreToResponses`, plus
+`deriveMessageId` (content-hash message identity), conversation signals and the
+subagent-namespace helpers. `WIRE_FORMATS` / `detectWireFormat` classify a
+request body by the codec that can parse it — `undefined` means the body is
+unparseable and must be passed through untransformed. Adapters map their
+host's model/API ids to formats and use `resolveTransformChannel` (with
+`wireViable` = body parseable AND the host applies the payload replacement)
+to decide between message-level and wire-level surgery.
 
 ## Status
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export { rebuildCompressionState } from "./rebuild.js";
 export type { RebuildResult, RebuildPorts } from "./rebuild.js";
 export { renderVisibleRefs, renderRefsNode, createRenderRefsNode } from "./render-refs.js";
 export type { RenderStrategy } from "./render-refs.js";
+export { resolveTransformChannel } from "./transform-channel.js";
+export type { TransformChannel } from "./transform-channel.js";
 export { searchBlocks, searchBlocksAsync, blockDocs, messageDocs } from "./search.js";
 export type { SearchResult, SearchOptions, SearchAlgorithm, AsyncSearchAlgorithm, AnySearchAlgorithm, SearchDoc, SearchDocKind, ScoredBlock, MessageRole, RoleWeights, MessageInput } from "./search.js";
 export { DEFAULT_ALGORITHM, DEFAULT_ROLE_WEIGHTS, registerSearchAlgorithm, getSearchAlgorithm, listSearchAlgorithms } from "./search.js";

--- a/src/transform-channel.ts
+++ b/src/transform-channel.ts
@@ -1,0 +1,14 @@
+export type TransformChannel = "message" | "wire";
+
+/**
+ * Pick the transform channel: an explicit preference always wins; otherwise
+ * the wire channel is used only when the caller's host actually applies the
+ * wire-payload replacement (adapters pass `wireViable` — e.g. the body format
+ * is in WIRE_FORMATS and the host honors the hook's return value).
+ */
+export function resolveTransformChannel(
+  explicit: TransformChannel | undefined,
+  wireViable: boolean,
+): TransformChannel {
+  return explicit ?? (wireViable ? "wire" : "message");
+}

--- a/src/wire/formats.ts
+++ b/src/wire/formats.ts
@@ -1,0 +1,47 @@
+export const WIRE_FORMATS = ["anthropic", "openai", "responses"] as const;
+export type WireFormat = (typeof WIRE_FORMATS)[number];
+
+export function isWireFormat(value: unknown): value is WireFormat {
+  return (
+    typeof value === "string" &&
+    (WIRE_FORMATS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Classify a provider request body by the codec that can parse it.
+ * Returns undefined when no codec handles the body — the caller must
+ * pass such payloads through untransformed.
+ */
+export function detectWireFormat(payload: unknown): WireFormat | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const p = payload as Record<string, unknown>;
+  if (Array.isArray(p.input)) return "responses";
+  const messages = p.messages;
+  if (!Array.isArray(messages)) return undefined;
+  if ("system" in p || "anthropic_version" in p) return "anthropic";
+  for (const m of messages as Array<Record<string, unknown>>) {
+    if (m === null || typeof m !== "object") continue;
+    const c = m.content;
+    if (Array.isArray(c)) {
+      for (const b of c as Array<Record<string, unknown>>) {
+        if (b && typeof b === "object" && typeof b.type === "string") {
+          if (
+            b.type === "tool_use" ||
+            b.type === "tool_result" ||
+            b.type === "thinking"
+          )
+            return "anthropic";
+          if (b.type === "text" && "cache_control" in b) return "anthropic";
+        }
+      }
+    }
+    if (Array.isArray(m.tool_calls)) return "openai";
+    if (m.role === "tool" && typeof m.tool_call_id === "string")
+      return "openai";
+    if (m.role === "system" || m.role === "developer") return "openai";
+  }
+  // Both chat formats share role+messages; default to openai — the safer
+  // guess for OpenAI-compatible endpoints (GLM, DeepSeek, vLLM).
+  return "openai";
+}

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -1,6 +1,7 @@
 export * from "./anthropic.js";
 export * from "./openai.js";
 export * from "./responses.js";
+export * from "./formats.js";
 export * from "./bili-message.js";
 export * from "./message-id.js";
 export * from "./util.js";

--- a/tests/transform-channel.test.ts
+++ b/tests/transform-channel.test.ts
@@ -1,0 +1,13 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveTransformChannel } from "../src/transform-channel.js";
+
+test("an explicit channel always wins", () => {
+  assert.equal(resolveTransformChannel("wire", false), "wire");
+  assert.equal(resolveTransformChannel("message", true), "message");
+});
+
+test("the default channel follows wire viability", () => {
+  assert.equal(resolveTransformChannel(undefined, true), "wire");
+  assert.equal(resolveTransformChannel(undefined, false), "message");
+});

--- a/tests/wire-formats.test.ts
+++ b/tests/wire-formats.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  WIRE_FORMATS,
+  detectWireFormat,
+  isWireFormat,
+} from "../src/wire/formats.js";
+
+test("WIRE_FORMATS lists exactly the codecs shipped by this package", () => {
+  assert.deepEqual([...WIRE_FORMATS], ["anthropic", "openai", "responses"]);
+  for (const f of WIRE_FORMATS) {
+    assert.equal(isWireFormat(f), true);
+  }
+  assert.equal(isWireFormat("unknown"), false);
+  assert.equal(isWireFormat(42), false);
+});
+
+test("detectWireFormat routes anthropic markers", () => {
+  assert.equal(
+    detectWireFormat({
+      model: "claude-x",
+      system: "s",
+      messages: [{ role: "user", content: "hi" }],
+    }),
+    "anthropic",
+  );
+  assert.equal(
+    detectWireFormat({
+      anthropic_version: "v1",
+      messages: [{ role: "user", content: "hi" }],
+    }),
+    "anthropic",
+  );
+  assert.equal(
+    detectWireFormat({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "1", name: "f", input: {} }],
+        },
+      ],
+    }),
+    "anthropic",
+  );
+  assert.equal(
+    detectWireFormat({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "1", content: "ok" }],
+        },
+      ],
+    }),
+    "anthropic",
+  );
+  assert.equal(
+    detectWireFormat({
+      messages: [
+        { role: "assistant", content: [{ type: "thinking", thinking: "hmm" }] },
+      ],
+    }),
+    "anthropic",
+  );
+  assert.equal(
+    detectWireFormat({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    }),
+    "anthropic",
+  );
+});
+
+test("detectWireFormat routes openai markers", () => {
+  assert.equal(
+    detectWireFormat({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ id: "t1", function: { name: "f", arguments: "{}" } }],
+        },
+      ],
+    }),
+    "openai",
+  );
+  assert.equal(
+    detectWireFormat({
+      messages: [{ role: "tool", tool_call_id: "t1", content: "r" }],
+    }),
+    "openai",
+  );
+  assert.equal(
+    detectWireFormat({ messages: [{ role: "system", content: "s" }] }),
+    "openai",
+  );
+  assert.equal(
+    detectWireFormat({ messages: [{ role: "developer", content: "s" }] }),
+    "openai",
+  );
+});
+
+test("detectWireFormat defaults plain role+content chat bodies to openai", () => {
+  assert.equal(
+    detectWireFormat({
+      model: "glm-x",
+      messages: [{ role: "user", content: "hi" }],
+    }),
+    "openai",
+  );
+});
+
+test("detectWireFormat routes responses bodies by the input array", () => {
+  assert.equal(
+    detectWireFormat({
+      model: "gpt-x",
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    }),
+    "responses",
+  );
+});
+
+test("detectWireFormat rejects unparseable payloads", () => {
+  assert.equal(detectWireFormat(null), undefined);
+  assert.equal(detectWireFormat(42), undefined);
+  assert.equal(detectWireFormat({}), undefined);
+  assert.equal(detectWireFormat({ foo: 1 }), undefined);
+  assert.equal(detectWireFormat({ messages: 42 }), undefined);
+});


### PR DESCRIPTION
## What

Two small, pure additions that let adapters stop hard-coding per-host tables:

**`acp-kernel/wire` — `WIRE_FORMATS` / `detectWireFormat`**
Classify a provider request body by the codec that can parse it (`anthropic` / `openai` / `responses`). `undefined` means no codec handles the body — the caller must pass it through untransformed. Detection semantics are ported from the field-proven billion-context-omp wire bridge (issue #52/#66 lineage), extended with the responses `input` shape the kernel codec already supports but no detector covered.

**`resolveTransformChannel`**
The shared channel-selection policy: an explicit preference always wins; the default is the wire channel only when the caller reports it viable (body parseable AND the host applies the payload replacement). Keeps the policy in one place as more adapters adopt wire-level surgery.

Both are host-agnostic (no pi-ai / omp / proxy imports), zero runtime dependencies, pure functions.

## Context

`ranxianglei/billion-context-omp` issue #79: with provider-mode as the blanket default, models on APIs whose host drops the wire-payload replacement (openai-completions & friends) received no compression injections and never compressed. The omp-side fix (PR ranxianglei/billion-context-omp#80) resolves the channel per API; this PR moves the *capability* half of that decision — which wire bodies the kernel can actually parse — into the kernel so all consumers (omp, proxy, future hosts) query one source. The host-side root fix is can1357/oh-my-pi#8717.

## Verification

- `npm run typecheck` clean
- `npm test` — 348 pass / 0 fail (12 new: detection routing incl. anthropic/openai/responses markers, unknown-shape rejection, channel policy truth table)
- `npm run build` clean
- No version bump (release branch per AGENTS.md after merge)
