### PR TITLE
release v0.0.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release PR for 0.0.30 (commit `11a13d6`, bumps package.json + package-lock.json). Contents since 0.0.29:

- **#95 / `db93a4e`** fix(boundaries): snap consumed anchors to the active owning block (#32) — multi-block distillation `compress(bN..bM)` no longer misrejected as "consumed" on the pruned view.
- **#96 / `fc56e64`** fix(compress): report stale refs instead of too-small when no range resolves (billion-context-pi#178) — all-unknown batches now tell the model to re-run acp_status instead of "Combine more messages".

Both verified: 390/390 tests, tsc clean, build OK on the merge commits.

Merge → CI publishes 0.0.30 → then billion-context-pi bumps acp-kernel 0.0.29 → 0.0.30 (second bump on PR #181's branch or follow-up) per the kernel-first publish order coordinated in billion-context-pi#3. Merge: human-only per AGENTS.md.