### PR TITLE
responses: fold EasyInputMessage items that omit type

### DIFF
--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -90,6 +90,19 @@ function isOpaqueItem(item: ResponseInputItem): boolean {
     return OPAQUE_ITEM_TYPES.has(item.type);
 }
 
+const EASY_INPUT_ROLES = new Set(["user", "assistant", "system", "developer"]);
+
+/** OpenAI's EasyInputMessage shorthand legally omits `type` (e.g. omp sends
+ *  `{ role: "user", content: "..." }`); without normalization those items fall
+ *  through the switch's `default` into the preamble and are never folded. */
+function normalizeEasyInputItem(item: ResponseInputItem): ResponseInputItem {
+    if (typeof item.type === "string") return item;
+    if (EASY_INPUT_ROLES.has(String((item as { role?: unknown }).role))) {
+        return { ...(item as { [key: string]: unknown }), type: "message" } as ResponseInputMessage;
+    }
+    return item;
+}
+
 function shouldDropAllReasoning(): boolean {
     return (process.env.ACP_REASONING_KEEP ?? "").trim().toLowerCase() === "none";
 }
@@ -120,7 +133,8 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
         msgs.push({ id, role: "user", contentType: "text", text: body.input });
         return { msgs, systemParts, preamble, customToolCallIds, layout, droppedReasoning, stringInput: { original: body.input, coreId: id } };
     }
