### PR TITLE
feat: absorb billion-context-kit into the kernel (root viableRanges + /panel subpath)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
         "./wire": {
             "types": "./dist/wire/index.d.ts",
             "import": "./dist/wire/index.js"
+        },
+        "./panel": {
+            "types": "./dist/panel/index.d.ts",
+            "import": "./dist/panel/index.js"
         }
     },
     "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,5 @@ export {
   type NodeEffects,
 } from "./pipeline.js";
 export * from "./filter/index.js";
+
+export { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "./viable.js";

--- a/src/panel/format.ts
+++ b/src/panel/format.ts
@@ -1,0 +1,10 @@
+/** Compact token formatting for user-facing panels: lowercase k/M with the
+ *  same thresholds as the hosts' footers (<1000 → raw, <10000 → one decimal
+ *  k, <1e6 → rounded k, <1e7 → one decimal M). */
+export function formatCompactTokens(count: number): string {
+  if (count < 1000) return count.toString();
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1000000) return `${Math.round(count / 1000)}k`;
+  if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
+  return `${Math.round(count / 1000000)}M`;
+}

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -1,0 +1,4 @@
+export { topicFallback } from "./topic.js";
+export { formatCompactTokens } from "./format.js";
+export { buildStatusPanel } from "./panel.js";
+export type { StatusPanelInput } from "./panel.js";

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -1,0 +1,151 @@
+import { defaultCountTokens } from "../tokenize.js";
+import { formatRanges } from "../nudge-text.js";
+import type { CompressionState, NudgeDecision } from "../types.js";
+import { formatCompactTokens } from "./format.js";
+import { topicFallback } from "./topic.js";
+import { viableRanges } from "../viable.js";
+
+export interface StatusPanelInput {
+  /** Adapter identifier for the header, e.g. "billion-context-omp@0.1.6".
+   *  Omit to hide the version line. */
+  version?: string;
+  /** Host session accounting — the SAME number the host footer displays.
+   *  It is the append-only session tree including compressed originals; it
+   *  never shrinks when compression prunes the per-request view. */
+  tokenCount: number;
+  /** Measured token count of the host system prompt (host-specific to
+   *  obtain; the kernel breakdown does not see it). */
+  systemPromptTokens: number;
+  /** Kernel state (blocks drive the Blocks section). */
+  state: CompressionState;
+  /** The nudge decision from core.processTurn for this turn, if any. The
+   *  panel applies the viability filter to compressibleRanges itself. */
+  nudge: NudgeDecision | undefined;
+  /** Configured model context window, in tokens. */
+  modelContextLimit: number;
+  /** chars/4 estimate of the FULL (unpruned) core-message projection — the
+   *  same estimation scale as the kernel breakdown. When provided, the
+   *  panel derives `Session-only` on that scale (unpruned − sent). Without
+   *  it the line is omitted: subtracting the host's provider-scale number
+   *  from an estimate-scale number invents a third, meaningless scale
+   *  (issue #18 "看板统计的和拆分的有差异"). */
+  unprunedTokens?: number;
+  /** Token formatter override (defaults to formatCompactTokens). */
+  fmtTokens?: (n: number) => string;
+}
+
+function bar(value: number, total: number, width: number = 20): string {
+  if (total === 0) return "";
+  const filled = Math.max(0, Math.min(width, Math.round((value / total) * width)));
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+/** Render the /acp status panel. Three token numbers, each labeled with
+ *  its own scale, never mixed in arithmetic:
+ *  - Session accounting (host footer scale): the append-only session tree
+ *    INCLUDING compressed originals. It never shrinks — adapter pruning is
+ *    a per-request transform view the host cannot see.
+ *  - Sent view (chars/4 est.): what actually reaches the LLM after
+ *    compression (kernel's classification over the pruned projection +
+ *    measured system prompt). This is the number compression controls.
+ *  - Session-only (chars/4 est.): unpruned projection − sent view; the
+ *    compressed originals pruned from every request.
+ *  Subtracting the host number from an estimate produced numbers that
+ *  reconciled with neither scale ("Framework 390K", "session-only 29k vs
+ *  112k compressed") — that is what issue #18 reported. */
+export function buildStatusPanel(input: StatusPanelInput): string {
+  const { tokenCount, state, nudge, modelContextLimit } = input;
+  const fmt = input.fmtTokens ?? formatCompactTokens;
+  const bd = nudge?.contextBreakdown;
+  const limit = modelContextLimit;
+  const classified = bd ? bd.system + bd.tool + bd.summaries + bd.code + bd.text : 0;
+  const systemPromptTokens = input.systemPromptTokens;
+  const sentTotal = classified + systemPromptTokens;
+  // Same-scale derivation only: both sides are chars/4 estimates. The host
+  // footer's tokenCount (provider-anchored, session-tree) is displayed as
+  // its own line and never fed into an arithmetic difference with these.
+  const sessionOnly = input.unprunedTokens !== undefined ? Math.max(0, input.unprunedTokens - sentTotal) : 0;
+  const displayTotal = tokenCount;
+  const displayPct = limit > 0 ? Math.round((displayTotal / limit) * 100) : 0;
+  const sentPct = limit > 0 ? Math.round((sentTotal / limit) * 100) : 0;
+  const activeBlocksList = state.blocks.filter((b) => b.active);
+  const totalBlocksList = state.blocks;
+
+  const lines: string[] = [];
+
+  lines.push("╭─────────────────────────────────────────────╮");
+  lines.push("│           ACP Context Analysis              │");
+  lines.push("╰─────────────────────────────────────────────╯");
+  if (input.version) lines.push(input.version);
+  lines.push("");
+  lines.push(`Context (session accounting, host footer scale): ${displayPct}% (${fmt(displayTotal)} / ${fmt(limit)}) — never shrinks; includes compressed originals`);
+
+  if (nudge && bd) {
+    const growth = bd.growth;
+    if (growth > 0 && displayTotal > 0) {
+      lines.push(`Growth: +${fmt(growth)} since last nudge`);
+    }
+    lines.push("");
+    lines.push(`Sent to LLM (after compression, est.): ${fmt(sentTotal)}${limit > 0 ? ` (${sentPct}% of limit)` : ""}`);
+    if (input.unprunedTokens !== undefined && sessionOnly > 0) {
+      lines.push(`Session-only (compressed originals, est.): ${fmt(sessionOnly)} — pruned from every request; the footer/nudge still count them`);
+    }
+    lines.push("");
+    lines.push("Token Breakdown (sent view):");
+
+    const categories: Array<{ label: string; value: number }> = [
+      { label: "Tool", value: bd.tool },
+      { label: "SysPrompt", value: systemPromptTokens },
+      { label: "Text", value: bd.text },
+      { label: "Code", value: bd.code },
+      { label: "Summaries", value: bd.summaries },
+    ];
+
+    for (const cat of categories) {
+      if (cat.value <= 0) continue;
+      const pct = sentTotal > 0 ? Math.round((cat.value / sentTotal) * 100) : 0;
+      const b = bar(cat.value, sentTotal);
+      lines.push(`  ${cat.label.padEnd(10)} ${b} ${String(pct).padStart(3)}%  ${fmt(cat.value)}`);
+    }
+  }
+
+  lines.push("");
+
+  if (nudge) {
+    if (nudge.shouldInject) {
+      const tierInfo = nudge.tier ? ` [T${nudge.tier} distillation]` : "";
+      lines.push(`Nudge: ACTIVE${tierInfo} — ${nudge.reason}`);
+    } else {
+      lines.push(`Nudge: idle — ${nudge.reason}`);
+    }
+  }
+
+  const ranges = viableRanges(nudge?.compressibleRanges ?? []);
+  const protectedRanges = nudge?.protectedRanges ?? [];
+  if (ranges.length > 0 || protectedRanges.length > 0) {
+    lines.push("");
+    lines.push(formatRanges(ranges, protectedRanges));
+  }
+
+  if (activeBlocksList.length > 0) {
+    lines.push("");
+    lines.push(`Blocks: ${activeBlocksList.length} active / ${totalBlocksList.length} total (${fmt(state.stats.tokensCompressed)} tokens compressed)`);
+    for (const b of activeBlocksList) {
+      const topic = b.topic ? `: ${b.topic}` : `: ${topicFallback(b.summary || "")}`;
+      const summaryTok = defaultCountTokens(b.summary || "");
+      const origTok = b.compressedTokens > 0 ? b.compressedTokens : summaryTok;
+      lines.push(`  [${b.blockId}] T${b.tier} ${fmt(origTok)}→${fmt(summaryTok)}${topic}`);
+    }
+  } else if (totalBlocksList.length > 0) {
+    lines.push("");
+    lines.push(`Blocks: 0 active / ${totalBlocksList.length} total (${fmt(state.stats.tokensCompressed)} tokens compressed)`);
+  } else {
+    lines.push("");
+    lines.push("Blocks: none (nothing compressed yet)");
+  }
+
+  lines.push("");
+  lines.push("Tag visibility: tags injected to LLM only (deep copy), not persisted in session, not shown in terminal.");
+
+  return lines.join("\n");
+}

--- a/src/panel/topic.ts
+++ b/src/panel/topic.ts
@@ -1,0 +1,8 @@
+/** Short topic for a block when the model did not provide one: first sentence
+ *  segment, leading quotes stripped, truncated to 30 chars with an ellipsis.
+ *  Used wherever block lists are rendered (panels, search results). */
+export function topicFallback(summary: string): string {
+  const first = summary.split(/[.\n]/)[0] ?? "";
+  const t = first.trim().replace(/^["'`]+/, "").trim();
+  return t.length <= 30 ? t : `${t.slice(0, 30).trimEnd()}…`;
+}

--- a/src/viable.ts
+++ b/src/viable.ts
@@ -1,0 +1,13 @@
+/** Minimum size for a compressible range to be worth recommending. Ranges
+ *  below this are fragmented leftovers (a 16-token ack, a one-line tool
+ *  result): the model cannot write a meaningful >=50-char summary for them,
+ *  and a batched compress call that includes one gets atomically rejected
+ *  (the kernel validates the whole batch). Observed in the wild: a 14-range
+ *  recommendation list containing a 16-token range → every batch attempt
+ *  failed with "Summary too short". Apply on every surface that recommends
+ *  ranges: the injected nudge, acp_status, and the /acp panel. */
+export const VIABLE_RANGE_MIN_TOKENS = 200;
+
+export function viableRanges<T extends { tokens: number }>(ranges: T[]): T[] {
+  return ranges.filter((r) => r.tokens >= VIABLE_RANGE_MIN_TOKENS);
+}

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -1,0 +1,105 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildStatusPanel, topicFallback, formatCompactTokens } from "../src/panel/index.js";
+import { VIABLE_RANGE_MIN_TOKENS } from "../src/viable.js";
+
+test("panel separates session accounting from sent view", () => {
+  const nudge = {
+    shouldInject: false,
+    reason: "idle — max compressible 8106 < threshold 50000",
+    compressibleRanges: [
+      { startRef: "m00002", endRef: "m00005", tokens: 16 },
+      { startRef: "m00010", endRef: "m00040", tokens: 8_106 },
+    ],
+    contextUsage: 0.43,
+    tier: null,
+    breakdown: { emergencyOverride: 0 },
+    contextBreakdown: { system: 0, tool: 20_000, text: 4_000, code: 0, summaries: 0, total: 24_000, growth: 6_100 },
+  };
+  const state = {
+    blocks: [],
+    messageRefs: { byRaw: {}, byRef: {} },
+    nudge: {},
+    stats: { tokensCompressed: 0 },
+    nextBlockId: 1,
+    nextRunId: 1,
+  };
+  const text = buildStatusPanel({
+    version: "acp-kernel@0.0.36 (test)",
+    tokenCount: 430_000,
+    systemPromptTokens: 0,
+    state: state as never,
+    nudge: nudge as never,
+    modelContextLimit: 1_000_000,
+  });
+
+  assert.match(text, /Context \(session accounting, host footer scale\): 43% \(430k \/ 1\.0M\) — never shrinks/);
+  assert.match(text, /Sent to LLM \(after compression, est\.\): 24k \(2% of limit\)/);
+  assert.doesNotMatch(text, /Session-only/, "omitted without unprunedTokens — no cross-scale subtraction");
+  assert.match(text, /Token Breakdown \(sent view\):/);
+  assert.doesNotMatch(text, /Framework/, "no fake Framework bucket");
+  const toolLine = text.split("\n").find((l) => l.trim().startsWith("Tool"))!;
+  assert.match(toolLine, / 83%/, `bar percentages must use the sent view: ${toolLine}`);
+  assert.doesNotMatch(text, /m00002\.\.m00005/, "sub-viability ranges must not be listed");
+});
+
+test("panel renders blocks with topic fallback and version line", () => {
+  const state = {
+    blocks: [
+      { blockId: "b1", tier: 1, active: true, summary: "Plugin discovery and registration walkthrough.", compressedTokens: 25_000, effectiveMessageIds: [], coveredRawIds: [], createdAt: 1 },
+    ],
+    messageRefs: { byRaw: {}, byRef: {} },
+    nudge: {},
+    stats: { tokensCompressed: 25_000 },
+    nextBlockId: 2,
+    nextRunId: 1,
+  };
+  const text = buildStatusPanel({ tokenCount: 1_000, systemPromptTokens: 0, state: state as never, nudge: undefined, modelContextLimit: 200_000 });
+  assert.match(text, /Blocks: 1 active \/ 1 total \(25k tokens compressed\)/);
+  assert.match(text, /\[b1\] T1 25k→\d+.*Plugin discovery and registrat…/);
+  assert.doesNotMatch(text, /acp-kernel@/, "no version line when omitted");
+});
+
+test("viability floor constant stays coupled to kernel summary rules", () => {
+  assert.equal(VIABLE_RANGE_MIN_TOKENS, 200);
+});
+
+test("session-only derives on the estimation scale, never cross-scale", () => {
+  // 430k provider-scale footer vs 24k sent view (chars/4). With the full
+  // projection estimated at 134k on the SAME chars/4 scale, session-only
+  // must read 110k — not 430k − 24k = 406k (issue #18).
+  const nudge = {
+    shouldInject: false,
+    reason: "idle",
+    contextBreakdown: { system: 0, tool: 20_000, text: 4_000, code: 0, summaries: 0, total: 24_000, growth: 0 },
+  };
+  const state = { blocks: [], messageRefs: { byRaw: {}, byRef: {} }, nudge: {}, stats: { tokensCompressed: 0 }, nextBlockId: 1, nextRunId: 1 };
+  const text = buildStatusPanel({
+    tokenCount: 430_000,
+    systemPromptTokens: 0,
+    state: state as never,
+    nudge: nudge as never,
+    modelContextLimit: 1_000_000,
+    unprunedTokens: 134_000,
+  });
+  assert.match(text, /Session-only \(compressed originals, est\.\): 110k — pruned from every request/);
+});
+
+test("topicFallback takes the first sentence segment, ≤30 chars", () => {
+  assert.equal(topicFallback("Database migration steps failed twice."), "Database migration steps faile…");
+  assert.equal(topicFallback('He said "hello". More text.'), 'He said "hello"');
+  assert.equal(topicFallback("Short."), "Short");
+});
+
+test("topicFallback truncates long segments at 30 chars with ellipsis", () => {
+  const out = topicFallback("A".repeat(50));
+  assert.equal(out.length, 31);
+  assert.ok(out.endsWith("…"));
+});
+
+test("formatCompactTokens matches host footer thresholds", () => {
+  assert.equal(formatCompactTokens(999), "999");
+  assert.equal(formatCompactTokens(9_500), "9.5k");
+  assert.equal(formatCompactTokens(430_000), "430k");
+  assert.equal(formatCompactTokens(1_500_000), "1.5M");
+});

--- a/tests/viable.test.ts
+++ b/tests/viable.test.ts
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "../src/viable.js";
+
+test("viableRanges drops fragmented ranges below the floor", () => {
+  const ranges = [
+    { startRef: "m00001", endRef: "m00004", tokens: 57 },
+    { startRef: "m00006", endRef: "m00006", tokens: 8 },
+    { startRef: "m00119", endRef: "m00128", tokens: 1_000 },
+    { startRef: "m00200", endRef: "m00201", tokens: 4_700 },
+  ];
+  const kept = viableRanges(ranges);
+  assert.deepEqual(kept.map((r) => r.tokens), [1_000, 4_700]);
+  assert.equal(VIABLE_RANGE_MIN_TOKENS, 200);
+});
+
+test("viableRanges boundary: exactly the floor is kept, empty is empty", () => {
+  assert.equal(viableRanges([{ tokens: 200 }]).length, 1);
+  assert.deepEqual(viableRanges([]), []);
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/wire/index.ts"],
+    entry: ["src/index.ts", "src/wire/index.ts", "src/panel/index.ts"],
     format: ["esm"],
     dts: false,
     clean: false,


### PR DESCRIPTION
## Why

billion-context-kit ("Layer 3 of the acp-kernel → kit → adapter stack") shipped as a separate package that pins acp-kernel@0.0.23. Downstream this means omp today installs **two kernel copies**:

```
acp-kernel@0.0.35
└─ billion-context-kit@0.2.0
   └── acp-kernel@0.0.23   (nested, 12 versions stale)
```

Benign only because kit used the kernel types-only. A "shared alignment layer" that is itself the biggest version-skew source is not paying its way — and the separation already leaked (kit's `VIABLE_RANGE_MIN_TOKENS=200` exists to compensate the kernel's atomic batch validation; proxy hand-rolls the same filter with a comment "Aligns with billion-context-pi's handleStatus").

## What

Absorb kit (315 lines, zero runtime deps) into the kernel:

| kit export | new home | why |
|---|---|---|
| `viableRanges`, `VIABLE_RANGE_MIN_TOKENS` | kernel **root** | validation-compensation policy; lives beside the atomic batch validation it compensates for |
| `topicFallback`, `formatCompactTokens`, `buildStatusPanel`, `StatusPanelInput` | new **`acp-kernel/panel`** subpath | presentation surface; same opt-in pattern as `acp-kernel/wire` — consumers that want no UI simply don't import it |

- Sources moved verbatim (byte-identical behavior); imports re-pointed to in-tree modules.
- Tests ported bun:test → node:test: 413 → **422 pass**, typecheck clean, `dist/panel` emits.
- Root keeps "zero runtime dependencies"; the in-package boundary (root = policy, /panel = rendering) replaces the cross-package one without the release-train cost.

## After merge

1. omp: swap kit imports → kernel, drop the dependency (dual kernel copy disappears)
2. billion-context-pi: same (kit's heaviest consumer)
3. proxy: `handleAcpStatus` stops hand-rolling the viability filter, consumes kernel `viableRanges`
4. archive the billion-context-kit repo
