### PR TITLE
fix(nudge): wire tiers.*Trigger block-count distillation (T1 treadmill) + snap consumed anchors

### DIFF
--- a/src/boundaries.ts
+++ b/src/boundaries.ts
@@ -72,6 +72,7 @@ export interface ResolvedRange {
   nestedBlockIds: string[];
   boundaryKind: BoundaryKind;
   protectedGaps: number[];
+  snappedBoundaries: string[];
 }
 
 export function resolveBoundaries(
@@ -90,8 +91,13 @@ export function resolveBoundaries(
     indexByRawId.set(message.id, index),
   );
 
-  let startIndex = resolveAnchorIndex(start, input.state, indexByRawId, "start");
-  let endIndex = resolveAnchorIndex(end, input.state, indexByRawId, "end");
+  let snappedBoundaries: string[] = [];
+  const startAnchor = resolveAnchorIndex(start, input.state, indexByRawId, "start");
+  if (startAnchor.snapped) snappedBoundaries.push(startAnchor.snapped);
+  const endAnchor = resolveAnchorIndex(end, input.state, indexByRawId, "end");
+  if (endAnchor.snapped) snappedBoundaries.push(endAnchor.snapped);
+  let startIndex = startAnchor.index;
+  let endIndex = endAnchor.index;
 
   if (startIndex > endIndex) {
     [startIndex, endIndex] = [endIndex, startIndex];
@@ -127,7 +133,13 @@ export function resolveBoundaries(
     nestedBlockIds,
     boundaryKind,
     protectedGaps,
+    snappedBoundaries,
   };
+}
+
+interface AnchorResolution {
+  index: number;
+  snapped: string | null;
 }
 
 function resolveAnchorIndex(
@@ -135,7 +147,7 @@ function resolveAnchorIndex(
   state: CompressionState,
   indexByRawId: Map<string, number>,
   endpoint: "start" | "end",
-): number {
+): AnchorResolution {
   const label = endpoint === "start" ? "startId" : "endId";
   if (boundary.kind === "message") {
     const rawId =
@@ -149,14 +161,21 @@ function resolveAnchorIndex(
       );
     }
     const index = indexByRawId.get(rawId);
-    if (index === undefined) {
-      throw new BoundaryNotFoundError(
-        "consumed",
-        endpoint,
-        `${label}="${boundary.raw}" not found in visible context (likely consumed by an existing block).`,
-      );
+    if (index !== undefined) {
+      return { index, snapped: null };
     }
-    return index;
+    const owner = activeOwnerAnchor(state, [rawId], indexByRawId);
+    if (owner !== null) {
+      return {
+        index: owner,
+        snapped: `${label}="${boundary.raw}" refers to a message already compressed into an active block — anchored to that block's summary instead.`,
+      };
+    }
+    throw new BoundaryNotFoundError(
+      "consumed",
+      endpoint,
+      `${label}="${boundary.raw}" not found in visible context (likely consumed by an existing block).`,
+    );
   }
 
   const block = blockById(state, `b${boundary.numericId}`);
@@ -167,6 +186,19 @@ function resolveAnchorIndex(
       `${label}="b${boundary.numericId}" does not exist in this session (typo or wrong session) — run acp_status for current refs.`,
     );
   }
+  if (block.active) {
+    const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
+    if (anchor !== null) {
+      return { index: anchor, snapped: null };
+    }
+  }
+  const owner = activeOwnerAnchor(state, block.effectiveMessageIds, indexByRawId);
+  if (owner !== null) {
+    return {
+      index: owner,
+      snapped: `${label}="b${boundary.numericId}" was consumed by a higher-tier block — anchored to the active block covering its content instead.`,
+    };
+  }
   if (!block.active) {
     throw new BoundaryNotFoundError(
       "consumed",
@@ -174,15 +206,36 @@ function resolveAnchorIndex(
       `${label}="b${boundary.numericId}" not found in visible context (block distilled/consumed by a higher-tier block).`,
     );
   }
-  const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
-  if (anchor === null) {
-    throw new BoundaryNotFoundError(
-      "consumed",
-      endpoint,
-      `${label}="b${boundary.numericId}" not found in visible context (block messages consumed by a higher-tier block).`,
-    );
+  throw new BoundaryNotFoundError(
+    "consumed",
+    endpoint,
+    `${label}="b${boundary.numericId}" not found in visible context (block messages consumed by a higher-tier block).`,
+  );
+}
+
+/**
+ * Snap a consumed anchor to the active block that now owns its content.
+ * Throwing instead dead-ends compress calls that follow nudge instructions
+ * with older (already-distilled) refs — the livelock in dog/billion-context-pi#32.
+ */
+function activeOwnerAnchor(
+  state: CompressionState,
+  ownedIds: string[],
+  indexByRawId: Map<string, number>,
+): number | null {
+  if (ownedIds.length === 0) return null;
+  const owned = new Set(ownedIds);
+  let best: number | null = null;
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    const anchor = earliestIndexOfIds(block.effectiveMessageIds, indexByRawId);
+    if (anchor === null) continue;
+    const ownsContent = block.effectiveMessageIds.some((id) => owned.has(id));
+    if (ownsContent && (best === null || anchor < best)) {
+      best = anchor;
+    }
   }
-  return anchor;
+  return best;
 }
 
 function formatPaddedRef(index: number): string {

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -124,6 +124,11 @@ function rangeError(
   return `range ${spec.startRef}..${spec.endRef}: ${message}`;
 }
 
+function numericBlockId(id: string): number {
+  const parsed = /^b(\d+)$/.exec(id);
+  return parsed ? Number(parsed[1]) : 0;
+}
+
 export function createCore(ports: Ports = {}): CompressionCore {
   const countTokens = ports.countTokens ?? defaultCountTokens;
 
@@ -234,9 +239,16 @@ export function createCore(ports: Ports = {}): CompressionCore {
         }
       }
       if (!hasBlockBoundaryRange && totalRangeChars < input.config.compress.minCompressRange) {
+        const live = activeBlocks(state)
+          .map((b) => b.blockId)
+          .sort((x, y) => numericBlockId(x) - numericBlockId(y));
+        const liveHint =
+          live.length > 0
+            ? ` Current active blocks span ${live[0]}..${live[live.length - 1]} — retry with startId/endId set to active block IDs in that span.`
+            : "";
         const gateMessage =
           consumedRanges.length > 0
-            ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do — run acp_status to see current compressible ranges.`
+            ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do.${liveHint}`
             : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {
           state: input.state,
@@ -264,6 +276,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
         errors.push(rangeError(spec, resolution.error.message));
         continue;
       }
+      warnings.push(...resolution.resolved.snappedBoundaries);
       try {
         const outcome = applySingleRange({
           spec,

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -994,7 +994,10 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   // priority and picks the tier with the MAX pending. Non-emergency defaults to
   // T1; T2 and T3 override when each crossed the shared 1.5x threshold AND
   // exceeds the effective pending of every lower tier (T2 > T1 effective;
-  // T3 > T2 and > T1 effective).
+  // T3 > T2 and > T1 effective), OR when the lower-tier BLOCK COUNT crossed
+  // tiers.tier2Trigger/tier3Trigger — in active sessions summary mass always
+  // loses the token race to fresh content, so without the block-count trigger
+  // T1 blocks accumulate forever (the "T1 treadmill").
   const tier2Threshold = Math.round(
     nudgeGrowthTokens * (config.nudge.tier2GrowthMultiplier ?? 1.5),
   );
@@ -1037,30 +1040,36 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     if (t1Eff >= nudgeGrowthTokens) {
       injectedTier = 1;
       injectedReason = `T1 effective ${t1Eff} >= ${nudgeGrowthTokens}, growth ${growthSinceReference}, usage ${Math.round(usage * 100)}%`;
-    } else if (
-      config.tiers.enabled &&
-      t2Pen >= tier2Threshold &&
-      t2Pen > t1Eff
-    ) {
-      const lastShown = state.nudge.lastShownByTier[2] ?? 0;
-      const cadenceMet =
-        lastShown === 0 || tokenCount - lastShown >= growthFloor;
-      if (cadenceMet) {
-        injectedTier = 2;
-        injectedReason = `T2 distill ready: ${tiers[2]!.targetBlocks.length} tier-1 blocks (${t2Pen} tokens) >= ${tier2Threshold} (1.5x) and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
-      }
-    } else if (
-      config.tiers.enabled &&
-      t3Pen >= tier2Threshold &&
-      t3Pen > t2Pen &&
-      t3Pen > t1Eff
-    ) {
-      const lastShown = state.nudge.lastShownByTier[3] ?? 0;
-      const cadenceMet =
-        lastShown === 0 || tokenCount - lastShown >= growthFloor;
-      if (cadenceMet) {
-        injectedTier = 3;
-        injectedReason = `T3 condense ready: ${tiers[3]!.targetBlocks.length} tier-2 blocks (${t3Pen} tokens) >= ${tier2Threshold} (1.5x) and > T2 ${t2Pen} and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
+    } else if (config.tiers.enabled) {
+      const t1Count = tiers[2]!.targetBlocks.length;
+      const t2Count = tiers[3]!.targetBlocks.length;
+      const t2ByMass = t2Pen >= tier2Threshold && t2Pen > t1Eff;
+      const t2ByCount = t1Count >= config.tiers.tier2Trigger;
+      if (t2ByMass || t2ByCount) {
+        const lastShown = state.nudge.lastShownByTier[2] ?? 0;
+        const cadenceMet =
+          lastShown === 0 || tokenCount - lastShown >= growthFloor;
+        if (cadenceMet) {
+          injectedTier = 2;
+          injectedReason = t2ByMass
+            ? `T2 distill ready: ${t1Count} tier-1 blocks (${t2Pen} tokens) >= ${tier2Threshold} (1.5x) and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`
+            : `T2 distill ready (block count): ${t1Count} tier-1 blocks (mass ${t2Pen} tokens) >= trigger ${config.tiers.tier2Trigger}, T1 effective ${t1Eff} — summary mass loses the token race in active sessions, so cap block accumulation early, usage ${Math.round(usage * 100)}%`;
+        }
+      } else {
+        const t3ByMass =
+          t3Pen >= tier2Threshold && t3Pen > t2Pen && t3Pen > t1Eff;
+        const t3ByCount = t2Count >= config.tiers.tier3Trigger;
+        if (t3ByMass || t3ByCount) {
+          const lastShown = state.nudge.lastShownByTier[3] ?? 0;
+          const cadenceMet =
+            lastShown === 0 || tokenCount - lastShown >= growthFloor;
+          if (cadenceMet) {
+            injectedTier = 3;
+            injectedReason = t3ByMass
+              ? `T3 condense ready: ${t2Count} tier-2 blocks (${t3Pen} tokens) >= ${tier2Threshold} (1.5x) and > T2 ${t2Pen} and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`
+              : `T3 condense ready (block count): ${t2Count} tier-2 blocks (mass ${t3Pen} tokens) >= trigger ${config.tiers.tier3Trigger}, T2 ${t2Pen}, T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
+          }
+        }
       }
     }
   }

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -337,7 +337,7 @@ test("retrying a consumed range reports already-compressed guidance, not too-sma
   assert.equal(retry.result.blocksCreated, 0);
   assert.equal(retry.result.errors.length, 1);
   assert.match(retry.result.errors[0]!, /already compressed/);
-  assert.match(retry.result.errors[0]!, /run acp_status/);
+  assert.match(retry.result.errors[0]!, /Current active blocks span/);
   assert.doesNotMatch(retry.result.errors[0]!, /Total compressible content too small/);
 });
 
@@ -549,5 +549,223 @@ test("resolveBoundaries throws typed BoundaryNotFoundError with kind and endpoin
     () => resolveBoundaries({ startRef: "m00002", endRef: "m00003", messages: pruned, state: after }),
     (e: unknown) =>
       e instanceof BoundaryNotFoundError && e.kind === "consumed" && e.endpoint === "start",
+  );
+});
+
+test("consumed block anchor snaps to the active owning block instead of failing the call (#32 livelock)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "old one"),
+    msg("b", "old two"),
+    msg("c", "raw c"),
+    msg("d", "raw d"),
+    msg("e", "raw e"),
+    msg("f", "raw f"),
+    msg("g", "raw g"),
+    msg("h", "raw h"),
+    msg("i", "raw i"),
+    msg("j", "raw j"),
+    msg("k", "recent one"),
+    msg("l", "recent two"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b2",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s2",
+      directMessageIds: ["a"],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: false,
+    },
+    {
+      blockId: "b50",
+      runId: "r1",
+      tier: 2,
+      topic: "t",
+      summary: "t2 distill",
+      directMessageIds: [],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: ["b2"],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k", "l"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+  state.nextBlockId = 111;
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "b2", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages,
+    state,
+    config: config(),
+  });
+
+  assert.equal(result.result.blocksCreated, 1, JSON.stringify(result.result));
+  assert.equal(result.result.errors.length, 0);
+  assert.ok(
+    result.result.warnings.some((w) =>
+      w.includes('startId="b2" was consumed by a higher-tier block'),
+    ),
+    `expected snap warning in: ${JSON.stringify(result.result.warnings)}`,
+  );
+  const created = result.state.blocks.find((b) => b.blockId === "b111");
+  assert.ok(created, "new block allocated after b110");
+  assert.equal(created!.tier, 2);
+  assert.deepEqual(created!.directBlockIds, ["b110"]);
+  assert.equal(result.state.blocks.find((b) => b.blockId === "b110")!.active, false);
+  assert.equal(result.state.blocks.find((b) => b.blockId === "b50")!.active, true);
+});
+
+test("consumed message anchor snaps to the active block covering it", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const full = [
+    msg("a", "old one"),
+    msg("b", "old two"),
+    msg("c", "raw c"),
+    msg("d", "raw d"),
+    msg("e", "raw e"),
+    msg("f", "raw f"),
+    msg("g", "raw g"),
+    msg("h", "raw h"),
+    msg("i", "raw i"),
+    msg("j", "raw j"),
+    msg("k", "recent one"),
+    msg("l", "recent two"),
+  ];
+  state.messageRefs = assignRefs(full, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b50",
+      runId: "r1",
+      tier: 2,
+      topic: "t",
+      summary: "t2 distill",
+      directMessageIds: ["c"],
+      effectiveMessageIds: ["a", "b", "c"],
+      directBlockIds: ["b2"],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k", "l"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+  const visible = full.slice(2);
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages: visible,
+    state,
+    config: config(),
+  });
+
+  assert.equal(result.result.blocksCreated, 1, JSON.stringify(result.result));
+  assert.equal(result.result.errors.length, 0);
+  assert.ok(
+    result.result.warnings.some((w) =>
+      w.includes('startId="m00001" refers to a message already compressed'),
+    ),
+    `expected snap warning in: ${JSON.stringify(result.result.warnings)}`,
+  );
+});
+
+test("gate error names the current active block span when anchors stay consumed", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [msg("a", "x"), msg("b", "y"), msg("k", "z")];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state.blocks.push(
+    {
+      blockId: "b2",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s2",
+      directMessageIds: ["a"],
+      effectiveMessageIds: ["a", "b"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: false,
+    },
+    {
+      blockId: "b110",
+      runId: "r1",
+      tier: 1,
+      topic: "t",
+      summary: "s110",
+      directMessageIds: ["k"],
+      effectiveMessageIds: ["k"],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+  );
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "b2", endRef: "b110", summary: "distilled span", topic: "t" }],
+    messages,
+    state,
+    config: config({ compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 } }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.equal(result.result.errors.length, 1);
+  assert.match(
+    result.result.errors[0]!,
+    /Requested range\(s\) already compressed \(e\.g\. b2\.\.b110\)/,
+  );
+  assert.match(
+    result.result.errors[0]!,
+    /Current active blocks span b110\.\.b110 — retry with startId\/endId set to active block IDs in that span\./,
   );
 });

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -258,6 +258,97 @@ test("nudge: tier distillation fires when lower-tier blocks accumulate enough", 
   assert.ok((turn.nudge.tierTargetBlocks?.length ?? 0) >= 1, "target T1 blocks listed");
 });
 
+test("nudge: tier-2 distillation fires by BLOCK COUNT below the mass threshold", () => {
+  const core = createCore();
+  // Preserve all messages so t1Eff stays 0 and only the tier-2 paths can fire;
+  // summaries are tiny so mass (~175 tokens) never reaches the 9000 threshold.
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = createInitialState();
+  state = core.processTurn({ messages, state, config, tokenCount: 50000 }).state;
+  state = {
+    ...state,
+    blocks: [0, 1, 2, 3, 4].map((i) => ({
+      blockId: `b${i + 1}`,
+      runId: "r1",
+      tier: 1 as const,
+      summary: `tier-1 summary block ${i} `,
+      directMessageIds: [`m${i}`],
+      effectiveMessageIds: [`m${i}`],
+      directBlockIds: [],
+      compressedTokens: 5000,
+      createdAt: Date.now(),
+      survivedCount: 0,
+      generation: "root" as const,
+      active: true,
+    })),
+  };
+
+  let turn = core.processTurn({ messages, state, config, tokenCount: 50000 });
+  assert.equal(turn.nudge.shouldInject, false, "no growth → no injection even at trigger count");
+
+  turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, "growth past floor → injects");
+  assert.equal(turn.nudge.tier, 2, "5 blocks >= tier2Trigger 5 fires despite tiny mass");
+  assert.match(turn.nudge.reason ?? "", /block count/);
+});
+
+test("nudge: tier-2 block-count trigger stays quiet below the trigger", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = createInitialState();
+  state = core.processTurn({ messages, state, config, tokenCount: 50000 }).state;
+  state = {
+    ...state,
+    blocks: [0, 1, 2].map((i) => ({
+      blockId: `b${i + 1}`,
+      runId: "r1",
+      tier: 1 as const,
+      summary: `tier-1 summary block ${i} `,
+      directMessageIds: [`m${i}`],
+      effectiveMessageIds: [`m${i}`],
+      directBlockIds: [],
+      compressedTokens: 5000,
+      createdAt: Date.now(),
+      survivedCount: 0,
+      generation: "root" as const,
+      active: true,
+    })),
+  };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, false, "3 blocks < tier2Trigger 5 and mass < threshold → nothing to inject");
+});
+
+test("nudge: tier-3 condensation fires by BLOCK COUNT below the mass threshold", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = createInitialState();
+  state = core.processTurn({ messages, state, config, tokenCount: 50000 }).state;
+  state = {
+    ...state,
+    blocks: Array.from({ length: 10 }, (_, i) => ({
+      blockId: `b${i + 1}`,
+      runId: "r1",
+      tier: 2 as const,
+      summary: `tier-2 summary block ${i} `,
+      directMessageIds: [`m${i}`],
+      effectiveMessageIds: [`m${i}`],
+      directBlockIds: [`b0${i}`],
+      compressedTokens: 5000,
+      createdAt: Date.now(),
+      survivedCount: 0,
+      generation: "root" as const,
+      active: true,
+    })),
+  };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, "growth past floor → injects");
+  assert.equal(turn.nudge.tier, 3, "10 tier-2 blocks >= tier3Trigger 10 fires despite tiny mass");
+  assert.match(turn.nudge.reason ?? "", /block count/);
+});
+
 test("nudge: production config (preserveRecentMessages > 0) computes compressible ranges", () => {
   const core = createCore();
   const config = buildConfig({ preserveRecentMessages: 5 });


### PR DESCRIPTION
Closes the structural half of billion-context-pi#3 (repeated-compression reports). Two commits:

## 1. fix(nudge): fire T2/T3 by block count (`14e48ac`)

**Problem — the T1 treadmill.** `tiers.tier2Trigger`/`tier3Trigger` existed in config (defaults 5/10, validated ≥1) but were **never read anywhere** — dead knobs. T2 distillation could only fire on the summary-mass path:

```
t2Pen >= 1.5 × adaptiveGrowth  &&  t2Pen > t1Eff
```

At 1M-window models adaptiveGrowth clamps to growthCap 50K → **75K absolute floor**, plus it must beat T1 effective pending. Production data (27 sessions, billion-context-pi#3): summary mass averages ~235 tok/block; the heaviest session reached **156 active T1 blocks / 36.5K mass — under half the floor** — and 440 blocks across the dataset were **100% Tier-1, zero T2/T3 ever**. Pressure mode (usage ≥ 75%) does arbitrate by max-pending, but 1M sessions peaked at 34% — it never engaged. Summaries accumulate forever → the base keeps growing → nudges keep firing → the model keeps compressing (the reported "连续重复压缩").

**Fix.** Wire the existing knobs into `decideNudge`'s growth branch: T2 ready when active T1 blocks ≥ `tier2Trigger`, T3 when active T2 blocks ≥ `tier3Trigger` — bypassing the mass gates (per-tier cadence still applies, so at most one distill nudge per growthFloor). Mass path unchanged.

**Probe (production parameters, 1M limit, 34% usage, 58 T1 blocks / 13K mass):**
```
tc=363000: inject=true tier=2 "T2 distill ready (block count): 58 tier-1 blocks (mass 13050) >= trigger 5"
tc=365000: inject=false  (cadence: growth 2000 < floor 22500)
```

## 2. fix(boundaries): snap consumed anchors (`79340d3`, was stranded on local master)

Block-boundary distillation misrejected on the pruned view: a block's anchor resolved via `earliestIndexOfIds(effectiveMessageIds)` returns null once its messages are consumed → `not found in visible context (consumed)` (kernel #32). With commit 1 actually suggesting T2, this becomes load-bearing: without it, `compress(b1..b3)` still fails. Snap consumed anchors to the active owning block instead.

## Tests

- 3 new cases in `tests/nudge.test.ts`: T2 by block count below mass threshold; quiet below trigger; T3 by block count.
- Full suite: **391/391 pass**, `tsc --noEmit` clean, build OK.

Merge: human-only per AGENTS.md. After release (0.0.30), billion-context-pi bumps per the kernel-first publish order.