### PR TITLE
Release v0.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.28",
+    "version": "0.0.29",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
版本 v0.0.29:仅 package.json 版本号 0.0.28 → 0.0.29(沿 release 惯例)。

## 自 v0.0.28 以来的变更(PR #87)

**search**
- CJK tokenizer 改用 `Intl.Segmenter`(CLDR 词典分词;全 OOV 序列回退 bigram + 单字)
- 2 字 CJK 查询准入 fuzzy 通道(Latin 侧不变)
- **性能**:单遍分段(消除 ~3µs/次 `segment()` 调用开销)+ 每 doc 特征缓存(`doc-cache.ts`,8M 源字符上限、FIFO)
  - 5MB 语料端到端:冷 3069ms → 622ms,热 3019ms → 17ms;质量 bench 逐分不变(hybrid MRR 0.898 / R@1 0.875 / R@3 0.917)
- 测试:status-quo 回归钉住基线 + ICU 词典漂移哨兵(385/385)
- 文档:SEARCH.md / hybrid.ts 基准表与最终代码测量同步