### PR TITLE
search: Intl.Segmenter CJK tokenizer + status-quo regression tests

### DIFF
--- a/bench/search/bench.ts
+++ b/bench/search/bench.ts
@@ -9,7 +9,7 @@
  *   node --import tsx bench/search/bench.ts
  */
 
-import { searchBlocks } from "../../src/search.js";
+import { searchBlocks, blockDocs } from "../../src/search.js";
 import { createInitialState } from "../../src/state.js";
 import type { CompressionState, CompressionBlock } from "../../src/types.js";
 import { CORPUS, QUERIES } from "./corpus.js";
@@ -28,7 +28,7 @@ function evaluate(algorithm: string | undefined) {
   let rr = 0, c1 = 0, it3 = 0;
   const fails: string[] = [];
   for (const q of QUERIES) {
-    const r = searchBlocks(state, q.query, { algorithm });
+    const r = searchBlocks(blockDocs(state), q.query, { algorithm });
     const got = r[0]?.blockId ?? null;
     const top3 = r.slice(0, 3).map((x) => x.blockId);
     const idx = r.findIndex((x) => x.blockId === q.expectFirst);

--- a/bench/search/corpus.ts
+++ b/bench/search/corpus.ts
@@ -19,7 +19,7 @@ export const CORPUS: BenchBlock[] = [
   { blockId: "b2", topic: "database-connection-pool", summary: "Database connection pooling for PostgreSQL. Configured pg Pool with max 20 connections, idle timeout 30s. Connection pool lives in src/db/pool.ts. Resolved connection leak where queries weren't releasing clients back to pool. Added pool.end() on graceful shutdown." },
   { blockId: "b3", topic: "decompress-default-to-file", summary: "Changed decompress tool to write restored content to a file by default instead of returning inline. Prevents context bloat when decompressing large blocks. New API: decompress({blockId}) writes to ~/.cache/pi/acp-decompress/, decompress({blockId, inline:true}) for explicit inline." },
   { blockId: "b4", topic: "compression-protected-zone", summary: "Soft-protect recent zone: filter protected refs instead of failing the whole compression call. NEVER_PRESERVE_RECENT_TOOLS excludes decompress results from the preserve set. applySingleRange now filters and warns rather than throwing on partial overlap." },
-  { blockId: "b5", topic: "用户认证模块", summary: "实现了用户登录认证流程，包含密码哈希（bcrypt）、session 管理、权限校验中间件。登录接口 POST /api/login 返回 JWT token。身份验证失败返回 401。支持 OAuth2 第三方登录（Google、GitHub）。token 过期自动刷新机制。" },
+  { blockId: "b5", topic: "用户认证模块", summary: "实现了用户登录认证流程，包含密码哈希（bcrypt）、session 管理、权限校验中间件。验证逻辑覆盖登录验证、token 验证、二次验证。登录接口 POST /api/login 返回 JWT token。身份验证失败返回 401。支持 OAuth2 第三方登录（Google、GitHub）。token 过期自动刷新机制。" },
   { blockId: "b6", topic: "npm-publish-workflow", summary: "CI release workflow: on merge of release-v* branch, CI runs typecheck + test + build, creates git tag, publishes to npm. Prerelease versions (containing -) published with --tag dev. NPM_TOKEN secret required." },
   { blockId: "b7", topic: "context-token-estimation", summary: "Token estimation uses chars/4 heuristic. Real tokenizer differs — the gap lands in 'Framework' category in breakdown. displayTotal reflects real context size, not classified sum. systemPromptTokens measured separately from message categories." },
   { blockId: "b8", topic: "review-fixes", summary: "Code review findings: config 150K context cap fix, token counting precision, protect-recent zone edge cases. Reviewer approved after addressing warnings field backward compatibility. Merged to master." },
@@ -45,6 +45,8 @@ export const CORPUS: BenchBlock[] = [
   { blockId: "b28", topic: "ci-cache-optimization", summary: "GitHub Actions cache optimization. Cached node_modules and .turbo. Reduced CI time from 4min to 90s. Cache key includes lockfile hash. Used actions/cache@v3 with restore-keys fallback. Matrix build parallelized across node versions." },
   { blockId: "b29", topic: "memory-leak-debug", summary: "Debugged memory leak in worker pool. Event listeners accumulated — removed on disconnect. WeakRef for cached objects. Heap snapshot comparison found detached DOM nodes. Set maxOldSpaceSize to 4096. Used --inspect to trace retention path." },
   { blockId: "b30", topic: "文件上传oss", summary: "文件上传到阿里云 OSS。分片上传大文件（>5MB），断点续传。预签名 URL 直传前端，减轻服务端压力。图片自动压缩生成缩略图（sharp）。CDN 加速静态资源分发。" },
+  { blockId: "b31", topic: "试验记录", summary: "试验记录表：记录三次批次的数据结果。" },
+  { blockId: "b32", topic: "图表工具", summary: "图表组件用于绘制折线图和柱状图。" },
 ];
 
 export interface BenchQuery {
@@ -73,7 +75,7 @@ export const QUERIES: BenchQuery[] = [
   { query: "token bucket", expectFirst: "b11", note: "disambiguation" },
   { query: "tokan", expectFirst: "b1", note: "typo" },
   { query: "authentication tokan", expectFirst: "b1", note: "multi-word typo+morph" },
-  { query: "redis", expectFirst: "b11", note: "ambiguous (token-densest wins)" },
+  { query: "redis", expectFirst: "b19", note: "ambiguous (token-densest wins)" },
   { query: "缓存", expectFirst: "b19", note: "CJK exact (redis cache)" },
   { query: "cache", expectFirst: "b19", note: "synonym (缓存=cache)" },
   { query: "webpack", expectFirst: "b10", note: "exact" },
@@ -100,4 +102,6 @@ export const QUERIES: BenchQuery[] = [
   { query: "日志", expectFirst: "b23", note: "CJK exact" },
   { query: "elk", expectFirst: "b23", note: "abbreviation" },
   { query: "security header", expectFirst: "b21", note: "phrase (csp)" },
+  { query: "试验证明", expectFirst: "b31", note: "CJK anti-fragment (must not match 验证 in b5)" },
+  { query: "图表可视化", expectFirst: "b32", note: "CJK phrase must not match b23 可视化 char-run" },
 ];

--- a/bench/search/corpus.ts
+++ b/bench/search/corpus.ts
@@ -75,7 +75,7 @@ export const QUERIES: BenchQuery[] = [
   { query: "token bucket", expectFirst: "b11", note: "disambiguation" },
   { query: "tokan", expectFirst: "b1", note: "typo" },
   { query: "authentication tokan", expectFirst: "b1", note: "multi-word typo+morph" },
-  { query: "redis", expectFirst: "b19", note: "ambiguous (token-densest wins)" },
+  { query: "redis", expectFirst: "b19", note: "ambiguous — b19 is the actual Redis cache block (bigram bloat had buried it under b11)" },
   { query: "缓存", expectFirst: "b19", note: "CJK exact (redis cache)" },
   { query: "cache", expectFirst: "b19", note: "synonym (缓存=cache)" },
   { query: "webpack", expectFirst: "b10", note: "exact" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.27",
+    "version": "0.0.28",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.27",
+            "version": "0.0.28",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type { RenderStrategy } from "./render-refs.js";
 export { resolveTransformChannel } from "./transform-channel.js";
 export type { TransformChannel } from "./transform-channel.js";
 export { searchBlocks, searchBlocksAsync, blockDocs, messageDocs } from "./search.js";
+export { clearDocFeatures, docCacheInfo, docFeatures, setDocCacheCap } from "./search.js";
 export type { SearchResult, SearchOptions, SearchAlgorithm, AsyncSearchAlgorithm, AnySearchAlgorithm, SearchDoc, SearchDocKind, ScoredBlock, MessageRole, RoleWeights, MessageInput } from "./search.js";
 export { DEFAULT_ALGORITHM, DEFAULT_ROLE_WEIGHTS, registerSearchAlgorithm, getSearchAlgorithm, listSearchAlgorithms } from "./search.js";
 export { isMessageProtected, matchToolPattern } from "./protected.js";

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,6 +2,8 @@
  * Search — re-exports from the modular src/search/ implementation.
  */
 export { searchBlocks, searchBlocksAsync, blockDocs, messageDocs } from "./search/index.js";
+export { clearDocFeatures, docCacheInfo, docFeatures, setDocCacheCap } from "./search/index.js";
+export type { DocFeatures } from "./search/index.js";
 export type {
     SearchResult,
     SearchOptions,

--- a/src/search/SEARCH.md
+++ b/src/search/SEARCH.md
@@ -52,15 +52,14 @@ Override via `SearchOptions.roleWeights`.
 
 ## Why the default is "hybrid"
 
-The default algorithm is `hybrid` (BM25+stem ⊕ fuzzy n-gram). On a 30-block
-mixed EN/CJK benchmark with 45 queries, against the original substring counter:
-
+The default algorithm is `hybrid` (BM25+stem ⊕ fuzzy n-gram). On a 32-block
+mixed EN/CJK benchmark with 48 queries, against the original substring counter:
 | algorithm   | MRR   | R@1   | R@3   |
 |-------------|-------|-------|-------|
-| substring   | 0.821 | 0.804 | 0.826 |
-| bm25        | 0.812 | 0.804 | 0.826 |
-| fuzzy       | 0.691 | 0.630 | 0.761 |
-| **hybrid**  | **0.879** | **0.848** | **0.913** |
+| substring   | 0.786 | 0.771 | 0.792 |
+| bm25        | 0.818 | 0.813 | 0.813 |
+| fuzzy       | 0.683 | 0.604 | 0.771 |
+| **hybrid**  | **0.883** | **0.854** | **0.896** |
 
 The wins come from three fixes to plain substring matching:
 

--- a/src/search/SEARCH.md
+++ b/src/search/SEARCH.md
@@ -63,13 +63,13 @@ The default algorithm is `hybrid` (BM25+stem ⊕ fuzzy n-gram). On a 32-block
 mixed EN/CJK benchmark with 48 queries, against the original substring counter:
 | algorithm   | MRR   | R@1   | R@3   |
 |-------------|-------|-------|-------|
-| substring   | 0.786 | 0.771 | 0.792 |
-| bm25        | 0.818 | 0.813 | 0.813 |
-| fuzzy       | 0.683 | 0.604 | 0.771 |
+| substring   | 0.797 | 0.792 | 0.792 |
+| bm25        | 0.833 | 0.833 | 0.833 |
+| fuzzy       | 0.795 | 0.708 | 0.875 |
 | **hybrid**  | **0.898** | **0.875** | **0.917** |
 
-hybrid row measured on the rework benchmark (32 blocks / 48 queries); the
-single-algorithm rows predate the CJK segmenter rework.
+All rows measured on the rework benchmark (32 blocks / 48 queries) with the
+final code (segmenter tokenizer + CJK fuzzy gate).
 
 The wins come from three fixes to plain substring matching:
 

--- a/src/search/SEARCH.md
+++ b/src/search/SEARCH.md
@@ -4,6 +4,13 @@ Block search finds compressed (invisible) content by keyword — the core value
 of ACP as conversations grow. This module is a **pluggable algorithm registry**:
 one stable interface, multiple strategies, zero runtime dependencies.
 
+> **Legacy path warning:** `CompressionCore.search()` (`src/compress.ts`) is a
+> separate substring-only implementation that does NOT go through this
+> registry — it over-matches short terms ("the" ≈ "theater") and sees only
+> active blocks. Production adapters use `searchBlocks`. The delegation plan
+> (core.search → searchBlocks) is tracked in
+> [issue #44](https://github.com/ranxianglei/acp-kernel/issues/44).
+
 ## Quick start
 
 ```ts

--- a/src/search/SEARCH.md
+++ b/src/search/SEARCH.md
@@ -59,16 +59,26 @@ mixed EN/CJK benchmark with 48 queries, against the original substring counter:
 | substring   | 0.786 | 0.771 | 0.792 |
 | bm25        | 0.818 | 0.813 | 0.813 |
 | fuzzy       | 0.683 | 0.604 | 0.771 |
-| **hybrid**  | **0.883** | **0.854** | **0.896** |
+| **hybrid**  | **0.898** | **0.875** | **0.917** |
+
+hybrid row measured on the rework benchmark (32 blocks / 48 queries); the
+single-algorithm rows predate the CJK segmenter rework.
 
 The wins come from three fixes to plain substring matching:
 
-1. **CJK bigram tokenization** — Chinese/Japanese has no spaces, so `"登录"`
-   tokenizes into overlapping bigrams that match inside `"登录认证流程"`.
+1. **CJK word segmentation** — Chinese/Japanese has no spaces, so `"登录"` is
+   segmented via `Intl.Segmenter("zh", {granularity:"word"})` (CLDR
+   dictionary): multi-char words stay atomic, and all-OOV runs fall back to
+   overlapping bigrams + single chars — `"身份验证"` still matches
+   `"身份验证流程"`, while `"试验证明"` no longer false-hits `"验证"`.
 2. **English stemming** — `compressed`/`compression`/`compressing` collapse to a
    common root (lightweight Porter-inspired suffix stripper, no deps).
 3. **Character n-gram fuzzy recall** — typo-tolerant (`tokan`≈`token`),
-   script-agnostic; BM25 supplies precision, fuzzy supplies recall.
+   script-agnostic; BM25 supplies precision, fuzzy supplies recall. The
+   query-token gate is script-aware: Latin tokens need >= 4 chars (2-3 char
+   stop-words are noise), but 2-char CJK words (`登录`/`缓存`) are admitted —
+   most CJK words are exactly 2 characters, so a Latin-style threshold would
+   starve the recall channel for a whole script.
 
 Previews are **match-context snippets**, not arbitrary prefixes — the result
 shows the sentence around the hit so the user sees *why* a block matched.
@@ -145,7 +155,7 @@ single batch keeps it to one round-trip per search.
 ```
 src/search/
 ├── types.ts              SearchAlgorithm, AsyncSearchAlgorithm, SearchOptions, SearchResult
-├── tokenizer.ts          Latin words + CJK bigram tokenization
+├── tokenizer.ts          Latin words + CJK word segmentation w/ bigram fallback
 ├── stemmer.ts            lightweight English stemmer
 ├── registry.ts           register / get / list algorithms
 ├── algorithms/

--- a/src/search/algorithms/bm25.ts
+++ b/src/search/algorithms/bm25.ts
@@ -9,8 +9,8 @@ import { tokenize, tfMap } from "../tokenizer.js";
  * raw term count. Stemming collapses English morphology
  * (compress/compressed/compression → ~compress).
  *
- * On a 30-block mixed EN/CJK benchmark: MRR 0.812 vs 0.821 for substring
- * alone — not better in isolation, but a strong precision component when
+ * On a 32-block mixed EN/CJK benchmark: MRR 0.818 vs 0.786 for substring
+ * — not better in isolation, but a strong precision component when
  * combined with fuzzy recall (see hybrid.ts).
  */
 export const bm25Algorithm: SearchAlgorithm = {

--- a/src/search/algorithms/bm25.ts
+++ b/src/search/algorithms/bm25.ts
@@ -9,9 +9,9 @@ import { tokenize, tfMap } from "../tokenizer.js";
  * raw term count. Stemming collapses English morphology
  * (compress/compressed/compression → ~compress).
  *
- * On a 32-block mixed EN/CJK benchmark: MRR 0.818 vs 0.786 for substring
- * — not better in isolation, but a strong precision component when
- * combined with fuzzy recall (see hybrid.ts).
+ * On the 32-block mixed EN/CJK benchmark: MRR 0.833 / R@1 0.833 / R@3 0.833
+ * vs 0.797 / 0.792 / 0.792 for substring — better in isolation on every
+ * metric, and the precision component of the hybrid default (see hybrid.ts).
  */
 export const bm25Algorithm: SearchAlgorithm = {
     name: "bm25",

--- a/src/search/algorithms/bm25.ts
+++ b/src/search/algorithms/bm25.ts
@@ -1,5 +1,6 @@
 import type { SearchAlgorithm, SearchDoc, ScoredBlock } from "../types.js";
-import { tokenize, tfMap } from "../tokenizer.js";
+import { tokenize } from "../tokenizer.js";
+import { docFeatures } from "../doc-cache.js";
 
 /**
  * BM25 with stemming + CJK bigram tokenization.
@@ -21,11 +22,8 @@ export const bm25Algorithm: SearchAlgorithm = {
         const k1 = 1.2;
         const b = 0.75;
         const parsed = docs.map((d) => {
-            const text = d.text;
-            const tf = tfMap(text, true);
-            let len = 0;
-            for (const v of tf.values()) len += v;
-            return { id: d.ref, tf, len };
+            const f = docFeatures(d.text); // memoized: tf + length, cached across calls
+            return { id: d.ref, tf: f.tf, len: f.len };
         });
         const avgdl = parsed.reduce((s, d) => s + d.len, 0) / (N || 1);
 

--- a/src/search/algorithms/fuzzy.ts
+++ b/src/search/algorithms/fuzzy.ts
@@ -9,8 +9,8 @@ import { charBigrams } from "../tokenizer.js";
  * uniformly across all scripts (CJK benefits most). Only considers query
  * tokens of length >= 4 to avoid noise from short common-character pairs.
  *
- * On benchmark: highest recall@3 (0.913) of any single algorithm — it is
- * the recall boost in the hybrid default.
+ * On benchmark: lowest MRR of any single algorithm (0.683) — precision is
+ * weak, but it is the recall boost in the hybrid default.
  */
 export const fuzzyAlgorithm: SearchAlgorithm = {
     name: "fuzzy",

--- a/src/search/algorithms/fuzzy.ts
+++ b/src/search/algorithms/fuzzy.ts
@@ -1,13 +1,22 @@
 import type { SearchAlgorithm, SearchDoc, ScoredBlock } from "../types.js";
-import { charBigrams } from "../tokenizer.js";
+import { charBigrams, CJK } from "../tokenizer.js";
 
 /**
  * Fuzzy character-bigram matching (Jaccard-style).
  *
  * Decomposes the query into character bigrams and measures overlap with
  * each doc. Robust to typos (tokan≈token), partial words, and works
- * uniformly across all scripts (CJK benefits most). Only considers query
- * tokens of length >= 4 to avoid noise from short common-character pairs.
+ * uniformly across all scripts (CJK benefits most).
+ *
+ * Query-token gate — CJK gets its own length rule; Latin is frozen:
+ *   length >= 4 (any script)   typo-tolerant bigram rescue needs a couple of
+ *       chars before it means anything; 2-3-char Latin tokens ("to", "of",
+ *       "us") are stop-word noise whose bigrams overlap nearly every doc.
+ *   length >= 2 && CJK         Chinese/Japanese/Korean words are mostly
+ *       2-character atomic units (登录/缓存/図表), so the Latin-style >= 4 rule
+ *       would lock the whole CJK query space out of this recall channel
+ *       (that gap is what bench "缓存 → nothing" exposed). Single CJK chars
+ *       stay excluded — one char cannot form a bigram, nothing to compare.
  *
  * On benchmark: lowest MRR of any single algorithm (0.683) — precision is
  * weak, but it is the recall boost in the hybrid default.
@@ -16,7 +25,9 @@ export const fuzzyAlgorithm: SearchAlgorithm = {
     name: "fuzzy",
     description: "Character bigram overlap. Typo-tolerant, script-agnostic, high recall.",
     score(docs: SearchDoc[], query: string): ScoredBlock[] {
-        const qTokens = query.toLowerCase().split(/[\s,]+/).filter((t) => t.length >= 4);
+        // Gate (see header): Latin short tokens are noise, 2-char CJK words
+        // are real terms — admit the latter so 缓存/登录 reach the scorer.
+        const qTokens = query.toLowerCase().split(/[\s,]+/).filter((t) => t.length >= 4 || (t.length >= 2 && CJK.test(t)));
         if (qTokens.length === 0) return docs.map((d) => ({ ref: d.ref, score: 0 }));
 
         const qGrams = new Set<string>();

--- a/src/search/algorithms/fuzzy.ts
+++ b/src/search/algorithms/fuzzy.ts
@@ -1,5 +1,6 @@
 import type { SearchAlgorithm, SearchDoc, ScoredBlock } from "../types.js";
 import { charBigrams, CJK } from "../tokenizer.js";
+import { docFeatures } from "../doc-cache.js";
 
 /**
  * Fuzzy character-bigram matching (Jaccard-style).
@@ -36,8 +37,7 @@ export const fuzzyAlgorithm: SearchAlgorithm = {
         if (qGrams.size === 0) return docs.map((d) => ({ ref: d.ref, score: 0 }));
 
         return docs.map((d) => {
-            const haystack = d.text.toLowerCase();
-            const docGrams = new Set(charBigrams(haystack));
+            const docGrams = docFeatures(d.text).grams; // memoized bigram set
             let hits = 0;
             for (const g of qGrams) if (docGrams.has(g)) hits++;
             return { ref: d.ref, score: hits / qGrams.size };

--- a/src/search/algorithms/fuzzy.ts
+++ b/src/search/algorithms/fuzzy.ts
@@ -18,8 +18,9 @@ import { charBigrams, CJK } from "../tokenizer.js";
  *       (that gap is what bench "缓存 → nothing" exposed). Single CJK chars
  *       stay excluded — one char cannot form a bigram, nothing to compare.
  *
- * On benchmark: lowest MRR of any single algorithm (0.683) — precision is
- * weak, but it is the recall boost in the hybrid default.
+ * On benchmark: lowest MRR of any single algorithm (0.795 — a hair under
+ * substring's 0.797) — precision is weak, but it is the recall boost in the
+ * hybrid default.
  */
 export const fuzzyAlgorithm: SearchAlgorithm = {
     name: "fuzzy",

--- a/src/search/algorithms/hybrid.ts
+++ b/src/search/algorithms/hybrid.ts
@@ -10,12 +10,11 @@ import { fuzzyAlgorithm } from "./fuzzy.js";
  * Each component is max-normalized to [0,1] before weighting so their
  * scales are comparable regardless of corpus size.
  *
- * Benchmark (30 blocks, 45 mixed EN/CJK queries):
- *   substring  MRR 0.821  R@1 0.804  R@3 0.826
- *   bm25       MRR 0.812  R@1 0.804  R@3 0.826
- *   fuzzy      MRR 0.834  R@1 0.761  R@3 0.913
- *   hybrid     MRR 0.881  R@1 0.848  R@3 0.913   ← best on every metric
- *
+ * Benchmark (32 blocks, 48 mixed EN/CJK queries):
+ *   substring  MRR 0.786  R@1 0.771  R@3 0.792
+ *   bm25       MRR 0.818  R@1 0.813  R@3 0.813
+ *   fuzzy      MRR 0.683  R@1 0.604  R@3 0.771
+ *   hybrid     MRR 0.883  R@1 0.854  R@3 0.896   ← best on MRR and R@1
  * The weight ratio is robust: 0.6–0.8 for BM25 all score within 0.001 MRR.
  */
 

--- a/src/search/algorithms/hybrid.ts
+++ b/src/search/algorithms/hybrid.ts
@@ -10,11 +10,12 @@ import { fuzzyAlgorithm } from "./fuzzy.js";
  * Each component is max-normalized to [0,1] before weighting so their
  * scales are comparable regardless of corpus size.
  *
- * Benchmark (32 blocks, 48 mixed EN/CJK queries):
- *   substring  MRR 0.786  R@1 0.771  R@3 0.792
- *   bm25       MRR 0.818  R@1 0.813  R@3 0.813
- *   fuzzy      MRR 0.683  R@1 0.604  R@3 0.771
- *   hybrid     MRR 0.883  R@1 0.854  R@3 0.896   ← best on MRR and R@1
+ * Benchmark (32 blocks, 48 mixed EN/CJK queries, final code — segmenter
+ * tokenizer + CJK fuzzy gate):
+ *   substring  MRR 0.797  R@1 0.792  R@3 0.792
+ *   bm25       MRR 0.833  R@1 0.833  R@3 0.833
+ *   fuzzy      MRR 0.795  R@1 0.708  R@3 0.875
+ *   hybrid     MRR 0.898  R@1 0.875  R@3 0.917   ← best on every metric
  * The weight ratio is robust: 0.6–0.8 for BM25 all score within 0.001 MRR.
  */
 

--- a/src/search/algorithms/substring.ts
+++ b/src/search/algorithms/substring.ts
@@ -1,4 +1,5 @@
 import type { SearchAlgorithm, SearchDoc, ScoredBlock } from "../types.js";
+import { docFeatures } from "../doc-cache.js";
 
 /**
  * Substring counting — the original baseline algorithm.
@@ -13,7 +14,7 @@ export const substringAlgorithm: SearchAlgorithm = {
         const terms = query.toLowerCase().trim().split(/\s+/).filter((t) => t.length > 0);
         if (terms.length === 0) return docs.map((d) => ({ ref: d.ref, score: 0 }));
         return docs.map((d) => {
-            const haystack = d.text.toLowerCase();
+            const haystack = docFeatures(d.text).lower; // memoized across calls
             let score = 0;
             for (const term of terms) score += countOccurrences(haystack, term);
             return { ref: d.ref, score };

--- a/src/search/doc-cache.ts
+++ b/src/search/doc-cache.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-doc derived features, memoized across search calls.
+ *
+ * A search over the compressed history re-scores the SAME immutable docs on
+ * every call — compressed block summaries and folded message text never
+ * change. Without this cache, every search_context call re-tokenized the
+ * entire corpus (segmenter CJK pass ≈ 0.3s/MB cold) plus re-lowercased it
+ * and rebuilt the bigram set for each channel: a 5MB session cost ~3s PER
+ * CALL, growing linearly with session length. With the cache the corpus is
+ * processed once; later searches are O(docs × query-terms).
+ *
+ * Keyed by doc text (immutable). Bounded by total cached source chars —
+ * oldest docs are evicted when the cap is exceeded, so a long-lived
+ * process serving many sessions cannot grow unboundedly. Hosts that want to
+ * release the memory eagerly on session shutdown/switch can call
+ * clearDocFeatures() (optional: the cap already bounds it).
+ */
+
+import { charBigrams, tfMap } from "./tokenizer.js";
+
+export interface DocFeatures {
+    /** Stemmed term frequencies (BM25 channel). */
+    tf: Map<string, number>;
+    /** Total term count (BM25 length normalization). */
+    len: number;
+    /** Lower-cased text (substring + fuzzy channels). */
+    lower: string;
+    /** Unique char bigrams of `lower` (fuzzy channel). */
+    grams: Set<string>;
+}
+
+const DEFAULT_CAP_CHARS = 8 * 1024 * 1024;
+let capChars = DEFAULT_CAP_CHARS;
+const cache = new Map<string, DocFeatures>();
+let cachedChars = 0;
+
+function build(text: string): DocFeatures {
+    const tf = tfMap(text, true);
+    let len = 0;
+    for (const v of tf.values()) len += v;
+    const lower = text.toLowerCase();
+    return { tf, len, lower, grams: new Set(charBigrams(lower)) };
+}
+
+export function docFeatures(text: string): DocFeatures {
+    const hit = cache.get(text);
+    if (hit) return hit;
+    const f = build(text);
+    if (text.length > 0 && text.length <= capChars) {
+        while (cachedChars + text.length > capChars && cache.size > 0) {
+            const k = cache.keys().next().value as string;
+            cachedChars -= k.length;
+            cache.delete(k);
+        }
+        cache.set(text, f);
+        cachedChars += text.length;
+    }
+    return f;
+}
+
+/** Drop all cached features (e.g. on session shutdown/switch). */
+export function clearDocFeatures(): void {
+    cache.clear();
+    cachedChars = 0;
+}
+
+/**
+ * Set the cache cap in source chars. Docs larger than the cap are never
+ * cached. Also used by tests to exercise eviction.
+ */
+export function setDocCacheCap(chars: number): void {
+    capChars = Math.max(1, chars);
+    while (cachedChars > capChars && cache.size > 0) {
+        const k = cache.keys().next().value as string;
+        cachedChars -= k.length;
+        cache.delete(k);
+    }
+}
+
+/** Cache occupancy — for diagnostics. */
+export function docCacheInfo(): { entries: number; chars: number } {
+    return { entries: cache.size, chars: cachedChars };
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -127,6 +127,9 @@ export function searchBlocks(docs: SearchDoc[], query: string, options: SearchOp
     return result;
 }
 
+export { clearDocFeatures, docCacheInfo, docFeatures, setDocCacheCap } from "./doc-cache.js";
+export type { DocFeatures } from "./doc-cache.js";
+
 export async function searchBlocksAsync(docs: SearchDoc[], query: string, options: SearchOptions = {}): Promise<SearchResult[]> {
     return await runSearch(docs, query, options);
 }

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -3,8 +3,9 @@
  *
  * Handles mixed Latin + CJK content — the single biggest quality lever
  * over plain substring search. Latin is split on non-word boundaries;
- * CJK (no spaces) is decomposed into overlapping bigrams so a query like
- * "身份验证" still scores against doc text "身份验证流程".
+ * CJK (no spaces) is word-segmented via Intl.Segmenter (CLDR dictionary),
+ * falling back to overlapping bigrams on out-of-vocabulary text so a query
+ * like "身份验证" still scores against doc text "身份验证流程".
  */
 
 const CJK = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
@@ -12,6 +13,29 @@ const CJK_RUN = new RegExp(`${CJK.source}+`, "g");
 const LATIN_WORD = /[a-z][a-z0-9_]*[a-z0-9]|[a-z0-9]/g;
 
 import { stem } from "./stemmer.js";
+
+const cjkSegmenter = new Intl.Segmenter("zh", { granularity: "word" });
+
+/**
+ * CJK run → tokens. Intl.Segmenter (CLDR dictionary) does word segmentation:
+ * multi-char words are kept as whole terms, so "国际化" matches "国际化" and
+ * "试验证明" no longer scores against "验证" through accidental char runs.
+ * When the dictionary finds no multi-char word at all (all-OOV text) we fall
+ * back to overlapping bigrams + single chars so recall is preserved — this
+ * also covers single-char queries like "验".
+ */
+function cjkTokens(run: string): string[] {
+    const words: string[] = [];
+    for (const seg of cjkSegmenter.segment(run)) {
+        const w = seg.segment;
+        if (w.length >= 2) words.push(w);
+    }
+    if (words.length > 0) return words;
+    const out: string[] = [];
+    for (let i = 0; i < run.length - 1; i++) out.push(run.slice(i, i + 2));
+    for (const ch of run) out.push(ch);
+    return out;
+}
 
 export interface TokenizeOptions {
     stem?: boolean;
@@ -31,12 +55,7 @@ export function tokenize(text: string, opts: TokenizeOptions = {}): string[] {
 
     const cjkRuns = lower.match(CJK_RUN) ?? [];
     for (const run of cjkRuns) {
-        if (run.length === 1) {
-            tokens.push(run);
-        } else {
-            for (let i = 0; i < run.length - 1; i++) tokens.push(run.slice(i, i + 2));
-            for (const ch of run) tokens.push(ch);
-        }
+        tokens.push(...cjkTokens(run));
     }
 
     return tokens;

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -16,11 +16,11 @@
  * English tokens ("to", "of") carry no meaning, while nearly all CJK words
  * are 2-char atomic units (登录/缓存), so the two scripts need opposite rules.
  */
+import { stem } from "./stemmer.js";
+
 export const CJK = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
 const CJK_RUN = new RegExp(`${CJK.source}+`, "g");
 const LATIN_WORD = /[a-z][a-z0-9_]*[a-z0-9]|[a-z0-9]/g;
-
-import { stem } from "./stemmer.js";
 
 const cjkSegmenter = new Intl.Segmenter("zh", { granularity: "word" });
 

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -8,7 +8,15 @@
  * like "身份验证" still scores against doc text "身份验证流程".
  */
 
-const CJK = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
+/**
+ * CJK ideograph/kana/hangul class — the one shared definition of "non-Latin
+ * script that must be handled specially". Exported so fuzzy.ts relaxes its
+ * short-query gate for the SAME range tokenizer.ts segments: two hand-copied
+ * regexes would silently drift apart. Latin is deliberately absent — 2-char
+ * English tokens ("to", "of") carry no meaning, while nearly all CJK words
+ * are 2-char atomic units (登录/缓存), so the two scripts need opposite rules.
+ */
+export const CJK = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
 const CJK_RUN = new RegExp(`${CJK.source}+`, "g");
 const LATIN_WORD = /[a-z][a-z0-9_]*[a-z0-9]|[a-z0-9]/g;
 

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -6,6 +6,15 @@
  * CJK (no spaces) is word-segmented via Intl.Segmenter (CLDR dictionary),
  * falling back to overlapping bigrams on out-of-vocabulary text so a query
  * like "身份验证" still scores against doc text "身份验证流程".
+ *
+ * CJK segmentation is a SINGLE segment() pass over the whole text, not one
+ * call per CJK run: a segment() call has fixed overhead (~3µs), and
+ * run-heavy text (logs: dozens of short runs per line) made per-run calls
+ * 10-16× slower than one bulk pass. ICU never merges CJK words across
+ * non-CJK boundaries, so bulk segmentation yields the same words per run
+ * (differential-verified against the per-run implementation across a
+ * mixed-script stress corpus); run boundaries are re-derived below to keep
+ * the all-OOV bigram fallback.
  */
 
 /**
@@ -19,26 +28,24 @@
 import { stem } from "./stemmer.js";
 
 export const CJK = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
-const CJK_RUN = new RegExp(`${CJK.source}+`, "g");
 const LATIN_WORD = /[a-z][a-z0-9_]*[a-z0-9]|[a-z0-9]/g;
 
 const cjkSegmenter = new Intl.Segmenter("zh", { granularity: "word" });
 
 /**
- * CJK run → tokens. Intl.Segmenter (CLDR dictionary) does word segmentation:
- * multi-char words are kept as whole terms, so "国际化" matches "国际化" and
- * "试验证明" no longer scores against "验证" through accidental char runs.
- * When the dictionary finds no multi-char word at all (all-OOV text) we fall
- * back to overlapping bigrams + single chars so recall is preserved — this
- * also covers single-char queries like "验".
+ * CJK segment groups → tokens, with the all-OOV fallback.
+ *
+ * `segs` are the word segments the segmenter produced for ONE contiguous
+ * CJK run. Multi-char words are kept as whole terms, so "国际化" matches
+ * "国际化" and "试验证明" no longer scores against "验证" through accidental
+ * char runs. When the dictionary finds no multi-char word at all (all-OOV
+ * text) we fall back to overlapping bigrams + single chars so recall is
+ * preserved — this also covers single-char queries like "验".
  */
-function cjkTokens(run: string): string[] {
-    const words: string[] = [];
-    for (const seg of cjkSegmenter.segment(run)) {
-        const w = seg.segment;
-        if (w.length >= 2) words.push(w);
-    }
+function cjkRunTokens(segs: string[]): string[] {
+    const words = segs.filter((w) => w.length >= 2);
     if (words.length > 0) return words;
+    const run = segs.join("");
     const out: string[] = [];
     for (let i = 0; i < run.length - 1; i++) out.push(run.slice(i, i + 2));
     for (const ch of run) out.push(ch);
@@ -61,9 +68,38 @@ export function tokenize(text: string, opts: TokenizeOptions = {}): string[] {
         }
     }
 
-    const cjkRuns = lower.match(CJK_RUN) ?? [];
-    for (const run of cjkRuns) {
-        tokens.push(...cjkTokens(run));
+    // CJK: one segmenter pass over the whole text instead of one
+    // segment() call per CJK run. A segment() call has fixed overhead
+    // (~3µs), and run-heavy text (logs: dozens of short runs per line) made
+    // per-run calls 10-16× slower than one bulk pass. ICU never merges CJK
+    // words across non-CJK boundaries, so bulk segmentation yields the same
+    // words per run (differential-verified against the per-run
+    // implementation across a mixed-script stress corpus); run boundaries
+    // are re-derived below to keep the all-OOV bigram fallback.
+    //
+    // Guard: skip the segmenter entirely when the text has no CJK at all —
+    // the old code never called it for pure-Latin text, and a bulk pass
+    // would pay a full-text scan (12ms → 33ms per MB of English) for nothing.
+    if (!CJK.test(lower)) return tokens;
+
+    // Group the bulk segments back into CJK runs: a non-CJK segment is a run
+    // boundary (the segmenter never puts non-CJK inside a CJK word segment).
+    const runSegs: string[][] = [];
+    let cur: string[] | null = null;
+    for (const s of cjkSegmenter.segment(lower)) {
+        const t = s.segment;
+        if (t.length === 0) continue;
+        if (CJK.test(t)) {
+            (cur ??= []).push(t);
+        } else if (cur) {
+            runSegs.push(cur);
+            cur = null;
+        }
+    }
+    if (cur) runSegs.push(cur);
+
+    for (const segs of runSegs) {
+        tokens.push(...cjkRunTokens(segs));
     }
 
     return tokens;

--- a/tests/doc-cache.test.ts
+++ b/tests/doc-cache.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Doc-features cache — memoization of per-doc derived data across search
+ * calls (src/search/doc-cache.ts).
+ *
+ * The corpus of a long session (compressed block summaries + folded message
+ * text) is immutable, so a search_context call must not re-tokenize /
+ * re-lowercase / rebuild bigram sets for the whole corpus on every query.
+ * These tests pin the cache semantics and the eviction cap.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  docFeatures,
+  clearDocFeatures,
+  docCacheInfo,
+  setDocCacheCap,
+  searchBlocks,
+  type SearchDoc,
+} from "../src/index.js";
+import { tokenize } from "../src/search/tokenizer.js";
+
+const DEFAULT_CAP = 8 * 1024 * 1024;
+
+test("docFeatures: same text → same cached object", () => {
+  clearDocFeatures();
+  const a = docFeatures("缓存命中 cache hit 身份验证");
+  const b = docFeatures("缓存命中 cache hit 身份验证");
+  assert.equal(a, b, "second call must return the cached instance");
+  assert.ok(docCacheInfo().entries >= 1);
+});
+
+test("docFeatures: different text → different objects, independent data", () => {
+  clearDocFeatures();
+  const a = docFeatures("身份验证失败"); // → 身份,验证,失败 (CLDR dictionary words)
+  const b = docFeatures("请求超时处理"); // → 请求,超,时,处理
+  assert.notEqual(a, b);
+  assert.ok(a.tf.has("身份") && !a.tf.has("请求"));
+  assert.ok(b.tf.has("请求") && !b.tf.has("身份"));
+});
+
+test("docFeatures: derived fields are correct", () => {
+  clearDocFeatures();
+  const f = docFeatures("The quick Cache cache CACHE, 缓存 缓存 hit");
+  assert.ok(f.lower.startsWith("the quick cache"), "lower must be lowercased");
+  assert.equal(f.tf.get("cache"), 3, "stemmed tf counts case-insensitive repeats");
+  assert.equal(f.tf.get("缓存"), 2, "CJK word tokens counted per occurrence");
+  assert.ok(f.len >= f.tf.size, "len = sum of tf values");
+  assert.ok(f.grams.has("qu"), "bigrams of the lower-cased text");
+  assert.ok(f.grams.has("缓存"), "CJK word bigrams present");
+});
+
+test("clearDocFeatures: forces a rebuild", () => {
+  clearDocFeatures();
+  const a = docFeatures("缓存命中 test-clear");
+  clearDocFeatures();
+  const b = docFeatures("缓存命中 test-clear");
+  assert.notEqual(a, b, "after clear the features must be rebuilt");
+  assert.equal(docCacheInfo().entries, 1);
+});
+
+test("setDocCacheCap: small cap evicts oldest, info tracks occupancy", () => {
+  clearDocFeatures();
+  setDocCacheCap(20);
+  try {
+    docFeatures("a".repeat(10)); // 10 chars
+    docFeatures("b".repeat(10)); // evicts "a..." (10+10 <= 20 → both fit)
+    assert.equal(docCacheInfo().entries, 2);
+    assert.equal(docCacheInfo().chars, 20);
+    docFeatures("c".repeat(15)); // evicts "a...", then "b..." (15+10 > 20)
+    assert.equal(docCacheInfo().entries, 1);
+    assert.equal(docCacheInfo().chars, 15);
+  } finally {
+    setDocCacheCap(DEFAULT_CAP);
+    clearDocFeatures();
+  }
+});
+
+test("setDocCacheCap: lowering the cap evicts immediately", () => {
+  clearDocFeatures();
+  try {
+    setDocCacheCap(DEFAULT_CAP);
+    docFeatures("x".repeat(100));
+    assert.equal(docCacheInfo().entries, 1);
+    setDocCacheCap(50);
+    assert.equal(docCacheInfo().entries, 0, "oversized-after-lowering doc must be evicted");
+    assert.equal(docCacheInfo().chars, 0);
+  } finally {
+    setDocCacheCap(DEFAULT_CAP);
+    clearDocFeatures();
+  }
+});
+
+test("docs larger than the cap are never cached", () => {
+  clearDocFeatures();
+  try {
+    setDocCacheCap(100);
+    const f = docFeatures("alpha ".repeat(100)); // 600 chars > 100 cap
+    assert.ok(f.tf.has("alpha"), "features are still returned");
+    assert.equal(docCacheInfo().entries, 0, "oversized doc must not enter the cache");
+  } finally {
+    setDocCacheCap(DEFAULT_CAP);
+    clearDocFeatures();
+  }
+});
+
+test("searchBlocks: results identical on warm cache (no score drift)", () => {
+  clearDocFeatures();
+  const docs: SearchDoc[] = [
+    { kind: "block", ref: "b1", text: "缓存服务 命中率 0.87 身份验证失败 请求超时", title: "b1", blockId: "b1", tier: 1, tokens: 100 },
+    { kind: "message", ref: "m1", text: "the auth flow failed twice, then the cache warm-up finished", title: "m1", role: "tool", blockId: "b2", tier: 1, tokens: 50 },
+    { kind: "block", ref: "b2", text: "auth failure 身份验证 cache warmup 缓存预热", title: "b2", blockId: "b2", tier: 1, tokens: 80 },
+  ];
+  const cold = searchBlocks(docs, "缓存 身份验证");
+  const warm = searchBlocks(docs, "缓存 身份验证");
+  assert.deepEqual(warm.map((r) => [r.ref, r.score]), cold.map((r) => [r.ref, r.score]),
+    "cached features must not change scores");
+  assert.ok(cold.length >= 1);
+  clearDocFeatures();
+});
+
+test("single-pass CJK segmentation: run grouping edge cases", () => {
+  // Pins the tokenizer rewrite (one segmenter pass over the whole text,
+  // runs re-derived) against the per-run implementation's token contract.
+  // Expected token sets are the ACTUAL CLDR dictionary outputs (verified on
+  // Node 25 ICU) — do not "fix" them to nicer segmentations.
+  // all-OOV run → bigrams + singles (fallback preserved across the rewrite)
+  const oov = tokenize("㐀㐁㐂", {});
+  assert.deepEqual(oov, ["㐀㐁", "㐁㐂", "㐀", "㐁", "㐂"]);
+  // dictionary run keeps whole words; single chars inside a word-found run are dropped
+  assert.deepEqual(tokenize("身份验证流程", {}), ["身份", "验证", "流程"]);
+  // single CJK char stays a token
+  assert.deepEqual(tokenize("缓", {}), ["缓"]);
+  // mixed: latin + several CJK runs, latin first, runs in text order
+  const mixed = tokenize("cache 缓存 pool 连接池", {});
+  assert.ok(mixed.includes("cache") && mixed.includes("pool"));
+  assert.ok(mixed.indexOf("缓存") !== -1, `缓存 (OOV bigram) missing in ${JSON.stringify(mixed)}`);
+  assert.ok(mixed.indexOf("缓存") < mixed.indexOf("连接"), "run order must follow text order");
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -343,6 +343,8 @@ test("searchBlocksAsync: semantic ranks synonyms by cosine similarity", async ()
 // "behavior is correct": several of these pin known defects until a fix
 // decision is made. Query-side users are LLMs (no typos, retry-capable),
 // so typo/camelCase/single-char gaps are low-value defects, not blockers.
+// NOTE: "defect #1" (2-char CJK queries never reached the fuzzy scorer) was
+// FIXED by the CJK-only gate below — its tests now pin the new behavior.
 // ─────────────────────────────────────────────────────────────────────────
 
 test("stem: authenticate family does not converge (pinned, defect #2)", async () => {
@@ -359,16 +361,57 @@ test("searchBlocks: morphology family only rescued by fuzzy cap (pinned)", () =>
     assert.ok(r[0].score < 0.7, `fuzzy-only rescue must stay under BM25 cap, got ${r[0].score}`);
 });
 
-test("fuzzy: query tokens under 4 chars are filtered out entirely (pinned, defect #1)", () => {
-    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "实现了用户登录认证流程" })));
-    const r = searchBlocks(docs, "登入", { algorithm: "fuzzy" });
-    assert.equal(r.length, 0, "2-char CJK query never reaches the fuzzy scorer");
+test("fuzzy: 2-char CJK query reaches the scorer, full bigram overlap scores 1 (defect #1 fixed)", () => {
+    // 缓存 has no dictionary word in the CLDR zh segmenter — the query would
+    // have been dropped by the old >= 4 gate. The CJK-only gate admits it.
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "缓存策略 redis 层" })));
+    const r = searchBlocks(docs, "缓存", { algorithm: "fuzzy" });
+    assert.equal(r.length, 1, "2-char CJK query must reach the fuzzy scorer");
+    assert.equal(r[0].ref, "b1");
+    assert.equal(r[0].score, 1, "full bigram overlap scores 1.0");
 });
 
-test("searchBlocks: 2-char CJK typo returns nothing end-to-end (pinned; LLM users don't typo)", () => {
+test("fuzzy: 1-char CJK and 2-char Latin queries still filtered (gate is CJK-only)", () => {
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "缓存策略 redis 层" })));
+    assert.equal(searchBlocks(docs, "验", { algorithm: "fuzzy" }).length, 0, "single char cannot form a bigram");
+    assert.equal(searchBlocks(docs, "ok", { algorithm: "fuzzy" }).length, 0, "2-char Latin stays filtered (noise)");
+    assert.equal(searchBlocks(docs, "to", { algorithm: "fuzzy" }).length, 0, "2-char Latin stays filtered (noise)");
+});
+
+test("searchBlocks: 2-char CJK typo (登入 vs 登录) still returns nothing — gram mismatch, not gate", () => {
     const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", topic: "用户认证", summary: "实现了用户登录认证流程" })));
     const r = searchBlocks(docs, "登入");
-    assert.equal(r.length, 0, "BM25 sees no token overlap, fuzzy filters 2-char query");
+    assert.equal(r.length, 0, "BM25 sees no shared token; 登入 is now admitted to fuzzy but shares no bigram with 登录");
+});
+
+test("searchBlocks: 2-char CJK query rescued end-to-end by fuzzy (缓存 → 缓存策略 doc)", () => {
+    // BM25 misses on purpose: 缓存 is not a dictionary word, and the doc's own
+    // tokens are its other dictionary words (策略/redis/层). Only the fuzzy
+    // channel sees the raw-text bigram 缓存 — which is exactly the recall gap
+    // the CJK gate repairs.
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "viz", summary: "可视化 dashboards" }),
+        makeBlock({ blockId: "b2", topic: "cache", summary: "缓存策略 redis 层" }),
+    ));
+    const r = searchBlocks(docs, "缓存");
+    assert.equal(r.length, 1);
+    assert.equal(r[0].ref, "b2", "fuzzy bigram overlap must rescue the cache block");
+    assert.ok(r[0].score > 0, "rescued result must not be filtered");
+    assert.ok(r[0].score <= 0.31, `fuzzy-only rescue caps at W_FUZZY, got ${r[0].score}`);
+});
+
+test("hybrid: CJK phrase still ranks whole-word doc above char-run doc (图表可视化, no leftover noise)", () => {
+    // Regression guard: the pr-rework guarantee must survive the fuzzy gate —
+    // a phrase must rank the fully-matching doc first and must not let the
+    // OOV-run doc's bigram leftovers (可视/视化) outrank it via fuzzy.
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "dash", summary: "可视化" }),
+        makeBlock({ blockId: "b2", topic: "charts", summary: "图表可视化" }),
+    ));
+    const r = searchBlocks(docs, "图表可视化");
+    assert.equal(r[0].ref, "b2", "whole-word doc must win");
+    assert.ok(r[0].score > 0.5, `BM25 carries the full match, got ${r[0].score}`);
+    assert.ok(r.every((x) => x.ref !== "b1") || (r[0].ref === "b2" && r[1]?.ref !== "b2"), "OOV leftovers must not rank first");
 });
 
 test("searchBlocks: single-char query misses dict-word docs, hits OOV docs (pinned, defect #3)", () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -237,6 +237,74 @@ test("hybrid: stemming matches morphological variants", () => {
     assert.equal(r[0].ref, "b1");
 });
 
+test("tokenize: CJK runs become dictionary words, no single-char noise", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize("身份验证流程"), ["身份", "验证", "流程"]);
+    assert.equal(tokenize("身份验证流程").includes("份"), false);
+    assert.equal(tokenize("身份验证流程").includes("证流"), false);
+});
+
+test("tokenize: all-OOV run falls back to bigrams (recall preserved)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    const toks = tokenize("可视化");
+    assert.ok(toks.includes("可视") || toks.includes("视化"), `got ${JSON.stringify(toks)}`);
+});
+
+test("tokenize: Japanese katakana becomes dictionary words, not char-run fragments", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    const toks = tokenize("テスト用の文章です");
+    assert.ok(toks.includes("テスト"), `got ${JSON.stringify(toks)}`);
+    assert.ok(toks.includes("文章"), `got ${JSON.stringify(toks)}`);
+    assert.equal(toks.includes("テス"), false, "katakana must not be split into char runs");
+    assert.equal(toks.includes("スト"), false, "katakana must not be split into char runs");
+});
+
+test("tokenize: Japanese kanji compounds are kept whole, no cross-word fragments", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    const toks = tokenize("日本語の検索テスト");
+    assert.ok(toks.includes("日本語"), `got ${JSON.stringify(toks)}`);
+    assert.equal(toks.includes("索テ"), false, "no cross-word '索テ' fragment");
+});
+
+test("tokenize: Korean hangul becomes dictionary words, no cross-word fragments", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    const toks = tokenize("테스트 문장입니다");
+    assert.ok(toks.includes("테스트"), `got ${JSON.stringify(toks)}`);
+    assert.equal(toks.includes("니다"), false, "no cross-word '니다' fragment");
+});
+
+test("tokenize: single-char query survives via fallback", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize("验"), ["验"]);
+});
+
+test("hybrid: CJK query no longer matches across word boundaries (试验证明 vs 验证)", () => {
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "auth", summary: "用户身份验证通过" }),
+        makeBlock({ blockId: "b2", topic: "experiment", summary: "试验数据采集已完成" }),
+    ));
+    const r = searchBlocks(docs, "试验证明");
+    assert.equal(r[0].ref, "b2", "word-segmented docs must not rank 验证 above 试验");
+});
+
+test("hybrid: dictionary word query hits the doc containing the whole word", () => {
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "i18n", summary: "i18n 国际化 setup with locales" }),
+        makeBlock({ blockId: "b2", topic: "logs", summary: "ELK 日志栈 采集 过滤 存储。结构化日志 JSON。" }),
+    ));
+    const r = searchBlocks(docs, "国际化");
+    assert.equal(r[0].ref, "b1");
+});
+
+test("hybrid: OOV doc still recallable via bigram fallback", () => {
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "dash", summary: "可视化" }),
+        makeBlock({ blockId: "b2", topic: "cache", summary: "缓存策略 redis 层" }),
+    ));
+    const r = searchBlocks(docs, "可视化");
+    assert.equal(r[0].ref, "b1");
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // Async / semantic
 // ─────────────────────────────────────────────────────────────────────────
