### PR TITLE
fix(wire): preserve all image_url parts in the OpenAI codec

### DIFF
--- a/src/wire/bili-message.ts
+++ b/src/wire/bili-message.ts
@@ -55,6 +55,13 @@ export interface BiliMessage extends CoreMessage {
     /** The base64 data of an image (without the data: prefix). Lets the
      *  reverse conversion rebuild the full image payload. */
     imageBase64?: string;
+    /** OpenAI chat: ALL original image_url content parts (each a data: URL
+     *  part) for a user message carrying more than one image, in wire order.
+     *  coreToOpenai re-emits these verbatim (after the text part). The
+     *  singular `rawOpenaiContent` still covers the single-image case and
+     *  legacy persisted state. Typed as unknown[] (not OpenAIContentPart) to
+     *  avoid a circular import with the openai codec. */
+    rawOpenaiContentParts?: unknown[];
 }
 
 /** Narrow a BiliMessage[] to CoreMessage[] for the kernel. The sidecar fields

--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -50,14 +50,21 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
             }
             case "user": {
                 const text = stringContent(m.content);
-                const img = firstImagePart(m.content);
+                const imgs = allImageParts(m.content);
+                const firstImg = imgs[0];
+                const firstUrl = firstImg ? firstImg.image_url.url : undefined;
+                const firstParsed = firstUrl ? parseDataUrl(firstUrl) : undefined;
                 const base = deriveMessageId("user", "text", text);
                 msgs.push({
                     id: clusters.next(base),
                     role: "user",
                     contentType: "text",
                     text,
-                    ...(img ? { rawOpenaiContent: img.part, imageMediaType: img.mediaType, imageBase64: img.base64 } : {}),
+                    ...(imgs.length === 1 && firstParsed
+                        ? { rawOpenaiContent: imgs[0], imageMediaType: firstParsed.mediaType, imageBase64: firstParsed.base64 }
+                        : imgs.length > 1
+                            ? { rawOpenaiContentParts: imgs }
+                            : {}),
                 });
                 break;
             }
@@ -153,10 +160,12 @@ export function coreToOpenai(messages: BiliMessage[]): OpenAIMessage[] {
             if (m.role === "system") {
                 out.push({ role: m.originalRole === "developer" ? "developer" : "system", content: m.text ?? "" });
             } else if (m.role === "user") {
-                if (m.rawOpenaiContent || m.imageBase64) {
+                if (m.rawOpenaiContent || m.imageBase64 || m.rawOpenaiContentParts) {
                     const parts: OpenAIContentPart[] = [];
                     if (m.text) parts.push({ type: "text", text: m.text });
-                    if (m.rawOpenaiContent) {
+                    if (m.rawOpenaiContentParts && m.rawOpenaiContentParts.length > 0) {
+                        for (const part of m.rawOpenaiContentParts) parts.push(part as OpenAIContentPart);
+                    } else if (m.rawOpenaiContent) {
                         parts.push(m.rawOpenaiContent as OpenAIContentPart);
                     } else if (m.imageBase64 && m.imageMediaType) {
                         parts.push({ type: "image_url", image_url: { url: `data:${m.imageMediaType};base64,${m.imageBase64}` } });
@@ -207,17 +216,22 @@ function stringContent(content: OpenAIMessage["content"]): string {
     return "";
 }
 
-function firstImagePart(content: OpenAIMessage["content"]): { part: OpenAIContentPart; mediaType: string; base64: string } | undefined {
-    if (!Array.isArray(content)) return undefined;
+type OpenAIImagePart = { type: "image_url"; image_url: { url: string } };
+
+/** Collect ALL data-URL image parts in a user content array, in wire order.
+ *  (firstImagePart only kept the first, which silently dropped images 2..N
+ *  on the coreToOpenai rebuild.) */
+function allImageParts(content: OpenAIMessage["content"]): OpenAIImagePart[] {
+    if (!Array.isArray(content)) return [];
+    const out: OpenAIImagePart[] = [];
     for (const p of content) {
-        if (p && typeof p === "object" && p.type === "image_url") {
-            const iu = (p as { image_url?: { url?: string } }).image_url;
-            const url = iu?.url;
-            if (typeof url === "string") {
-                const parsed = parseDataUrl(url);
-                if (parsed) return { part: p, mediaType: parsed.mediaType, base64: parsed.base64 };
-            }
-        }
+        if (typeof p !== "object" || p === null) continue;
+        if (!("type" in p) || p.type !== "image_url" || !("image_url" in p)) continue;
+        // The union's index-signature member leaves image_url as `unknown`, so
+        // narrow via a named const before reading the url.
+        const imagePart = p as { image_url: { url?: unknown } };
+        const url = imagePart.image_url.url;
+        if (typeof url === "string" && parseDataUrl(url)) out.push(p as OpenAIImagePart);
     }
-    return undefined;
+    return out;
 }

