### PR TITLE
chore: release v0.0.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Bump package.json to 0.0.37. Contains #120 (openai leading system/developer hoisted out of the fold space — fixes compression eating the system prompt and restart replay fingerprint mismatches). Merge publishes to npm via release.yml (NPM_TOKEN already set).