### PR TITLE
chore: release v0.0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.34",
+    "version": "0.0.35",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release PR for the Phase 2 mirror constructors (#114). Merging publishes acp-kernel@0.0.35 to npm via release.yml.