### PR TITLE
fix(boundaries): snap consumed anchors to the active owning block (compress livelock)

### DIFF
--- a/src/boundaries.ts
+++ b/src/boundaries.ts
@@ -72,6 +72,7 @@ export interface ResolvedRange {
   nestedBlockIds: string[];
   boundaryKind: BoundaryKind;
   protectedGaps: number[];
+  snappedBoundaries: string[];
 }
 
 export function resolveBoundaries(
@@ -90,8 +91,13 @@ export function resolveBoundaries(
     indexByRawId.set(message.id, index),
   );
 
-  let startIndex = resolveAnchorIndex(start, input.state, indexByRawId, "start");
-  let endIndex = resolveAnchorIndex(end, input.state, indexByRawId, "end");
+  let snappedBoundaries: string[] = [];
+  const startAnchor = resolveAnchorIndex(start, input.state, indexByRawId, "start");
+  if (startAnchor.snapped) snappedBoundaries.push(startAnchor.snapped);
+  const endAnchor = resolveAnchorIndex(end, input.state, indexByRawId, "end");
+  if (endAnchor.snapped) snappedBoundaries.push(endAnchor.snapped);
+  let startIndex = startAnchor.index;
+  let endIndex = endAnchor.index;
 
   if (startIndex > endIndex) {
     [startIndex, endIndex] = [endIndex, startIndex];
@@ -127,7 +133,13 @@ export function resolveBoundaries(
     nestedBlockIds,
     boundaryKind,
     protectedGaps,
+    snappedBoundaries,
   };
+}
+
+interface AnchorResolution {
+  index: number;
+  snapped: string | null;
 }
 
 function resolveAnchorIndex(
@@ -135,7 +147,7 @@ function resolveAnchorIndex(
   state: CompressionState,
   indexByRawId: Map<string, number>,
   endpoint: "start" | "end",
-): number {
+): AnchorResolution {
   const label = endpoint === "start" ? "startId" : "endId";
   if (boundary.kind === "message") {
     const rawId =
@@ -149,14 +161,21 @@ function resolveAnchorIndex(
       );
     }
     const index = indexByRawId.get(rawId);
-    if (index === undefined) {
-      throw new BoundaryNotFoundError(
-        "consumed",
-        endpoint,
-        `${label}="${boundary.raw}" not found in visible context (likely consumed by an existing block).`,
-      );
+    if (index !== undefined) {
+      return { index, snapped: null };
     }
-    return index;
+    const owner = activeOwnerAnchor(state, [rawId], indexByRawId);
+    if (owner !== null) {
+      return {
+        index: owner,
+        snapped: `${label}="${boundary.raw}" refers to a message already compressed into an active block — anchored to that block's summary instead.`,
+      };
+    }
+    throw new BoundaryNotFoundError(
+      "consumed",
+      endpoint,
+      `${label}="${boundary.raw}" not found in visible context (likely consumed by an existing block).`,
+    );
   }
 
   const block = blockById(state, `b${boundary.numericId}`);
@@ -167,6 +186,19 @@ function resolveAnchorIndex(
       `${label}="b${boundary.numericId}" does not exist in this session (typo or wrong session) — run acp_status for current refs.`,
     );
   }
+  if (block.active) {
+    const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
+    if (anchor !== null) {
+      return { index: anchor, snapped: null };
+    }
+  }
+  const owner = activeOwnerAnchor(state, block.effectiveMessageIds, indexByRawId);
+  if (owner !== null) {
+    return {
+      index: owner,
+      snapped: `${label}="b${boundary.numericId}" was consumed by a higher-tier block — anchored to the active block covering its content instead.`,
+    };
+  }
   if (!block.active) {
     throw new BoundaryNotFoundError(
       "consumed",
@@ -174,15 +206,36 @@ function resolveAnchorIndex(
       `${label}="b${boundary.numericId}" not found in visible context (block distilled/consumed by a higher-tier block).`,
     );
   }
-  const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
-  if (anchor === null) {
-    throw new BoundaryNotFoundError(
-      "consumed",
-      endpoint,
-      `${label}="b${boundary.numericId}" not found in visible context (block messages consumed by a higher-tier block).`,
-    );
+  throw new BoundaryNotFoundError(
+    "consumed",
+    endpoint,
+    `${label}="b${boundary.numericId}" not found in visible context (block messages consumed by a higher-tier block).`,
+  );
+}
+
+/**
+ * Snap a consumed anchor to the active block that now owns its content.
+ * Throwing instead dead-ends compress calls that follow nudge instructions
+ * with older (already-distilled) refs — the livelock in dog/billion-context-pi#32.
+ */
+function activeOwnerAnchor(
+  state: CompressionState,
+  ownedIds: string[],
+  indexByRawId: Map<string, number>,
+): number | null {
+  if (ownedIds.length === 0) return null;
+  const owned = new Set(ownedIds);
+  let best: number | null = null;
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
+    if (anchor === null) continue;
+    const ownsContent = block.effectiveMessageIds.some((id) => owned.has(id));
+    if (ownsContent && (best === null || anchor < best)) {
+      best = anchor;
+    }
   }
-  return anchor;
+  return best;
 }
 
 function formatPaddedRef(index: number): string {

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -124,6 +124,11 @@ function rangeError(
   return `range ${spec.startRef}..${spec.endRef}: ${message}`;
 }
 
+function numericBlockId(id: string): number {
+  const parsed = /^b(\d+)$/.exec(id);
+  return parsed ? Number(parsed[1]) : 0;
+}
+
 export function createCore(ports: Ports = {}): CompressionCore {
   const countTokens = ports.countTokens ?? defaultCountTokens;
 
@@ -234,9 +239,16 @@ export function createCore(ports: Ports = {}): CompressionCore {
         }
       }
       if (!hasBlockBoundaryRange && totalRangeChars < input.config.compress.minCompressRange) {
+        const live = activeBlocks(state)
+          .map((b) => b.blockId)
+          .sort((x, y) => numericBlockId(x) - numericBlockId(y));
+        const liveHint =
+          live.length > 0
+            ? ` Current active blocks span ${live[0]}..${live[live.length - 1]} — retry with startId/endId set to active block IDs in that span.`
+            : "";
         const gateMessage =
           consumedRanges.length > 0
-            ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do — run acp_status to see current compressible ranges.`
+            ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do.${liveHint}`
             : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {
           state: input.state,
@@ -264,6 +276,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
         errors.push(rangeError(spec, resolution.error.message));
         continue;
       }
+      warnings.push(...resolution.resolved.snappedBoundaries);
       try {
         const outcome = applySingleRange({
           spec,

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -337,7 +337,7 @@ test("retrying a consumed range reports already-compressed guidance, not too-sma
   assert.equal(retry.result.blocksCreated, 0);
   assert.equal(retry.result.errors.length, 1);
   assert.match(retry.result.errors[0]!, /already compressed/);
-  assert.match(retry.result.errors[0]!, /run acp_status/);
+  assert.match(retry.result.errors[0]!, /Current active blocks span/);
   assert.doesNotMatch(retry.result.errors[0]!, /Total compressible content too small/);
 });
 
@@ -549,5 +549,223 @@ test("resolveBoundaries throws typed BoundaryNotFoundError with kind and endpoin
     () => resolveBoundaries({ startRef: "m00002", endRef: "m00003", messages: pruned, state: after }),
     (e: unknown) =>
       e instanceof BoundaryNotFoundError && e.kind === "consumed" && e.endpoint === "start",
+  );
+});
+
+test("consumed block anchor snaps to the active owning block instead of failing the call (#32 livelock)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "old one"),
+    msg("b", "old two"),
+    msg("c", "raw c"),
+    msg("d", "raw d"),
+    msg("e", "raw e"),
+    msg("f", "raw f"),
+    msg("g", "raw g"),
+    msg("h", "raw h"),
+    msg("i", "raw i"),
+    msg("j", "raw j"),
+    msg("k", "recent one"),
+    msg("l", "recent two"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b2",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s2",
+      directMessageIds: ["a"],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: false,
+    },
+    {
+      blockId: "b50",
+      runId: "r1",
+      tier: 2,
+      topic: "t",
+      summary: "t2 distill",
+      directMessageIds: [],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: ["b2"],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k", "l"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+  state.nextBlockId = 111;
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "b2", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages,
+    state,
+    config: config(),
+  });
+
+  assert.equal(result.result.blocksCreated, 1, JSON.stringify(result.result));
+  assert.equal(result.result.errors.length, 0);
+  assert.ok(
+    result.result.warnings.some((w) =>
+      w.includes('startId="b2" was consumed by a higher-tier block'),
+    ),
+    `expected snap warning in: ${JSON.stringify(result.result.warnings)}`,
+  );
+  const created = result.state.blocks.find((b) => b.blockId === "b111");
+  assert.ok(created, "new block allocated after b110");
+  assert.equal(created!.tier, 2);
+  assert.deepEqual(created!.directBlockIds, ["b110"]);
+  assert.equal(result.state.blocks.find((b) => b.blockId === "b110")!.active, false);
+  assert.equal(result.state.blocks.find((b) => b.blockId === "b50")!.active, true);
+});
+
+test("consumed message anchor snaps to the active block covering it", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const full = [
+    msg("a", "old one"),
+    msg("b", "old two"),
+    msg("c", "raw c"),
+    msg("d", "raw d"),
+    msg("e", "raw e"),
+    msg("f", "raw f"),
+    msg("g", "raw g"),
+    msg("h", "raw h"),
+    msg("i", "raw i"),
+    msg("j", "raw j"),
+    msg("k", "recent one"),
+    msg("l", "recent two"),
+  ];
+  state.messageRefs = assignRefs(full, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b50",
+      runId: "r1",
+      tier: 2,
+      topic: "t",
+      summary: "t2 distill",
+      directMessageIds: ["c"],
+      effectiveMessageIds: ["a", "b", "c"],
+      directBlockIds: ["b2"],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k", "l"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+  const visible = full.slice(2);
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages: visible,
+    state,
+    config: config(),
+  });
+
+  assert.equal(result.result.blocksCreated, 1, JSON.stringify(result.result));
+  assert.equal(result.result.errors.length, 0);
+  assert.ok(
+    result.result.warnings.some((w) =>
+      w.includes('startId="m00001" refers to a message already compressed'),
+    ),
+    `expected snap warning in: ${JSON.stringify(result.result.warnings)}`,
+  );
+});
+
+test("gate error names the current active block span when anchors stay consumed", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [msg("a", "x"), msg("b", "y"), msg("k", "z")];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b2",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s2",
+      directMessageIds: ["a"],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: false,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "b2", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages,
+    state,
+    config: config({ compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 } }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.equal(result.result.errors.length, 1);
+  assert.match(
+    result.result.errors[0]!,
+    /Requested range\(s\) already compressed \(e\.g\. b2\.\.b110\)/,
+  );
+  assert.match(
+    result.result.errors[0]!,
+    /Current active blocks span b110\.\.b110 — retry with startId\/endId set to active block IDs in that span\./,
   );
 });


