### PR TITLE
release v0.0.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.30",
+    "version": "0.0.31",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Releases the OpenAI multi-image fix from #98 (merged to master but not yet published — v0.0.30 was cut before #98 landed, so it ships only the pre-fix codec).

**What this releases:**
- #98 / 626f933: `fix(wire): preserve all image_url parts in the OpenAI codec` — `openaiToCore`/`coreToOpenai` now round-trip N image parts (new `rawOpenaiContentParts` sidecar) instead of dropping all but the first, so provider-mode payloads with multiple images no longer fail the representability gate and provider compression can run.

Merging this branch to master triggers the release workflow: typecheck + full test suite + build, tag `v0.0.31`, `npm publish --tag latest`, and a GitHub release.

**Depends on this before merging:**
- `billion-context-omp` PR #101 (draft) — the companion gate relaxation; its pin bump 0.0.28 → 0.0.31 must land against this release.