### PR TITLE
Revert PR #18: keep newest two orphaned compress calls (failure visibility)

### DIFF
--- a/src/hide-consumed.ts
+++ b/src/hide-consumed.ts
@@ -1,6 +1,14 @@
 import type { CompressionState, CoreMessage } from "./types.js";
 
-const KEEP_LAST_ORPHANED = 0;
+// Orphaned compress calls (no matching block — failed attempts, or historical
+// calls whose blocks predate compressCallId recording) keep their NEWEST two
+// call+result pairs visible: failures must stay observable or a deterministic
+// model re-issues the same no-op compress forever, pinned at a fixed point
+// (billion-context-pi issue #9: 3,849 identical calls over 5h13m under
+// KEEP_LAST_ORPHANED=0). Older orphans are hidden, so the residue is bounded
+// at two pairs regardless of session length — PR #18's unbounded accumulation
+// does not return (its own live check showed the cap: 10 in → 6 out).
+const KEEP_LAST_ORPHANED = 2;
 
 export interface HideConsumedResult {
     messages: CoreMessage[];

--- a/tests/hide-merge-rebuild.test.ts
+++ b/tests/hide-merge-rebuild.test.ts
@@ -23,7 +23,7 @@ function block(overrides: Partial<CompressionBlock>): CompressionBlock {
     };
 }
 
-test("hideConsumedCompressCalls keeps active-block compress calls, hides all orphaned", () => {
+test("hideConsumedCompressCalls keeps active-block calls, hides consumed, keeps newest two orphans", () => {
     const state: CompressionState = {
         ...createInitialState(),
         blocks: [block({ blockId: "b1", compressCallId: "call-active", active: true })],
@@ -36,14 +36,52 @@ test("hideConsumedCompressCalls keeps active-block compress calls, hides all orp
         { id: "m5", role: "user", contentType: "text", text: "hello" },
     ];
     const result = hideConsumedCompressCalls(state, messages);
-    // active-block call kept; consumed + all orphaned hidden (KEEP_LAST_ORPHANED=0).
-    assert.equal(result.hidden, 3);
+    // active-block call kept; consumed hidden; newest KEEP_LAST_ORPHANED=2
+    // orphans kept visible (failure observability — billion-context-pi #9).
+    assert.equal(result.hidden, 1);
     const remainingCallIds = result.messages.filter((m) => m.toolName === "compress").map((m) => m.toolCallId);
     assert.ok(remainingCallIds.includes("call-active"));
     assert.ok(!remainingCallIds.includes("call-consumed"));
-    assert.ok(!remainingCallIds.includes("call-orphan1"));
-    assert.ok(!remainingCallIds.includes("call-orphan2"));
+    assert.ok(remainingCallIds.includes("call-orphan1"));
+    assert.ok(remainingCallIds.includes("call-orphan2"));
     assert.ok(result.messages.some((m) => m.text === "hello"));
+});
+
+test("orphaned compress residue is bounded: only the newest two pairs survive any session length", () => {
+    const state: CompressionState = {
+        ...createInitialState(),
+        blocks: [block({ blockId: "b1", compressCallId: "call-active", active: true })],
+    };
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-active", text: "{}" },
+    ];
+    for (let i = 1; i <= 12; i++) {
+        messages.push({ id: `c${i}`, role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: `call-fail${i}`, text: "{}" });
+        messages.push({ id: `r${i}`, role: "user", contentType: "tool-result", toolName: "compress", toolCallId: `call-fail${i}`, text: "nothing to compress" });
+    }
+    messages.push({ id: "mend", role: "user", contentType: "text", text: "tail" });
+
+    const result = hideConsumedCompressCalls(state, messages);
+    // 12 failed pairs in → only the newest 2 pairs + the active call remain:
+    // PR #18's unbounded accumulation cannot recur under KEEP_LAST_ORPHANED=2.
+    assert.equal(result.hidden, 20);
+    const remainingCallIds = result.messages.filter((m) => m.toolName === "compress" && m.contentType === "tool-call").map((m) => m.toolCallId);
+    assert.deepEqual(remainingCallIds, ["call-active", "call-fail11", "call-fail12"]);
+    const remainingResultIds = result.messages.filter((m) => m.contentType === "tool-result").map((m) => m.toolCallId);
+    assert.deepEqual(remainingResultIds, ["call-fail11", "call-fail12"]);
+});
+
+test("a failed compress call and its result stay visible (issue #9 fixed-point precondition removed)", () => {
+    const state: CompressionState = { ...createInitialState(), blocks: [] };
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "q" },
+        { id: "m2", role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId: "call-fail", text: "{}" },
+        { id: "m3", role: "user", contentType: "tool-result", toolName: "compress", toolCallId: "call-fail", text: "Requested range(s) already compressed; nothing to do" },
+    ];
+    const result = hideConsumedCompressCalls(state, messages);
+    assert.equal(result.hidden, 0);
+    assert.ok(result.messages.some((m) => m.toolCallId === "call-fail" && m.contentType === "tool-call"));
+    assert.ok(result.messages.some((m) => m.toolCallId === "call-fail" && m.contentType === "tool-result"));
 });
 
 test("rebuildCompressionState replays historical compress tool calls", () => {


### PR DESCRIPTION
Reverts the behavioral half of #18 (`KEEP_LAST_ORPHANED` 2 → 0). Fixes the kernel-side root cause of ranxianglei/billion-context-pi#9.

## Why

`KEEP_LAST_ORPHANED = 0` hid **every** compress call that produced no active block — including failed/no-op attempts — from the sent view. A deterministic model that keeps failing then observes an unchanging context: it re-issued the byte-identical no-op compress **3,849 times over 5h13m** (billion-context-pi session 01a02542, context pinned at 22.6K the whole time).

## Change

`src/hide-consumed.ts`: `KEEP_LAST_ORPHANED = 2` (the original v0.0.2 value). The newest two orphaned call+result pairs stay visible — failures become observable, and each new failure changes the sent view, breaking the fixed point. Consumed/superseded calls (block exists but inactive) remain fully hidden.

## Does PR #18's impact return? No.

PR #18 fixed "12 orphaned compress messages accumulating, never clearing". That accumulation does **not** recur under `=2`:

- Older orphans beyond the newest-2 window are hidden (call **and** result, via `hiddenCallIds`) in every pipeline path — `processTurn` and `applyCompression` share the same `hide-compress-calls` node.
- Residue is capped at 2 call+result pairs (~4 messages) regardless of session length.
- PR #18's own live verification showed the same cap working: 10 compress msgs in → 6 out (1 active pair + 2 orphan pairs).
- New bounding test: 12 failed pairs + 1 active → exactly 2 newest pairs + active remain, 20 hidden.

## Tests

- [x] `npm run typecheck`
- [x] `npm test` — 392 pass / 0 fail (1 test rewritten for the new semantics, 2 added: residue bounding + failure visibility)

## Rollout

Kernel ships first; downstream adapters (billion-context-pi PR #190, omp) then pin the new version. pi #190 (circuit breaker + STOP injection) remains valuable defense-in-depth on top of restored visibility.