### PR TITLE
fix(wire): normalize inline demoted thinking into one identity space (issue #64)

### DIFF
--- a/src/wire/demoted-thinking.ts
+++ b/src/wire/demoted-thinking.ts
@@ -1,0 +1,77 @@
+/** Inline "demoted thinking" normalization.
+ *
+ * Hosts that cannot replay prior-turn reasoning as a structured block
+ * (pi-ai transform-messages demotion on model switch, openai-completions
+ * `requiresThinkingAsText` profiles, gateways that inline native
+ * reasoning) fold it INTO the assistant content string wrapped in a
+ * dialect tag:
+ *
+ *   glm / deepseek / kimi / qwen3 / hermes : <think>\n{text}\n</think>
+ *   anthropic / minimax / xml              : <thinking>\n{text}\n</thinking>
+ *   gemini                                 : ```thinking\n{text}\n```
+ *
+ * followed by a single "\n" glue before the next content block. The same
+ * logical turn can therefore arrive as a `reasoning_content` field (or a
+ * separate reasoning item on /v1/responses) OR as this inline form. If the
+ * wire codecs kept both as one text blob, the two serializations of one
+ * turn would land in DIFFERENT core-id/fingerprint spaces — exactly the
+ * issue #64 "restart loses blocks" class, where the mirror produced one
+ * form and the live wire the other.
+ *
+ * splitDemotedThinking() reverses the rendering byte-exactly so both
+ * codecs can normalize before identity derivation (deriveMessageId). It
+ * only fires when the tag opens at offset 0 of the content, which is the
+ * only position the demotion renderer can produce it in.
+ *
+ * One form is intentionally NOT recoverable here: the pi-ai anthropic
+ * dialect demotes to BARE text (no tag), which is indistinguishable from
+ * ordinary assistant prose; that case must be aligned upstream (mirror
+ * uses the same bare rendering), not parsed. */
+
+export type DemotedSplit = {
+    reasoning: string;
+    text: string;
+};
+
+type DelimitedForm = {
+    open: string;
+    close: string;
+};
+
+/** The three inline tag forms hosts actually emit (see file comment). */
+const FORMS: readonly DelimitedForm[] = [
+    { open: "<think>\n", close: "\n</think>" },
+    { open: "<thinking>\n", close: "\n</thinking>" },
+    { open: "```thinking\n", close: "\n```" },
+];
+
+/** If `content` starts with one or more inline demoted-thinking blocks,
+ *  split them out. Returns null when no tag opens the content (the common
+ *  case — including every user message and every assistant message whose
+ *  reasoning traveled as a field/item), in which case callers keep the
+ *  content as-is. Malformed (unterminated) or empty blocks do not match;
+ *  the content is then treated as plain text, never dropped. */
+export function splitDemotedThinking(content: string): DemotedSplit | null {
+    let rest = content;
+    const parts: string[] = [];
+    for (;;) {
+        let matched = false;
+        for (const form of FORMS) {
+            if (!rest.startsWith(form.open)) continue;
+            const end = rest.indexOf(form.close, form.open.length);
+            if (end < 0) continue;
+            const inner = rest.slice(form.open.length, end);
+            if (inner.length === 0) continue;
+            parts.push(inner);
+            rest = rest.slice(end + form.close.length);
+            // Glue the demotion renderer inserts between a demoted block
+            // and the block that follows it.
+            if (rest.startsWith("\n")) rest = rest.slice(1);
+            matched = true;
+            break;
+        }
+        if (!matched) break;
+    }
+    if (parts.length === 0) return null;
+    return { reasoning: parts.join("\n"), text: rest };
+}

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -4,4 +4,5 @@ export * from "./responses.js";
 export * from "./formats.js";
 export * from "./bili-message.js";
 export * from "./message-id.js";
+export * from "./demoted-thinking.js";
 export * from "./util.js";

--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -1,3 +1,4 @@
+import { splitDemotedThinking } from "./demoted-thinking.js";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
 import { parseDataUrl, type BiliMessage } from "./bili-message.js";
@@ -69,7 +70,23 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                 break;
             }
             case "assistant": {
-                const reasoning = typeof m.reasoning_content === "string" ? m.reasoning_content : "";
+                const fieldReasoning = typeof m.reasoning_content === "string" ? m.reasoning_content : "";
+                let reasoning = fieldReasoning;
+                let text = stringContent(m.content);
+                if (!reasoning) {
+                    // Hosts that cannot replay prior-turn reasoning as a
+                    // structured field inline it into content wrapped in a
+                    // dialect tag (<think>, <thinking>, ```thinking). Split
+                    // it back out BEFORE identity derivation so the inline
+                    // form and the reasoning_content field form of one turn
+                    // land in a single core-id/fingerprint space (issue #64
+                    // demoted variant).
+                    const split = splitDemotedThinking(text);
+                    if (split) {
+                        reasoning = split.reasoning;
+                        text = split.text;
+                    }
+                }
                 if (reasoning) {
                     const base = deriveMessageId("assistant", "reasoning", reasoning);
                     msgs.push({
@@ -80,7 +97,6 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                         reasoningContent: reasoning,
                     });
                 }
-                const text = stringContent(m.content);
                 if (text) {
                     const base = deriveMessageId("assistant", "text", text);
                     msgs.push({ id: clusters.next(base), role: "assistant", contentType: "text", text });

--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -1,4 +1,5 @@
 import type { CoreMessage } from "../types.js";
+import { splitDemotedThinking } from "./demoted-thinking.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
 import type { ConversationIdentity } from "./util.js";
 import { hashId } from "./util.js";
@@ -182,19 +183,41 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                     continue;
                 } else if (message.role === "user" || (message.role === "assistant" && text)) {
                     const role = message.role;
-                    coreId = clusters.next(deriveMessageId(role, "text", text));
-                    const imageUrl = Array.isArray(message.content)
-                        ? message.content.find((part) => part.type === "input_image" && typeof part.image_url === "string")?.image_url
-                        : undefined;
-                    const image = typeof imageUrl === "string" ? parseDataUrl(imageUrl) : undefined;
-                    msgs.push({
-                        id: coreId,
-                        role,
-                        contentType: "text",
-                        text,
-                        rawResponsesItem: item,
-                        ...(image ? { imageMediaType: image.mediaType, imageBase64: image.base64 } : {}),
-                    });
+                    let effText = text;
+                    if (role === "assistant") {
+                        // Same normalization as openaiToCore: hosts that demote
+                        // prior-turn reasoning inline it as a dialect tag at the
+                        // head of the message text. Split it out before identity
+                        // derivation so the inline form and the separate
+                        // reasoning-item form of one turn share a single
+                        // core-id/fingerprint space.
+                        const split = splitDemotedThinking(text);
+                        if (split) {
+                            msgs.push({
+                                id: clusters.next(deriveMessageId("assistant", "reasoning", split.reasoning)),
+                                role: "assistant",
+                                contentType: "reasoning",
+                                text: split.reasoning,
+                                rawResponsesItem: item,
+                            });
+                            effText = split.text;
+                        }
+                    }
+                    if (effText) {
+                        coreId = clusters.next(deriveMessageId(role, "text", effText));
+                        const imageUrl = Array.isArray(message.content)
+                            ? message.content.find((part) => part.type === "input_image" && typeof part.image_url === "string")?.image_url
+                            : undefined;
+                        const image = typeof imageUrl === "string" ? parseDataUrl(imageUrl) : undefined;
+                        msgs.push({
+                            id: coreId,
+                            role,
+                            contentType: "text",
+                            text: effText,
+                            rawResponsesItem: item,
+                            ...(image ? { imageMediaType: image.mediaType, imageBase64: image.base64 } : {}),
+                        });
+                    }
                 }
                 break;
             }

