### PR TITLE
release v0.0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Changes since v0.0.31

- #104 — Revert #18: `KEEP_LAST_ORPHANED` 0 → 2 (keep the newest two orphaned compress call+result pairs visible). Restores failure observability in the sent view and removes the fixed-point precondition behind the infinite no-op compress loop (ranxianglei/billion-context-pi#9). Residue stays bounded at 2 pairs in all pipeline paths (bounding test added); #18's accumulation does not return.

## Preflight

- [x] typecheck
- [x] tests 393/393
- [x] build

Downstream dependency-bump releases (billion-context-pi / billion-context-omp / billion-context) follow once this is published to npm.