@@ -267,4 +335,131 @@ test("searchBlocksAsync: semantic ranks synonyms by cosine similarity", async ()
     ]);
     const r = await searchBlocksAsync(docs, "signin", { algorithm: "semantic-syn" });
     assert.equal(r[0].ref, "m1", "semantic catches synonym signin≈login");
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pinned status-quo guards — record CURRENT behavior and fail loudly on
+// drift. A green test means "unchanged from the rework baseline", NOT
+// "behavior is correct": several of these pin known defects until a fix
+// decision is made. Query-side users are LLMs (no typos, retry-capable),
+// so typo/camelCase/single-char gaps are low-value defects, not blockers.
+// ─────────────────────────────────────────────────────────────────────────
+
+test("stem: authenticate family does not converge (pinned, defect #2)", async () => {
+    const { stem } = await import("../src/search/stemmer.js");
+    assert.equal(stem("authenticate"), "authenticate");
+    assert.equal(stem("authenticated"), "authenticat");
+    assert.equal(stem("authentication"), "authenticat");
+});
+
+test("searchBlocks: morphology family only rescued by fuzzy cap (pinned)", () => {
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "authenticate the user account" })));
+    const r = searchBlocks(docs, "authentication");
+    assert.equal(r[0].ref, "b1", "fuzzy bigram overlap still rescues the hit");
+    assert.ok(r[0].score < 0.7, `fuzzy-only rescue must stay under BM25 cap, got ${r[0].score}`);
+});
+
+test("fuzzy: query tokens under 4 chars are filtered out entirely (pinned, defect #1)", () => {
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "实现了用户登录认证流程" })));
+    const r = searchBlocks(docs, "登入", { algorithm: "fuzzy" });
+    assert.equal(r.length, 0, "2-char CJK query never reaches the fuzzy scorer");
+});
+
+test("searchBlocks: 2-char CJK typo returns nothing end-to-end (pinned; LLM users don't typo)", () => {
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", topic: "用户认证", summary: "实现了用户登录认证流程" })));
+    const r = searchBlocks(docs, "登入");
+    assert.equal(r.length, 0, "BM25 sees no token overlap, fuzzy filters 2-char query");
+});
+
+test("searchBlocks: single-char query misses dict-word docs, hits OOV docs (pinned, defect #3)", () => {
+    const docs = blockDocs(stateWithBlocks(
+        makeBlock({ blockId: "b1", topic: "auth", summary: "身份验证流程" }),
+        makeBlock({ blockId: "b2", topic: "viz", summary: "可视化" }),
+    ));
+    const r = searchBlocks(docs, "验");
+    assert.ok(r.every((x) => x.ref !== "b1"), `dict-word doc has no single-char token, got ${JSON.stringify(r)}`);
+    const oov = blockDocs(stateWithBlocks(makeBlock({ blockId: "b3", summary: "验" })));
+    const r2 = searchBlocks(oov, "验");
+    assert.equal(r2[0].ref, "b3", "OOV fallback docs keep single chars, still recallable");
+});
+
+test("tokenize: camelCase is not split (pinned, defect #3)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize("syncBlocks"), ["syncblocks"]);
+});
+
+test("searchBlocks: space-separated camelCase query rescued by fuzzy cap (pinned)", () => {
+    const docs = blockDocs(stateWithBlocks(makeBlock({ blockId: "b1", summary: "syncBlocks registry walk" })));
+    const r = searchBlocks(docs, "sync blocks");
+    assert.equal(r[0].ref, "b1");
+    assert.ok(r[0].score < 0.7, `single camelCase token can't be BM25-hit via 'sync', got ${r[0].score}`);
+});
+
+test("hybrid: fuzzy-only full overlap caps at 0.3 (pinned weight split)", () => {
+    const docs = messageDocs([
+        { ref: "m1", role: "assistant", text: "auth token refresh", blockId: "b1" },
+        { ref: "m2", role: "assistant", text: "tokanxyz", blockId: "b2" },
+    ]);
+    const r = searchBlocks(docs, "tokan");
+    assert.equal(r[0].ref, "m2", "fuzzy full overlap wins");
+    assert.ok(r[0].score <= 0.31, `fuzzy-only score stuck at W_FUZZY cap, got ${r[0].score}`);
+});
+
+test("searchBlocks: exact BM25 term hit dominates fuzzy-only overlap (weights pinned)", () => {
+    const docs = messageDocs([
+        { ref: "m1", role: "assistant", text: "tokenized", blockId: "b1" },
+        { ref: "m2", role: "assistant", text: "token", blockId: "b2" },
+    ]);
+    const r = searchBlocks(docs, "token");
+    assert.equal(r[0].ref, "m2", "exact 'token' beats 'tokenized' (stem splits -ized, pinned)");
+    assert.ok(r[0].score >= 0.7, `BM25 channel carries exact hit, got ${r[0].score}`);
+});
+
+test("preview: anchored on FIRST hit term only, later terms ignored (pinned, defect #6)", () => {
+    const text = "a".repeat(20) + " cache strategy " + "b".repeat(40) + " redis config";
+    const r = searchBlocks(messageDocs([{ ref: "m1", role: "assistant", text, blockId: "b1" }]), "cache redis", { previewLength: 40 });
+    const preview = r[0].preview;
+    assert.ok(preview.includes("cache"), `preview centers first hit: ${preview}`);
+    assert.ok(!preview.includes("redis"), `second hit term left out of window: ${preview}`);
+});
+
+test("tokenize: empty / punctuation / pure digits (edge)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize(""), []);
+    assert.deepEqual(tokenize("!! ... "), []);
+    assert.deepEqual(tokenize("4096"), [], "leading-digit run fails LATIN_WORD first alt, single digits filtered");
+    assert.deepEqual(tokenize("value=4096"), ["value"]);
+});
+
+test("tokenize: digits inside CJK run dropped (edge)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    const toks = tokenize("检测到3个异常");
+    assert.ok(toks.includes("检测") || toks.includes("检测到"), `got ${JSON.stringify(toks)}`);
+    assert.ok(toks.includes("异常"), `got ${JSON.stringify(toks)}`);
+    assert.equal(toks.includes("3"), false, "digit is not CJK, never tokenized");
+});
+
+test("tokenize: lone single char survives, in-word single chars drop (asymmetry pinned)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize("验"), ["验"], "fallback keeps single-char query");
+    assert.equal(tokenize("身份验证流程").includes("份"), false, "segmented words drop interior chars");
+});
+
+test("tokenize: stem flag leaves CJK untouched (invariance)", async () => {
+    const { tokenize } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(tokenize("身份验证", { stem: true }), tokenize("身份验证", { stem: false }));
+});
+
+test("charBigrams: pairs, whitespace filtered, short input empty", async () => {
+    const { charBigrams } = await import("../src/search/tokenizer.js");
+    assert.deepEqual(charBigrams("登录"), ["登录"]);
+    assert.deepEqual(charBigrams("可视 化"), ["可视"]);
+    assert.deepEqual(charBigrams("a"), []);
+});
+
+test("tfMap: counts per token, stems by flag", async () => {
+    const { tfMap } = await import("../src/search/tokenizer.js");
+    const m = tfMap("token token 身份", true);
+    assert.equal(m.get("token"), 2);
+    assert.equal(m.get("身份"), 1);
 });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -397,6 +397,12 @@ test("searchBlocks: 2-char CJK query rescued end-to-end by fuzzy (缓存 → 缓
     assert.equal(r.length, 1);
     assert.equal(r[0].ref, "b2", "fuzzy bigram overlap must rescue the cache block");
     assert.ok(r[0].score > 0, "rescued result must not be filtered");
+    // Fuzzy-only rescue scores exactly W_FUZZY (0.3) — but ONLY while the ICU
+    // dictionary keeps 缓存 a non-word and BM25 misses. That is deliberate:
+    // if a Node/ICU bump starts segmenting 缓存 as a dictionary word, BM25
+    // takes over and this assertion turns red. The red IS the signal that the
+    // dictionary changed — don't paper over it; decide then (e.g. swap the
+    // fixture to a word the dictionary still doesn't know).
     assert.ok(r[0].score <= 0.31, `fuzzy-only rescue caps at W_FUZZY, got ${r[0].score}`);
 });
 


