### PR TITLE
release: v0.0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.33",
+    "version": "0.0.34",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.34 — contains #112 (wire: normalize inline demoted thinking into one identity space, issue #64 kernel half).

After merge, CI (release.yml) tags v0.0.34 and publishes to npm.

Downstream:
- billion-context-omp: bump acp-kernel to 0.0.34, then drop the #124 mirror-layer demoteThinking retry (now redundant).
- billion-context (proxy): bump acp-kernel to 0.0.34 — picks up the same normalization (qwen inline-thinking streams get correct reasoning/text split + fingerprints).