-    for (const item of body.input) {
+    for (const raw of body.input) {
+        const item = normalizeEasyInputItem(raw);
         let coreId: string | undefined;
         if (isOpaqueItem(item)) preamble.push(item);
         switch (item.type) {

--- a/tests/wire-bili-message-roundtrip.test.ts
+++ b/tests/wire-bili-message-roundtrip.test.ts
@@ -2,10 +2,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { anthropicToCore, coreToAnthropic } from "../src/wire/anthropic.js";
 import { openaiToCore, coreToOpenai } from "../src/wire/openai.js";
-import { responsesToCore, coreToResponses } from "../src/wire/responses.js";
+import { responsesToCore, coreToResponses, patchResponsesInput } from "../src/wire/responses.js";
 import type { AnthropicBlock, AnthropicRequestBody } from "../src/wire/anthropic.js";
 import type { OpenAIRequestBody } from "../src/wire/openai.js";
-import type { ResponsesRequestBody } from "../src/wire/responses.js";
+import type { ResponseInputItem, ResponsesRequestBody } from "../src/wire/responses.js";
 
 const IMG_DATA = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 const DATA_URL = `data:image/png;base64,${IMG_DATA}`;
@@ -431,4 +431,69 @@ test("responses: ACP_REASONING_KEEP=none drops reasoning but keeps call items", 
         if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
         else process.env.ACP_REASONING_KEEP = prev;
     }
+});
+
+// 10. OpenAI's EasyInputMessage shorthand legally omits `type` (omp and bare
+// /v1/responses clients send `{ role, content }`): those items must fold
+// exactly like their typed `message` form instead of falling into the preamble.
+test("responses: EasyInputMessage without type folds like a typed message", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi there" },
+            { type: "message", role: "user", content: "second" },
+        ] as unknown as ResponseInputItem[],
+    };
+    const { msgs, preamble, systemParts } = responsesToCore(body);
+    assert.equal(preamble.length, 0, "type-less messages are not opaque");
+    assert.equal(msgs.length, 3);
+    assert.equal(msgs[0]?.role, "user");
+    assert.equal(msgs[0]?.text, "hello");
+    assert.equal(msgs[1]?.role, "assistant");
+    assert.equal(msgs[1]?.text, "hi there");
+    assert.equal(systemParts.length, 0);
+});
+
+// 11. Folded text splices back into the EasyInputMessage slot; re-emitted
+// items carry the canonical typed form (interchangeable on the wire).
+test("responses: EasyInputMessage round-trips through patchResponsesInput", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { role: "user", content: "fold me" },
+            { role: "assistant", content: "ok" },
+            { role: "user", content: "and me" },
+        ] as unknown as ResponseInputItem[],
+    };
+    const projection = responsesToCore(body);
+    const patched = projection.msgs.map((m, i) => (i === 0 ? { ...m, text: `[sum] ${m.text}` } : m));
+    const rebuilt = patchResponsesInput(projection, patched);
+    assert.ok(Array.isArray(rebuilt));
+    const first = rebuilt[0] as { type?: string; role?: string; content?: unknown };
+    assert.equal(first.type, "message", "re-emitted in canonical typed form");
+    assert.equal(first.role, "user");
+    assert.equal(first.content, "[sum] fold me");
+    assert.equal((rebuilt[1] as { content?: unknown }).content, "ok", "untouched slots keep content");
+});
+
+// 12. Type-less system/developer shorthands follow the typed path into
+// systemParts (hosts re-inject them via injectResponsesDeveloperMessage).
+test("responses: EasyInputMessage system role joins systemParts", () => {
+    const body: ResponsesRequestBody = {
+        instructions: "be brief",
+        input: [{ role: "system", content: "extra rules" }] as unknown as ResponseInputItem[],
+    };
+    const { msgs, systemParts } = responsesToCore(body);
+    assert.deepEqual(systemParts, ["be brief", "extra rules"]);
+    assert.equal(msgs.length, 0);
+});
+
+// 13. Items with neither `type` nor a message `role` stay opaque.
+test("responses: type-less non-message items stay in the preamble", () => {
+    const body: ResponsesRequestBody = {
+        input: [{ foo: "bar" }] as unknown as ResponseInputItem[],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.equal(msgs.length, 0);
+    assert.equal(preamble.length, 1);
+    assert.deepEqual(preamble[0], { foo: "bar" });
 });


### PR DESCRIPTION
## Problem

OpenAI's Responses API accepts input message items without an explicit `type` (the EasyInputMessage shorthand: `{ role: "user", content: "..." }`). `responsesToCore` dispatched its item switch on `item.type`, so shorthand items fell through the `default` branch into the **opaque preamble** and were never folded:

- Hosts sending the shorthand for every turn (the omp adapter's `buildResponsesInput`) had their ENTIRE conversation bypass compression — fold size stayed 0 and `compress` always rejected with "0 chars".
- The billion-context proxy serving bare `/v1/responses` clients (curl etc., all legal shorthand) hit the same hole, surfaced in ranxianglei/billion-context-omp#12 and the comparison against billion-context.

The omp adapter had to pre-normalize payloads itself (`normalizeResponsesPayload`); the proxy does not, so the fix belongs in the kernel.

## Fix

Normalize type-less items carrying a message role (`user`/`assistant`/`system`/`developer`) to the canonical typed form before dispatch:

- `user`/`assistant` fold as text messages (string or content-part arrays both handled downstream).
- `system`/`developer` join `systemParts` exactly like their typed counterparts (hosts re-inject via `injectResponsesDeveloperMessage`).
- `patchResponsesInput` splices folded text back into the slot; re-emitted items carry `type: "message"` — the shorthand and typed forms are interchangeable on the wire (verified live against SGLang's `/v1/responses` over a 9-turn tool-loop session).
- Items with **neither** `type` nor a message `role` keep the opaque preamble path (unchanged).

The caller's body object is never mutated — normalization works on copies.

## Tests

4 new cases in `tests/wire-bili-message-roundtrip.test.ts`:

1. Shorthand user/assistant items fold like typed messages (preamble stays empty).
2. `patchResponsesInput` round-trip: patched text lands in the slot, untouched slots keep content, output in typed form.
3. Shorthand `system` role joins `systemParts` alongside `instructions`.
4. Type-less non-message items stay opaque.

Full pre-flight: `tsc --noEmit` clean, **395 tests pass**, build OK.

## Downstream

- `billion-context-omp`: the adapter-local `normalizeResponsesPayload` becomes redundant once it pins a kernel release with this fix (kept for now; harmless double-normalize).
- `billion-context` (proxy): shorthand bodies served to bare clients become compressible with no proxy-side change.

Refs ranxianglei/billion-context-omp#12