### PR TITLE
fix(wire): key responses reasoning core id on text, not host item id

### DIFF
--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -105,6 +105,27 @@ function messageContent(content: string | ResponseContentPart[]): string {
     return typeof content === "string" ? content : content.map(partText).join("\n");
 }
 
+/** Extract the reasoning text from a responses reasoning item. The host
+ *  carries it in `content` (reasoning_text parts); the primeFold mirror
+ *  carries it in `summary` (summary_text parts). Both must yield the same
+ *  text so the kernel derives the same core id (issue #64, responses). */
+function reasoningText(item: ResponseInputItem): string {
+    const fromParts = (parts: unknown, type: string): string => {
+        if (!Array.isArray(parts)) return "";
+        const texts: string[] = [];
+        for (const part of parts) {
+            if (part && typeof part === "object" && "type" in part && "text" in part) {
+                const rec = part as { type: unknown; text: unknown };
+                if (rec.type === type && typeof rec.text === "string") texts.push(rec.text);
+            }
+        }
+        return texts.join("\n");
+    };
+    const content = "content" in item ? item.content : undefined;
+    const summary = "summary" in item ? item.summary : undefined;
+    return fromParts(content, "reasoning_text") || fromParts(summary, "summary_text");
+}
+
 export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection {
     const msgs: BiliMessage[] = [];
     const systemParts: string[] = [];
@@ -129,10 +150,19 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                     droppedReasoning++;
                     continue;
                 }
+                // Key the reasoning piece on its TEXT (deterministic), consistent
+                // with the anthropic/openai codecs. The host mints a per-request
+                // item id that the primeFold mirror cannot reproduce; keying on it
+                // put the mirror in a different ref/fingerprint space, so restart
+                // replay rejected every in-stream compress call (issue #64,
+                // responses variant).
+                const text = reasoningText(item);
                 const rid =
-                    typeof (item as { id?: unknown }).id === "string"
-                        ? String((item as { id?: string }).id)
-                        : hashId(JSON.stringify(item));
+                    text.length > 0
+                        ? text
+                        : "id" in item && typeof item.id === "string"
+                            ? item.id
+                            : hashId(JSON.stringify(item));
                 coreId = clusters.next(deriveMessageId("assistant", "reasoning", rid));
                 msgs.push({
                     id: coreId,


### PR DESCRIPTION
## Problem

On `/v1/responses` (e.g. SGLang, Qwen with thinking), compressed blocks
disappear after a restart: `acp_status` shows `Blocks: none` until the
first live provider request refolds the session.

## Root cause

`responsesToCore` derived the reasoning core id from the host-generated
`item.id` (`rs_<hash>`), while the anthropic/openai codecs derive it from
the thinking **text**. The primeFold mirror (billion-context-omp
`viewToResponsesCore`) emits reasoning items **without** an id, so the
kernel fell back to `hashId(JSON.stringify(item))` — a *different* core id
than the host's. On restart the span fingerprints mismatched, every
in-stream compress replay was rejected, and the blocks were lost.

Verified: host item (id `rs_abc123`) → `h_c3508dda8f092e50`; mirror item
(no id) → `h_80d750dfefe263dd`. Mismatch.

## Fix

Derive the reasoning core id from the reasoning **text** (extracted from
`content` `reasoning_text` parts or `summary` `summary_text` parts),
consistent with the anthropic/openai codecs. Fall back to the item id /
content hash only when the text is empty.

After the fix, host and mirror both yield `h_4d84d3ba9d0ecf44` for the
same thinking text.

`coreToResponses` rebuilds reasoning from `rawResponsesItem`, so the
`text`-field change does not affect the rebuild.

## Tests

- All 393 existing kernel tests pass.
- Typecheck clean.
- The companion billion-context-omp PR adds a restart regression test
  (`provider+responses: restart primeFold rebuilds blocks from
  thinking-bearing turns`) that fails on 0.0.32 and passes with this fix.

## Note

This is a behavior change for responses reasoning core ids (they now key
on text instead of the host item id). Existing sessions will refold on
the next request; no data loss.