### PR TITLE
fix(compress): report stale refs instead of too-small when no range resolves (#178)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -192,6 +192,13 @@ export function createCore(ports: Ports = {}): CompressionCore {
       }
     }
 
+    let resolvableCount = 0;
+    let unknownCount = 0;
+    for (const resolution of classifications.values()) {
+      if (resolution.status === "ok") resolvableCount++;
+      else if (resolution.status === "unknown") unknownCount++;
+    }
+
     const rangeIndexSets: { spec: typeof input.ranges[number]; indices: number[] }[] = [];
     for (const [spec, resolution] of classifications) {
       if (resolution.status !== "ok") continue;
@@ -247,7 +254,9 @@ export function createCore(ports: Ports = {}): CompressionCore {
             ? ` Current active blocks span ${live[0]}..${live[live.length - 1]} — retry with startId/endId set to active block IDs in that span.`
             : "";
         const gateMessage =
-          consumedRanges.length > 0
+          resolvableCount === 0 && consumedRanges.length === 0 && unknownCount > 0
+            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then re-issue the compress in the same turn using only the refs it reports.`
+            : consumedRanges.length > 0
             ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do.${liveHint}`
             : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -378,6 +378,77 @@ test("consumed plus fresh-but-small range is not misreported as too small", () =
   assert.doesNotMatch(retry.result.errors[0]!, /Combine more messages/);
 });
 
+test("all-unknown batch reports stale refs instead of too-small (billion-context-pi#178)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+    msg("c", "gamma"),
+    msg("d", "delta"),
+  ];
+  state.messageRefs = assignRefs(messages, { existing: state.messageRefs, nextIndex: 1 }).map;
+
+  const result = core.applyCompression({
+    ranges: [
+      { startRef: "m00050", endRef: "m00060", summary: "stale A" },
+      { startRef: "m00070", endRef: "m00080", summary: "stale B" },
+    ],
+    messages,
+    state,
+    config: config({ compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 } }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.equal(result.result.errors.length, 3);
+  assert.match(result.result.errors[0]!, /None of the 2 requested range\(s\) resolved/);
+  assert.match(result.result.errors[0]!, /renumbers the remaining refs/);
+  assert.match(result.result.errors[0]!, /Run acp_status/);
+  assert.doesNotMatch(result.result.errors[0]!, /too small/);
+  assert.match(result.result.errors[1]!, /does not exist in this session/);
+  assert.match(result.result.errors[2]!, /does not exist in this session/);
+});
+
+test("consumed plus unknown ranges keep the already-compressed message", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+    msg("c", "gamma"),
+    msg("d", "delta"),
+  ];
+  state.messageRefs = assignRefs(messages, { existing: state.messageRefs, nextIndex: 1 }).map;
+
+  const { state: after } = core.applyCompression({
+    ranges: [{ startRef: "m00002", endRef: "m00003", summary: "intro recap" }],
+    messages,
+    state,
+    config: config(),
+  });
+  const pruned = prune(messages, after);
+
+  const retry = core.applyCompression({
+    ranges: [
+      { startRef: "m00002", endRef: "m00003", summary: "intro recap" },
+      { startRef: "m00050", endRef: "m00060", summary: "stale" },
+    ],
+    messages: pruned,
+    state: after,
+    config: config({ compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 } }),
+  });
+
+  assert.equal(retry.result.blocksCreated, 0);
+  assert.match(retry.result.errors[0]!, /already compressed/);
+  assert.doesNotMatch(retry.result.errors[0]!, /None of the 2 requested range\(s\) resolved/);
+  assert.match(
+    retry.result.errors.find((e) => e.startsWith("range m00050..m00060")) ?? "",
+    /does not exist in this session/,
+  );
+});
+
 test("fresh small content without consumed ranges keeps the too-small message", () => {
   const core = createCore();
   const state = createInitialState();


### PR DESCRIPTION
Fixes the aggregate-error half of billion-context-pi#178 (author's trace confirmed on 0.0.29). Complements #95 (anchor-snap), already merged — together they gate the 0.0.30 release.

## Bug

Batch `compress` where **every** range fails with `BoundaryNotFoundError` kind=`unknown` gets this first line:

```
Total compressible content too small (0 chars across 0 range(s), min 5000). Combine more messages into your range(s) to meet the threshold.
```

`countedRanges = 0` → `totalRangeChars = 0` → the minCompressRange gate fires with "add more content" semantics, while the real problem is that the refs don't exist. Cause chain (per #178): every successful compress **renumbers the remaining refs** (observed m00190→m00289 in production), so any ref recorded before the last compress is stale by execution time. The model follows the misleading advice, tweaks ranges, fails again — the cross-turn retry loop behind the "连续重复压缩" reports in billion-context-pi#3 (334/350 logged errors carried this text).

## Fix

Three-way gate in `applyCompression`: when the batch has zero resolvable ranges, zero consumed ranges, and ≥1 unknown ranges →

```
None of the N requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then re-issue the compress in the same turn using only the refs it reports.
```

Per-range detail errors still follow. "Too small" is preserved for batches with resolvable-but-small ranges; consumed-first batches keep the "already compressed" message (0.0.28 behavior).

## Tests

- all-unknown batch → stale-refs first line (no "too small"), per-range details, blocksCreated 0
- consumed + unknown mixed batch → "already compressed" preserved
- Suite: **390/390 pass** (388 + 2), `tsc --noEmit` clean, build OK.

Merge: human-only per AGENTS.md; then release 0.0.30 (per #3 coordination: kernel first → npm verify → billion-context-pi bump).