### PR TITLE
release v0.0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.35",
+    "version": "0.0.36",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Kernel absorption of billion-context-kit (#116): root viableRanges + /panel subpath. Publishes acp-kernel@0.0.36 — required before omp/pi/proxy can consume it.