--- a/tests/wire-demoted-thinking.test.ts
+++ b/tests/wire-demoted-thinking.test.ts
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { splitDemotedThinking } from "../src/wire/demoted-thinking.js";
+import { coreToOpenai, openaiToCore, type OpenAIRequestBody } from "../src/wire/openai.js";
+import { responsesToCore, type ResponsesRequestBody } from "../src/wire/responses.js";
+
+// --- splitDemotedThinking unit -------------------------------------------------
+
+test("splitDemotedThinking reverses each dialect form byte-exactly", () => {
+    assert.deepStrictEqual(splitDemotedThinking("<think>\nA\n</think>\n\n\n两个 PR："), {
+        reasoning: "A",
+        text: "\n\n两个 PR：",
+    });
+    assert.deepStrictEqual(splitDemotedThinking("<thinking>\nB\n</thinking>\ntail"), {
+        reasoning: "B",
+        text: "tail",
+    });
+    assert.deepStrictEqual(splitDemotedThinking("```thinking\nC\n```\ntail"), {
+        reasoning: "C",
+        text: "tail",
+    });
+});
+
+test("splitDemotedThinking handles stacked blocks and glue", () => {
+    assert.deepStrictEqual(splitDemotedThinking("<think>\nA\n</think>\n<think>\nB\n</think>\n\ntext"), {
+        reasoning: "A\nB",
+        text: "\ntext",
+    });
+    // thinking-only turn: glue consumed, text empty
+    assert.deepStrictEqual(splitDemotedThinking("<think>\nA\n</think>"), { reasoning: "A", text: "" });
+});
+
+test("splitDemotedThinking refuses malformed / non-tag content", () => {
+    assert.strictEqual(splitDemotedThinking(""), null);
+    assert.strictEqual(splitDemotedThinking("plain answer"), null);
+    assert.strictEqual(splitDemotedThinking("pre <think>\nA\n</think>"), null); // tag must open at offset 0
+    assert.strictEqual(splitDemotedThinking("<think>\nA\n</thin>"), null); // unterminated
+    assert.strictEqual(splitDemotedThinking("<think>x"), null); // renderer always breaks after the open tag
+    assert.strictEqual(splitDemotedThinking("<think>\n</think>"), null); // empty block
+});
+
+// --- openaiToCore invariance ----------------------------------------------------
+
+const INLINE_TURN = "<think>\nThe user asks.\n</think>\n\n\n两个 PR：内核与代理。";
+const FIELD_TEXT = "\n\n两个 PR：内核与代理。";
+const FIELD_REASONING = "The user asks.";
+
+const inlineBody: OpenAIRequestBody = {
+    model: "glm-x",
+    messages: [
+        { role: "user", content: "q" },
+        { role: "assistant", content: INLINE_TURN },
+        { role: "user", content: "r" },
+    ],
+};
+const fieldBody: OpenAIRequestBody = {
+    model: "glm-x",
+    messages: [
+        { role: "user", content: "q" },
+        { role: "assistant", content: FIELD_TEXT, reasoning_content: FIELD_REASONING },
+        { role: "user", content: "r" },
+    ],
+};
+
+test("openaiToCore: inline <think> and reasoning_content field share one identity space", () => {
+    const inline = openaiToCore(inlineBody).msgs;
+    const field = openaiToCore(fieldBody).msgs;
+    assert.strictEqual(inline.length, 4);
+    // Same ids, same order, same contentTypes — one fingerprint space.
+    assert.deepStrictEqual(
+        inline.map((m) => ({ id: m.id, role: m.role, contentType: m.contentType, text: m.text })),
+        field.map((m) => ({ id: m.id, role: m.role, contentType: m.contentType, text: m.text })),
+    );
+    const reasoning = inline[1];
+    assert.strictEqual(reasoning.contentType, "reasoning");
+    assert.strictEqual(reasoning.text, FIELD_REASONING);
+    assert.strictEqual(inline[2].text, FIELD_TEXT);
+});
+
+test("openaiToCore: reasoning_content field wins; tagged content is not double-split", () => {
+    const body: OpenAIRequestBody = {
+        model: "glm-x",
+        messages: [{ role: "assistant", content: "<think>\nA\n</think>text", reasoning_content: "R" }],
+    };
+    const msgs = openaiToCore(body).msgs;
+    assert.strictEqual(msgs.length, 2);
+    assert.strictEqual(msgs[0].text, "R");
+    assert.strictEqual(msgs[1].text, "<think>\nA\n</think>text");
+});
+
+test("openaiToCore: thinking-only turn yields reasoning with no empty text piece", () => {
+    const msgs = openaiToCore({
+        model: "glm-x",
+        messages: [{ role: "assistant", content: "<think>\nonly\n</think>" }],
+    }).msgs;
+    assert.deepStrictEqual(
+        msgs.map((m) => m.contentType),
+        ["reasoning"],
+    );
+});
+
+test("openaiToCore: user content starting with a tag is never split", () => {
+    const msgs = openaiToCore({
+        model: "glm-x",
+        messages: [{ role: "user", content: "<think>\nA\n</think>q" }],
+    }).msgs;
+    assert.deepStrictEqual(
+        msgs.map((m) => m.contentType),
+        ["text"],
+    );
+    assert.strictEqual(msgs[0].text, "<think>\nA\n</think>q");
+});
+
+test("coreToOpenai round-trip normalizes inline form to the field form", () => {
+    const wire = coreToOpenai(openaiToCore(inlineBody).msgs);
+    const assistant = wire.find((m) => m.role === "assistant");
+    assert.ok(assistant);
+    assert.strictEqual(assistant.reasoning_content, FIELD_REASONING);
+    assert.strictEqual(assistant.content, FIELD_TEXT);
+});
+
+// --- responsesToCore invariance -------------------------------------------------
+
+const inlineResponsesBody = (): ResponsesRequestBody => ({
+    model: "resp-x",
+    input: [
+        { type: "message", role: "user", content: "q" },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: INLINE_TURN }] },
+        { type: "message", role: "user", content: "r" },
+    ] as ResponsesRequestBody["input"],
+});
+const itemResponsesBody = (): ResponsesRequestBody => ({
+    model: "resp-x",
+    input: [
+        { type: "message", role: "user", content: "q" },
+        { type: "reasoning", summary: [{ type: "summary_text", text: FIELD_REASONING }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: FIELD_TEXT }] },
+        { type: "message", role: "user", content: "r" },
+    ] as ResponsesRequestBody["input"],
+});
+
+test("responsesToCore: inline <think> message and reasoning item share one identity space", () => {
+    const inline = responsesToCore(inlineResponsesBody()).msgs;
+    const item = responsesToCore(itemResponsesBody()).msgs;
+    assert.strictEqual(inline.length, 4);
+    assert.strictEqual(item.length, 4);
+    assert.deepStrictEqual(
+        inline.map((m) => ({ id: m.id, role: m.role, contentType: m.contentType, text: m.text })),
+        item.map((m) => ({ id: m.id, role: m.role, contentType: m.contentType, text: m.text })),
+    );
+});
+
+test("responsesToCore: thinking-only message yields reasoning with no empty text piece", () => {
+    const proj = responsesToCore({
+        model: "resp-x",
+        input: [
+            { type: "message", role: "assistant", content: [{ type: "output_text", text: "<think>\nonly\n</think>" }] },
+        ] as ResponsesRequestBody["input"],
+    });
+    assert.deepStrictEqual(
+        proj.msgs.map((m) => m.contentType),
+        ["reasoning"],
+    );
+});
+
+test("responsesToCore: user content starting with a tag is never split", () => {
+    const proj = responsesToCore({
+        model: "resp-x",
+        input: [{ type: "message", role: "user", content: "<think>\nA\n</think>q" }] as ResponsesRequestBody["input"],
+    });
+    assert.deepStrictEqual(
+        proj.msgs.map((m) => m.contentType),
+        ["text"],
+    );
+    assert.strictEqual(proj.msgs[0].text, "<think>\nA\n</think>q");
+});