--- a/tests/wire-bili-message-roundtrip.test.ts
+++ b/tests/wire-bili-message-roundtrip.test.ts
@@ -142,6 +142,41 @@ test("openai: user image_url content part is restored", () => {
     assert.deepEqual((img as unknown as { image_url: { url: string } }).image_url.url, DATA_URL, "image data URL restored");
 });
 
+// 5b. OpenAI multi-image user message preserves ALL images. firstImagePart
+//     previously kept only the first image, so images 2..N were silently
+//     dropped on the coreToOpenai rebuild (and the omp wire-fold gate failed
+//     open on the whole payload). All data-URL parts must round-trip in order.
+test("openai: user message with multiple image_url parts round-trips ALL images", () => {
+    const DATA_URL2 = `data:image/png;base64,${IMG_DATA}AAAA`;
+    const DATA_URL3 = `data:image/png;base64,${IMG_DATA}AAAAA`;
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "compare these?" },
+                    { type: "image_url", image_url: { url: DATA_URL } },
+                    { type: "image_url", image_url: { url: DATA_URL2 } },
+                    { type: "image_url", image_url: { url: DATA_URL3 } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(msgs[0]?.rawOpenaiContentParts, "multi-image sidecar stored (not singular rawOpenaiContent)");
+    assert.equal((msgs[0]?.rawOpenaiContentParts ?? []).length, 3);
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    assert.ok(Array.isArray(u.content), "content rebuilt as array");
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    const imgs = parts.filter((p) => p.type === "image_url");
+    assert.equal(imgs.length, 3, "all 3 image_url parts preserved");
+    const urls = imgs.map((p) => (p as unknown as { image_url: { url: string } }).image_url.url);
+    assert.deepEqual(urls, [DATA_URL, DATA_URL2, DATA_URL3], "image order preserved");
+    const text = parts.find((p) => p.type === "text");
+    assert.ok(typeof text?.text === "string" && text.text.startsWith("compare these?"), "text preserved");
+});
+
 // 6. Responses API input_image round-trips (image was previously dropped).
 test("responses: user input_image is restored via rawResponsesItem", () => {
     const body: ResponsesRequestBody = {


### PR DESCRIPTION
## Problem

`openaiToCore` only kept the **first** `image_url` part (`firstImagePart`).
A user message carrying multiple `data:` images (e.g. an ACP archived
transcript) silently lost images 2..N on the core→wire round-trip.

Because `billion-context-omp`'s `payloadRepresentable` gate independently
rejects any user message with >1 data image, the combined effect was that
the **entire** provider-mode transform failed open on multi-image
payloads — no fold, no nudge, no compression.

## Fix

- Add `rawOpenaiContentParts?: unknown[]` to `BiliMessage` (wire/bili-message.ts)
  carrying **all** image_url parts in wire order.
- `openaiToCore`: collect every data-URL image part via a new
  `allImageParts()` helper; store the array when >1, keep the singular
  `rawOpenaiContent` path unchanged for single-image and legacy state.
- `coreToOpenai`: when `rawOpenaiContentParts` is present, re-emit **all**
  parts verbatim after the text part. The single-image `rawOpenaiContent` /
  `imageBase64` fallback path is preserved for backward compatibility.

## Tests

- New round-trip regression test in `tests/wire-bili-message-roundtrip.test.ts`:
  a user message with 3 data: image parts round-trips all 3 in order.
- Full existing suite: 391/391 pass.

## Release ordering

This must be released as a new `acp-kernel` version **before** the
companion `billion-context-omp` PR that relaxes the representability gate
can be merged (see that PR for the gate change + pin bump).