### PR TITLE
release v0.0.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.28",
+    "version": "0.0.38",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.28",
+            "version": "0.0.38",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.37",
+    "version": "0.0.38",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Ships the #195 promote-after-prune fix (PR #119, merged as 50bfa0b) which was cut from v0.0.37 (that release predates the #119 merge and only carried openai-system-hoist).

- fix: resolve active blocks via their rendered summary after prune (billion-context-pi#195) — 8a4dc72
- 437/437 tests, typecheck clean, build OK

Downstream (billion-context-pi v0.1.46, billion-context-omp v0.3.2, billion-context) pin 0.0.38 and wait on this publish.