### PR DESCRIPTION
## Summary

The issue #64 family ("restart loses blocks / one fix here, another breaks there") traces to one structural gap: the SAME logical turn can arrive on the wire in two serializations —

- structured: `reasoning_content` field (openai-completions) or a separate `reasoning` item (/v1/responses)
- inline "demoted": hosts that cannot replay prior-turn reasoning as a structured block (pi-ai transform-messages demotion on model switch, `requiresThinkingAsText` profiles, gateways inlining native reasoning) fold it into the assistant content string wrapped in a dialect tag:

```
glm/deepseek/kimi/qwen3/hermes : <think>\n{text}\n</think>
anthropic/minimax/xml          : <thinking>\n{text}\n</thinking>
gemini                         : ```thinking\n{text}\n```
```

followed by a single `\n` glue before the next content block.

Both wire codecs keyed identity on whichever serialization they saw, so one turn landed in TWO core-id/fingerprint spaces. The omp mirror produced one form and the live wire the other → restart replay rejected every in-stream compress call. billion-context-omp #124 patched this at the omp mirror layer (demoteThinking retry); the correct home is here, in the kernel, where the fix also covers the proxy (qwen inline traffic was being fingerprinted with reasoning treated as text).

## Changes

- **new `src/wire/demoted-thinking.ts`** — `splitDemotedThinking()` reverses the demotion rendering byte-exactly (all 3 tag forms, stacked blocks, glue). Only fires when a tag opens at offset 0 of assistant content; malformed/unterminated/empty blocks never match (content is kept as plain text, never dropped). The anthropic-dialect BARE-text demotion is documented as intentionally unrecoverable by parsing.
- **`openaiToCore`** — when `reasoning_content` is absent, split inline tags out of the assistant content BEFORE `deriveMessageId`, producing the exact same `reasoning` + `text` core sequence (including `reasoningContent` field) the field form produces. Field form wins; no double-split.
- **`responsesToCore` message case** — same normalization for assistant message items: inline-tagged text and `reasoning` item + clean message now share one identity space. Thinking-only turns yield a single reasoning piece (no empty text piece).
- exported from `wire/index.ts` for downstream mirrors (omp phase 2 will consume it instead of hand-rolling).

## Invariance guaranteed

For one turn, all of these now collapse to ONE id sequence / fingerprint:

| wire form | before | after |
|---|---|---|
| `reasoning_content` field + text | R + T | R + T |
| inline `<think>` + text | *(R+T)* as one text blob → different ids | R + T |
| responses `reasoning` item + message | R + T | R + T |
| responses message with inline tag | one text blob | R + T |

## Testing

- new `tests/wire-demoted-thinking.test.ts`: byte-exact reversal of every dialect form, stacked blocks + glue, malformed refusals, user-content-never-split, field-wins, thinking-only turns, `coreToOpenai` round-trip (inline → field normalization).
- suite: 404/404 pass; `tsc --noEmit` clean.

Fixes the kernel half of the issue #64 demoted variant (companion to billion-context-omp #124, which can now drop its mirror-layer retry).