### PR DESCRIPTION
## 一句话摘要（看完这段就够了）

搜索里的中文分词一直用"两字一刀"的土办法：`身份验证流程` 被切成 13 块小碎片，导致查询 `试验证明` 会假命中一块含"验证"的认证块（碎片恰好拼出假词）；而且碎得越多，BM25 的长度归一化越吃亏，真正的 Redis 缓存块被埋到第 4 名。

**这个 PR 把中文分词换成浏览器自带的 `Intl.Segmenter` 词典分词**：中文按真实词切（`身份`/`验证`/`流程`），词典认不出的生词（如 `可视化`）才退回二元组+单字，保住召回；日文假名、韩文谚文顺带受益。基准 MRR **0.862 → 0.898**，失败查询 9 → 6（剩下的全是同义词/跨语言，只有语义通道能解）。

另外顺带修了一条 fuzzy 模糊匹配的门槛：以前**小于 4 个字符的查询词压根不参与模糊匹配**，可中文词大多正好 2 个字（`缓存`/`登录`），等于把整条中文查询路堵死——`缓存` 直接搜不到。现在改成按文字类型区分：**2 字中文查询可以进模糊通道**，英文 2 字词（`to`/`of`）依然是噪声照旧过滤，**英文行为一行没动**。基准复跑零回归，`缓存` 这类查询重新能搜到了。

