### PR TITLE
release v0.0.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.38",
+    "version": "0.0.39",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.38",
+            "version": "0.0.39",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.38",
+    "version": "0.0.39",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Ships the nested-discovery follow-up fix from #124 (billion-context-pi#195):
blocks covering the session's first user message are now consumed by m-ref
ranges again (pi e2e 05-multiple-compressions regression on 0.0.38).

Pre-flight: typecheck clean, 438/438 tests, build OK.

Downstream release branches (pi v0.1.46 / omp v0.3.2 / billion-context) will
re-pin to 0.0.39 once this is live on npm.