### PR DESCRIPTION
## Root cause (from user log `acp (3).log`, session 01a00239)

At 04:12 the session overflowed its 272k window (312418 tokens = 115%). The emergency nudge fired every 60–90s for 4+ hours. The model obeyed and called `compress` with `startId=b2..endId=b110` — but `b2` was an INACTIVE tier-1 block (long since distilled into a tier-2 block). `resolveAnchorIndex` threw `BoundaryNotFoundError(kind=consumed)`, the whole call was classified consumed, and the min-compress gate returned:

```
Requested range(s) already compressed (e.g. b2..b110); remaining compressible content 0 chars < min 5000. Nothing to do
```

**177 consecutive rejections, zero progress, context frozen at ~279k tokens.** The error echoes the stale refs back at the model, so it retried the same range while the emergency nudge kept demanding compression — a livelock.

## Fix

1. **`src/boundaries.ts` — anchor snap.** A consumed anchor (block or message) now resolves to the **active block that currently owns that content** (earliest visible anchor) instead of throwing. `ResolvedRange.snappedBoundaries` records what was snapped and why. A consumed anchor with no active owner still throws as before.
2. **`src/compress.ts` — actionable gate error.** When ranges stay consumed, the error now names the live span: `Current active blocks span b3..b108 — retry with startId/endId set to active block IDs in that span.` instead of echoing stale refs.

Semantics: an active-block anchor already resolves to the block's earliest visible message; the snap extends that same convention to consumed refs. A mixed range (T2 owner + T1 targets) picks `targetTier = min(nested tiers)`, so the T2 owner stays active and only T1 blocks are consumed — conservative, no double-distill.

## Tests

- `tests/compress.test.ts`: 3 new tests (block-anchor snap reproducing the #32 livelock shape, message-anchor snap, gate error live-span hint) + 1 updated for the new gate wording.
- Full suite: **388 pass, 0 fail**. `tsc --noEmit` clean.
- Cross-repo pre-validation: dist overlaid onto billion-context-pi (both top-level and billion-context-kit nested copies) — pi suite **344 pass**, `npm run build` success.

Fixes the livelock reported in dog/billion-context-pi#32.