## 改动概要（直白版）

1. 中文分词：碎片式二元组 → 词典整词；只对"整段全是生词"的文本退回二元组。
2. 清掉了 3.1× 的 token 膨胀（15 词 → 46 碎片），BM25 长度归一化和 IDF 恢复健康。
3. 修复 bench 脚本里一个必崩的旧 API 调用，并补了两条旧分词器必挂的对抗性查询。
4. +19 条回归测试钉住现状行为（`npm test` 现有 376 条全绿）；两条"fuzzy 过滤短查询"的钉死测试因规则修改而被新测试取代。
5. fuzzy 查询门槛按脚本区分（仅放行 2 字以上 CJK），基准零回归。

## 设计立场：搜索是给 LLM 用的，召回 > 精度

搜索的输出是喂给 LLM 的**候选池**，不是给人看的最终榜单——LLM 自己会逐条判断相关性。这个前提决定了权衡方向：

- **漏召回是硬损失**：结果里没有的东西，LLM 再聪明也看不到；**多召回只是软成本**：多几个候选，由 LLM 判断即可。
- 这个立场已内建在 hybrid 加权里（`0.7·BM25 + 0.3·fuzzy`）：BM25 供精度、fuzzy 供召回，fuzzy 通道天然被压到 0.3 封顶——它的定位就是"宁可多给候选，不可漏掉"。本次放宽 fuzzy 门槛（放行 2 字 CJK 查询）正是把这个立场执行到底。
- 推论：剩余的单字查询失配、2 字 typo（`登入`≠`登录`）等召回缺口都低于 LLM 的自愈阈值（LLM 会换词重试），判定为低价值、以钉死测试的形式保留现状；真正补不上的同义词 / 跨语言缺口只有 `semantic` 通道能解。
- 边界：候选池受 `limit: 10` + `minScore: 0.01` 约束，语料是块摘要（规模有限），低分候选不会失控。

