### PR TITLE
release v0.0.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.32",
+    "version": "0.0.33",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Bump version to 0.0.33.

Includes the /v1/responses restart fix from #107 (reasoning core id derived from reasoning text instead of host-minted item id, so the primeFold mirror can reproduce it and restart replay no longer drops compressed blocks).

Merging this triggers the release workflow: typecheck + test + build, tag v0.0.33, npm publish --tag latest, GitHub Release.