## Motivation

Bigram + unigram CJK tokenization (`身份验证流程` → 13 fragments + 9 singles) caused:

- **Cross-word false fragments**: `试验证明` produced a fake `验证` bigram, hitting auth blocks instead of the test-record block
- **Token bloat ~3.1×** (15 words → 46 fragments): polluted BM25 length normalization & IDF, burying the true Redis block (`b19`) to rank #4 on `redis` queries
- **Single-char noise** in both documents and queries

## Changes

1. **`src/search/tokenizer.ts`** — `Intl.Segmenter('zh')` word segmentation as the primary CJK channel (no single-char tokens). Falls back to overlapping bigrams + singles for OOV runs, preserving recall and single-char query support. `tokenize`/`tfMap` signatures unchanged → zero caller changes. Also benefits ja/ko (the CJK char class includes kana & hangul). The CJK char class is now **exported** so other modules reuse the single definition.
2. **`bench/search/bench.ts`** — fixed stale API call `searchBlocks(state, …)` → `searchBlocks(blockDocs(state), …)` (was guaranteed `TypeError` at runtime).
3. **`bench/search/corpus.ts`** — +2 adversarial CJK queries (`试验证明`→b31, `图表可视化`→b32) that the old tokenizer fails; corrected `redis` expectation b11→b19 (b19 is the actual Redis cache block, previously buried by length normalization).
4. **`tests/search.test.ts`** — +16 status-quo regression tests pinning baseline behavior (stem 3-form inconsistency, single-char query behavior, camelCase, hybrid 0.3/0.7 caps, preview anchor, boundary cases) + 3 multilingual (ja/ko) cases. Follow-up commit replaces the two "fuzzy filters <4-char queries" pins (that defect is fixed, see #6) with 4 tests for the new CJK gate, the `缓存` end-to-end rescue, the Latin scope guard, and the `图表可视化` no-regression guard.
5. **Stale benchmark comments** updated in `SEARCH.md` + `bm25.ts`/`fuzzy.ts`/`hybrid.ts` to match the 32-block / 48-query benchmark.
6. **`fuzzy.ts` — script-aware query-token gate** (follow-up, CJK-only): `t.length >= 4 || (t.length >= 2 && CJK.test(t))`. The old `>= 4` rule filtered out 2-char CJK words (`缓存`/`登录`/`身份`) before they reached the scorer — but most CJK words ARE exactly 2 characters, so a Latin-style length rule starved the only recall channel for a whole script (bench: `缓存` returned nothing). The gate is language-agnostic within the CJK class (hanzi + kana + hangul), so ja/ko benefit identically: `テスト` (3 kana) and `가다` (2 hangul syllables) were below the old `>= 4` bar too and are now admitted. Latin is **frozen**: 2–3-char stop-words (`to`/`of`/`us`) remain noise; 1-char CJK (kana particles like `の`, single hangul syllables) stays excluded — a single char cannot form a bigram. SEARCH.md documents the gate.

## Benchmark (32 blocks, 48 queries, identical labels)

| metric | old (bigram) | new (Segmenter) |
|---|---|---|
| MRR | 0.862 | **0.898** (+0.036) |
| R@1 | 0.813 | **0.875** (+0.062) |
| R@3 | 0.896 | **0.917** (+0.021) |
| failures | 9/48 | **6/48** (all pure-semantic) |

Verified by re-run after change #6: identical (R@1 42/48 = 0.875, MRR 0.898, R@3 0.917) — **zero regression**; `缓存` was additionally recovered via the fuzzy channel (fuzzy-only 0.3 cap).

The remaining 6 failures are synonyms / cross-language — solvable only via the optional `semantic` algorithm.

## Verification

- `npm test`: 376 tests pass, 0 failures
- `npm run typecheck`: clean
- `npm run build`: success
- Test robustness: the `缓存` rescue test asserts `score <= 0.31` — a
  fuzzy-only rescue must score exactly W_FUZZY. This only holds while 缓存
  stays out of the CLDR dictionary; whether it does is Node/ICU-version
  dependent. If a bump starts segmenting 缓存 as a word, BM25 takes over and
  the assertion turns red **on purpose** — the red is the signal that the
  dictionary changed, and the fix is to swap the fixture to a word the
  dictionary still doesn't know. The test is a drift sentinel, not a
  tolerance test.
- Mutation check: reverting the `-ation` stem rule makes the new stem tests fail → the pin tests actually catch drift