### PR TITLE
feat(persist): StateStore subpath — generic atomic state persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
         "./panel": {
             "types": "./dist/panel/index.d.ts",
             "import": "./dist/panel/index.js"
+        },
+        "./persist": {
+            "types": "./dist/persist/index.d.ts",
+            "import": "./dist/persist/index.js"
         }
     },
     "files": [

--- a/src/persist/index.ts
+++ b/src/persist/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Persistence subpath: crash-safe JSON state storage for downstream hosts.
+ *
+ * The kernel core is pure (no fs). This subpath is the ONLY kernel module
+ * that touches the filesystem, so hosts that never persist stay fs-free by
+ * not importing `acp-kernel/persist`.
+ *
+ * Division of responsibility:
+ * - store owns MECHANISM: atomic writes, rename retries, debounce,
+ *   serialization, discovery, corrupt-file tolerance
+ * - downstream owns POLICY: storage location (dir is a constructor
+ *   argument — the kernel has no default path), schema version, payload
+ *   shape, validation, and lifecycle (when to save, what to load)
+ * - the store never deletes files; cleanup is a downstream decision
+ */
+export { StateStore, flatFileNameFor } from "./store.js";
+export type { PersistedEnvelope, PersistLogger, StateStoreOptions } from "./store.js";
+export { mergeCompressionState } from "./state-merge.js";

--- a/src/persist/state-merge.ts
+++ b/src/persist/state-merge.ts
@@ -1,0 +1,23 @@
+import type { CompressionState } from "../types.js";
+import { createInitialState } from "../state.js";
+
+/**
+ * Forward-compat: merge a parsed state with a fresh one so fields added in
+ * later kernel versions get sane defaults instead of `undefined`. Nested
+ * groups (nudge, stats) are shallow-merged per field so older snapshots
+ * keep their values while newer counters default in.
+ *
+ * Lifted verbatim in behavior from billion-context's proxy mergeState.
+ */
+export function mergeCompressionState(parsed: CompressionState): CompressionState {
+  const fresh = createInitialState();
+  return {
+    blocks: parsed.blocks ?? fresh.blocks,
+    messageRefs: parsed.messageRefs ?? fresh.messageRefs,
+    nudge: { ...fresh.nudge, ...(parsed.nudge ?? {}) },
+    stats: { ...fresh.stats, ...(parsed.stats ?? {}) },
+    nextBlockId: parsed.nextBlockId ?? fresh.nextBlockId,
+    nextRunId: parsed.nextRunId ?? fresh.nextRunId,
+    tokenSnapshot: parsed.tokenSnapshot ?? fresh.tokenSnapshot,
+  };
+}

--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -1,0 +1,431 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+/** Logger callback. Downstream routes it wherever it wants (file, stderr). */
+export type PersistLogger = (level: "info" | "warn" | "error", msg: string) => void;
+
+/**
+ * On-disk record shape. The store owns the envelope (version stamp, save
+ * time, id) so atomicity and discovery can rely on it; the payload schema
+ * is entirely downstream-owned. `payload` must be JSON-serializable.
+ */
+export interface PersistedEnvelope<T> {
+    version: number;
+    savedAt: number;
+    id: string;
+    payload: T;
+}
+
+export interface StateStoreOptions<T> {
+    /**
+     * Storage root. The kernel deliberately has NO default location: the
+     * downstream decides where state lives (CLI dir, XDG data dir, plugin
+     * dir, temp dir in tests). All records live under this directory.
+     */
+    dir: string;
+    /**
+     * Schema version stamped into every envelope. Owned by the downstream;
+     * bump it when the payload shape changes. The store itself never
+     * rejects a record over its version — migration policy belongs to the
+     * reader.
+     */
+    version: number;
+    /** Debounce window for scheduleSave, ms. Default 500. */
+    debounceMs?: number;
+    /** Default true. When false, all writes are silent no-ops and loads
+     *  return empty results. */
+    enabled?: boolean;
+    log?: PersistLogger;
+    /**
+     * Relative path (under `dir`) for a record, possibly namespaced into
+     * subdirectories (e.g. `openai/host-hash.json`). Default: flat
+     * `<sha256(id)[:24]>.json`.
+     *
+     * Because the path may depend on payload fields the store only learns
+     * at write time, single-record loads resolve namespaced files only
+     * after loadAll() has discovered them (or the store itself wrote
+     * them). The flat default name is always checked as a fallback, so
+     * downstreams using a custom relPath should call loadAll() at boot.
+     */
+    relPath?: (id: string, payload: T) => string;
+    /**
+     * Payload validation on load. Return false to skip a record (foreign
+     * schema, corrupt content). Default: envelope-shape check only
+     * (string id, non-null payload).
+     */
+    validate?: (envelope: PersistedEnvelope<T>) => boolean;
+}
+
+/**
+ * Crash-safe, debounce-coalescing JSON state store. Mechanism only — lifted
+ * from billion-context's proxy SessionStore and generalized:
+ *
+ * - atomic writes: temp file + rename, so a crash mid-write never leaves a
+ *   truncated record (readers see either the old or the new file)
+ * - rename retries on Windows transient locks (EPERM/EBUSY/EACCES)
+ * - per-id serialization so concurrent writeNow calls never interleave
+ *   temp-file names or reorders writes
+ * - debounced scheduleSave coalesces bursts into one write; the record is
+ *   built at WRITE time from a builder, so late mutations are picked up
+ * - loadAll skips `.tmp-*` orphans, corrupt JSON, and records whose
+ *   filename does not match their id — one bad file never blocks boot
+ *
+ * The store never deletes files. Session cleanup is a downstream policy
+ * decision (kernel position: persisted state should not be deleted
+ * opportunistically).
+ */
+export class StateStore<T> {
+    readonly enabled: boolean;
+    private readonly dir: string;
+    private readonly version: number;
+    private readonly debounceMs: number;
+    private readonly log: PersistLogger;
+    private readonly relPathFn?: (id: string, payload: T) => string;
+    private readonly validateFn: (envelope: PersistedEnvelope<T>) => boolean;
+    private readonly timers = new Map<string, NodeJS.Timeout>();
+    private readonly pending = new Map<string, () => T>();
+    private readonly writeChains = new Map<string, Promise<void>>();
+    /** id → absolute path, populated by writes and loadAll. */
+    private readonly discovered = new Map<string, string>();
+    /** Monotonic counter for unique temp filenames within a process. */
+    private tmpSeq = 0;
+
+    constructor(opts: StateStoreOptions<T>) {
+        this.dir = opts.dir;
+        this.version = opts.version;
+        this.debounceMs = opts.debounceMs ?? 500;
+        this.enabled = opts.enabled ?? true;
+        this.log = opts.log ?? ((_level, _msg) => {});
+        this.relPathFn = opts.relPath;
+        this.validateFn = opts.validate ?? defaultValidate;
+    }
+
+    /** Debounced save. Coalesces bursts; the builder runs at write time, so
+     *  the freshest state is always persisted. Never throws. */
+    scheduleSave(id: string, build: () => T): void {
+        if (!this.enabled) return;
+        this.pending.set(id, build);
+        const existing = this.timers.get(id);
+        if (existing) return;
+        const timer = setTimeout(() => {
+            this.timers.delete(id);
+            const builder = this.pending.get(id);
+            this.pending.delete(id);
+            if (!builder) return;
+            // Errors are logged inside writeInner; swallowing here keeps a
+            // failed timer write from becoming an unhandledRejection.
+            void this.writeNow(id, builder).catch(() => {});
+        }, this.debounceMs);
+        timer.unref?.();
+        this.timers.set(id, timer);
+    }
+
+    /** Immediate save, serialized per id. Rejects on write failure; a
+     *  failing write never breaks the chain for the next one. */
+    async writeNow(id: string, build: () => T): Promise<void> {
+        if (!this.enabled) return;
+        // The previous promise may reject (disk full, EPERM) — catch so our
+        // chain doesn't break, then run our own write.
+        const prev = this.writeChains.get(id) ?? Promise.resolve();
+        const next = prev.catch(() => {}).then(() => this.writeInner(id, build));
+        this.writeChains.set(id, next);
+        // Clean up the chain entry once settled so the Map doesn't grow. The
+        // .catch() is load-bearing: .finally() returns a derived promise that
+        // nobody else holds — when the chain rejects it would surface as an
+        // unhandledRejection and crash the host on default Node settings.
+        next
+            .finally(() => {
+                if (this.writeChains.get(id) === next) this.writeChains.delete(id);
+            })
+            .catch(() => {});
+        return next;
+    }
+
+    /** Synchronous flush for one id. Used where the caller cannot await
+     *  (memory eviction, sync shutdown paths). Cancels any pending debounce
+     *  timer. Returns true on success, false on failure — callers that use
+     *  the result to drop in-memory state must NOT drop it on failure. */
+    flushSync(id: string, build: () => T): boolean {
+        if (!this.enabled) return true;
+        const timer = this.timers.get(id);
+        if (timer) {
+            clearTimeout(timer);
+            this.timers.delete(id);
+            this.pending.delete(id);
+        }
+        let payload: T;
+        try {
+            payload = build();
+        } catch (e) {
+            this.log("error", `[persist] builder failed for ${id}: ${errText(e)}`);
+            return false;
+        }
+        const file = this.resolvePath(id, payload);
+        const data = JSON.stringify(this.envelope(id, payload));
+        try {
+            fs.mkdirSync(path.dirname(file), { recursive: true });
+        } catch (e) {
+            this.log("warn", `[persist] could not create dir ${path.dirname(file)}: ${errText(e)}`);
+        }
+        const tmp = this.tempPath(file);
+        try {
+            fs.writeFileSync(tmp, data, "utf8");
+            // renameSync can throw EPERM/EBUSY on Windows when the dest is
+            // briefly held (AV scanner, indexer, SMB). Retry briefly —
+            // transient locks usually release within ms.
+            let lastErr: unknown;
+            for (let attempt = 0; attempt < 3; attempt++) {
+                try {
+                    fs.renameSync(tmp, file);
+                    lastErr = undefined;
+                    break;
+                } catch (e) {
+                    lastErr = e;
+                    const code = (e as NodeJS.ErrnoException).code;
+                    if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
+                    // brief sync backoff (Atomics.wait is the sync sleep)
+                    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20 * (attempt + 1));
+                }
+            }
+            if (lastErr) throw lastErr;
+            this.discovered.set(id, file);
+            return true;
+        } catch (e) {
+            this.log("error", `[persist] flushSync failed for ${id}: ${errText(e)}`);
+            try {
+                fs.unlinkSync(tmp);
+            } catch {
+                // best-effort cleanup of the orphan temp
+            }
+            return false;
+        }
+    }
+
+    /** Load one record. Checks the discovered path (from a prior
+     *  write/loadAll) and the flat default name. Returns null when absent,
+     *  disabled, corrupt, or rejected by validate. */
+    loadSync(id: string): PersistedEnvelope<T> | null {
+        if (!this.enabled) return null;
+        const candidates = [this.discovered.get(id), path.join(this.dir, flatFileNameFor(id))];
+        for (const file of candidates) {
+            if (!file) continue;
+            const envelope = this.readEnvelope(file);
+            if (envelope && envelope.id === id) return envelope;
+        }
+        return null;
+    }
+
+    /** Load every record under dir. Populates the discovery map (enables
+     *  loadSync for namespaced relPaths). Skips corrupt files, `.tmp-*`
+     *  orphans, and records whose filename does not match their id — one
+     *  bad file never blocks boot. Never throws. */
+    async loadAll(): Promise<Map<string, PersistedEnvelope<T>>> {
+        const out = new Map<string, PersistedEnvelope<T>>();
+        if (!this.enabled) return out;
+        const files = await this.walkJsonFiles(this.dir);
+        for (const file of files) {
+            const envelope = this.readEnvelope(file);
+            if (!envelope) continue;
+            const expected =
+                path.basename(this.relPathOf(envelope.id, envelope.payload)) === path.basename(file) ||
+                flatFileNameFor(envelope.id) === path.basename(file);
+            if (!expected) {
+                this.log("warn", `[persist] skipping ${rel(file, this.dir)}: filename does not match record id`);
+                continue;
+            }
+            this.discovered.set(envelope.id, file);
+            out.set(envelope.id, envelope);
+        }
+        return out;
+    }
+
+    /** Whether a debounced write is pending for an id. */
+    hasPending(id: string): boolean {
+        return this.timers.has(id);
+    }
+
+    /** Ids with a pending debounced write. */
+    pendingIds(): string[] {
+        return [...this.timers.keys()];
+    }
+
+    /** Flush every pending debounced write immediately, then drain in-flight
+     *  writes. For graceful shutdown (SIGTERM/SIGINT). Never rejects. */
+    async flushAll(): Promise<void> {
+        const ids = this.pendingIds();
+        for (const timer of this.timers.values()) clearTimeout(timer);
+        this.timers.clear();
+        const builders = new Map<string, () => T>();
+        for (const id of ids) {
+            const build = this.pending.get(id);
+            if (build) builders.set(id, build);
+            this.pending.delete(id);
+        }
+        await Promise.all(
+            [...builders.entries()].map(([id, build]) =>
+                this.writeNow(id, build).catch((e) => {
+                    this.log("error", `[persist] shutdown flush failed for ${id}: ${errText(e)}`);
+                }),
+            ),
+        );
+        // Drain writes whose timer fired earlier but are still mid-flight.
+        await Promise.allSettled([...this.writeChains.values()]);
+    }
+
+    /** Cancel all pending debounced writes without flushing (tests). */
+    cancelAll(): void {
+        for (const timer of this.timers.values()) clearTimeout(timer);
+        this.timers.clear();
+        this.pending.clear();
+    }
+
+    private async writeInner(id: string, build: () => T): Promise<void> {
+        let payload: T;
+        try {
+            payload = build();
+        } catch (e) {
+            this.log("error", `[persist] builder failed for ${id}: ${errText(e)}`);
+            throw e;
+        }
+        const file = this.resolvePath(id, payload);
+        try {
+            await fsp.mkdir(path.dirname(file), { recursive: true });
+        } catch (e) {
+            this.log("warn", `[persist] could not create dir ${path.dirname(file)}: ${errText(e)}`);
+        }
+        const tmp = this.tempPath(file);
+        try {
+            await fsp.writeFile(tmp, JSON.stringify(this.envelope(id, payload)), "utf8");
+            await renameWithRetry(tmp, file);
+            this.discovered.set(id, file);
+        } catch (e) {
+            // Wrap so a failure cleans up the .tmp orphan instead of leaving
+            // it for the next write to collide with.
+            await fsp.unlink(tmp).catch(() => {});
+            this.log("error", `[persist] write failed for ${id}: ${errText(e)}`);
+            throw e;
+        }
+    }
+
+    private envelope(id: string, payload: T): PersistedEnvelope<T> {
+        return { version: this.version, savedAt: Date.now(), id, payload };
+    }
+
+    /** Absolute path for a record: custom relPath (guarded against path
+     *  escape) or the flat hash default. */
+    private resolvePath(id: string, payload: T): string {
+        return path.join(this.dir, this.relPathOf(id, payload));
+    }
+
+    private relPathOf(id: string, payload: T): string {
+        const custom = this.relPathFn?.(id, payload);
+        if (!custom) return flatFileNameFor(id);
+        const rel = path.normalize(custom);
+        if (path.isAbsolute(rel) || rel.split(/[\\/]+/).includes("..")) {
+            this.log("warn", `[persist] relPath for ${id} escapes dir; using flat name`);
+            return flatFileNameFor(id);
+        }
+        return rel;
+    }
+
+    /** Unique temp file next to the destination (same dir ⇒ same volume ⇒
+     *  rename is atomic). Prefixed `.tmp-` so loadAll skips orphans. */
+    private tempPath(dest: string): string {
+        const seq = this.tmpSeq++;
+        return path.join(path.dirname(dest), `.tmp-${path.basename(dest, ".json")}-${process.pid}-${seq}`);
+    }
+
+    /** Parse + validate one file. Corrupt or invalid records return null
+     *  (logged) instead of throwing — load paths must never block boot. */
+    private readEnvelope(file: string): PersistedEnvelope<T> | null {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+        } catch (e) {
+            // A missing candidate path is an expected miss (loadSync probes);
+            // only genuinely unreadable/corrupt files get logged.
+            if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+                this.log("warn", `[persist] skipping corrupt file ${rel(file, this.dir)}: ${errText(e)}`);
+            }
+            return null;
+        }
+        if (!isEnvelopeLike(parsed) || !this.validateFn(parsed as PersistedEnvelope<T>)) {
+            this.log("warn", `[persist] skipping invalid record ${rel(file, this.dir)}`);
+            return null;
+        }
+        return parsed as PersistedEnvelope<T>;
+    }
+
+    /** Iterative recursive walk (no readdir-recursive dependency), skipping
+     *  `.tmp-*` names and non-.json files. */
+    private async walkJsonFiles(root: string): Promise<string[]> {
+        const out: string[] = [];
+        const queue: string[] = [root];
+        while (queue.length > 0) {
+            const dir = queue.pop()!;
+            let dirents: fs.Dirent[];
+            try {
+                dirents = await fsp.readdir(dir, { withFileTypes: true });
+            } catch {
+                continue; // missing dir → no records yet
+            }
+            for (const d of dirents) {
+                if (d.name.startsWith(".tmp-")) continue;
+                const full = path.join(dir, d.name);
+                if (d.isDirectory()) queue.push(full);
+                else if (d.isFile() && d.name.endsWith(".json")) out.push(full);
+            }
+        }
+        return out;
+    }
+}
+
+function defaultValidate<T>(envelope: PersistedEnvelope<T>): boolean {
+    return typeof envelope.id === "string" && envelope.id.length > 0 && envelope.payload != null;
+}
+
+function isEnvelopeLike(value: unknown): value is PersistedEnvelope<unknown> {
+    if (!value || typeof value !== "object") return false;
+    const v = value as Partial<PersistedEnvelope<unknown>>;
+    return typeof v.id === "string" && "payload" in v;
+}
+
+/** Deterministic flat filename: `<sha256(id)[:24]>.json`. Truncated hash —
+ *  96 bits keeps collisions unreachable for realistic id counts, and short
+ *  names stay greppable. */
+export function flatFileNameFor(id: string): string {
+    return createHash("sha256").update(id, "utf8").digest("hex").slice(0, 24) + ".json";
+}
+
+/** fs.rename with brief retries on Windows transient locks (EPERM/EBUSY/
+ *  EACCES from AV scan, search indexer, SMB). A short delay + retry almost
+ *  always succeeds; other errors are real and rethrown immediately. */
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            await fsp.rename(src, dest);
+            return;
+        } catch (e) {
+            lastErr = e;
+            const code = (e as NodeJS.ErrnoException).code;
+            if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") throw e;
+            const { promise, resolve } = Promise.withResolvers<void>();
+            setTimeout(resolve, 20 * (attempt + 1));
+            await promise;
+        }
+    }
+    throw lastErr;
+}
+
+function errText(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+}
+
+
+function rel(p: string, base: string): string {
+    const r = path.relative(base, p);
+    return r && !r.startsWith("..") ? r : p;
+}

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -1,0 +1,371 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { StateStore, flatFileNameFor } from "../src/persist/store.js";
+import { mergeCompressionState } from "../src/persist/state-merge.js";
+import { createInitialState } from "../src/state.js";
+import type { CompressionState } from "../src/types.js";
+
+interface Payload {
+    label: string;
+    count: number;
+}
+
+function tmpDir(): string {
+    return mkdtempSync(path.join(tmpdir(), "acp-kernel-persist-"));
+}
+
+function store(dir: string, opts: Partial<ConstructorParameters<typeof StateStore<Payload>>[0]> = {}): StateStore<Payload> {
+    return new StateStore<Payload>({ dir, version: 1, ...opts });
+}
+
+/**
+ * Poll until `cond` holds. Debounce timing is real platform behavior (the
+ * timer fires via the event loop), so the tests await the observable signal
+ * — the settled disk state — instead of a guessed fixed duration. The sleep
+ * step is only the poll cadence, never the assertion.
+ */
+async function until(cond: () => boolean, what: string, deadlineMs = 4000): Promise<void> {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > deadlineMs) {
+            assert.fail(`timed out waiting for: ${what}`);
+        }
+        await new Promise((r) => setTimeout(r, 5));
+    }
+}
+
+test("writeNow persists a round-trippable envelope", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        await s.writeNow("sid-1", () => ({ label: "hello", count: 42 }));
+        const loaded = s.loadSync("sid-1");
+        assert.ok(loaded);
+        assert.equal(loaded.id, "sid-1");
+        assert.equal(loaded.version, 1);
+        assert.equal(typeof loaded.savedAt, "number");
+        assert.deepEqual(loaded.payload, { label: "hello", count: 42 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("writeNow builds the payload at write time, not call time", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        const live = { label: "before", count: 0 };
+        const pending = s.writeNow("sid-live", () => live);
+        live.label = "after";
+        live.count = 7;
+        await pending;
+        const loaded = s.loadSync("sid-live");
+        assert.ok(loaded);
+        assert.deepEqual(loaded.payload, { label: "after", count: 7 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadSync returns null for unknown ids and when disabled", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        assert.equal(s.loadSync("missing"), null);
+        const off = store(dir, { enabled: false });
+        await off.writeNow("sid-off", () => ({ label: "x", count: 0 }));
+        assert.equal(off.loadSync("sid-off"), null);
+        assert.equal((await off.loadAll()).size, 0);
+        // disabled flushSync reports success (nothing was at risk)
+        assert.equal(off.flushSync("sid-off", () => ({ label: "x", count: 0 })), true);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scheduleSave coalesces bursts into one freshest write", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { debounceMs: 20 });
+        let builds = 0;
+        const live = { label: "v1", count: 1 };
+        const build = (): Payload => {
+            builds += 1;
+            return live;
+        };
+        s.scheduleSave("sid-d", build);
+        live.label = "v2";
+        live.count = 2;
+        s.scheduleSave("sid-d", build);
+        assert.equal(s.hasPending("sid-d"), true);
+        assert.deepEqual(s.pendingIds(), ["sid-d"]);
+        // await the settled disk state: the debounced timer fired, the write
+        // landed, and it carries the freshest payload
+        await until(() => s.loadSync("sid-d")?.payload.label === "v2", "debounced write to settle");
+        assert.equal(s.hasPending("sid-d"), false);
+        // builder ran exactly once — the second scheduleSave only replaced it
+        assert.equal(builds, 1);
+        assert.deepEqual(s.loadSync("sid-d")?.payload, { label: "v2", count: 2 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scheduleSave builder failures are contained, not unhandled rejections", async () => {
+    const dir = tmpDir();
+    try {
+        const errors: string[] = [];
+        const s = store(dir, {
+            debounceMs: 10,
+            log: (level, msg) => {
+                if (level === "error") errors.push(msg);
+            },
+        });
+        s.scheduleSave("sid-bad", () => {
+            throw new Error("boom");
+        });
+        await until(() => !s.hasPending("sid-bad") && errors.length > 0, "failed builder to be logged");
+        assert.equal(errors.length, 1);
+        assert.match(errors[0] ?? "", /boom/);
+        // store still usable afterwards
+        await s.writeNow("sid-ok", () => ({ label: "ok", count: 0 }));
+        assert.ok(s.loadSync("sid-ok"));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("flushSync writes immediately and cancels the debounce", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { debounceMs: 30 });
+        let builds = 0;
+        s.scheduleSave("sid-f", () => {
+            builds += 1;
+            return { label: "debounced", count: 0 };
+        });
+        assert.equal(s.flushSync("sid-f", () => ({ label: "flushed", count: 3 })), true);
+        assert.equal(s.hasPending("sid-f"), false);
+        const loaded = s.loadSync("sid-f");
+        assert.ok(loaded);
+        assert.deepEqual(loaded.payload, { label: "flushed", count: 3 });
+        // Proving the cancelled timer never fires is a negative over time.
+        // Deterministic clock control can't cover it: node:test mock timers
+        // don't support the unref() the store's debounce relies on, so this
+        // one assertion deliberately outruns the real 30ms window.
+        const start = Date.now();
+        while (Date.now() - start < 60) {
+            await new Promise((r) => setTimeout(r, 5));
+        }
+        assert.equal(builds, 0); // timer cancelled before it could fire
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("flushAll flushes pending builders and drains in-flight writes", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { debounceMs: 5000 });
+        s.scheduleSave("sid-a", () => ({ label: "a", count: 0 }));
+        s.scheduleSave("sid-b", () => ({ label: "b", count: 0 }));
+        assert.equal(s.pendingIds().length, 2);
+        await s.flushAll();
+        assert.equal(s.pendingIds().length, 0);
+        assert.ok(s.loadSync("sid-a"));
+        assert.ok(s.loadSync("sid-b"));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("concurrent writeNow calls on one id serialize and leave a valid file", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        const writes = Array.from({ length: 12 }, (_, i) =>
+            s.writeNow("sid-race", () => ({ label: `w${i}`, count: i })).then(() => i),
+        );
+        const settled = await Promise.all(writes);
+        assert.deepEqual(settled, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        const loaded = s.loadSync("sid-race");
+        assert.ok(loaded);
+        assert.equal(loaded.payload.count, 11); // last write wins
+        // no orphan temp files left behind
+        const leftovers = readdirSync(dir).filter((f) => f.startsWith(".tmp-"));
+        assert.deepEqual(leftovers, []);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll skips corrupt files, tmp orphans, and id/filename mismatches", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        await s.writeNow("good-1", () => ({ label: "good", count: 1 }));
+        writeFileSync(path.join(dir, flatFileNameFor("corrupt-1")), "{ not json", "utf8");
+        writeFileSync(path.join(dir, ".tmp-orphan-123"), JSON.stringify({ version: 1, savedAt: 0, id: "orph", payload: {} }), "utf8");
+        // envelope with a valid shape but a filename from a different id
+        writeFileSync(path.join(dir, flatFileNameFor("other-id")), JSON.stringify({ version: 1, savedAt: 0, id: "impostor", payload: { label: "x", count: 0 } }), "utf8");
+        const all = await s.loadAll();
+        assert.deepEqual([...all.keys()], ["good-1"]);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll rejects records failing the downstream validate hook", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { validate: (env) => typeof env.payload.count === "number" && env.payload.count > 0 });
+        await s.writeNow("pos", () => ({ label: "p", count: 5 }));
+        await s.writeNow("zero", () => ({ label: "z", count: 0 }));
+        const all = await s.loadAll();
+        assert.deepEqual([...all.keys()], ["pos"]);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("custom relPath namespaces into subdirectories and loadAll discovers them", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, {
+            relPath: (id, payload) => path.join(payload.label, `${id}.json`),
+        });
+        await s.writeNow("ns-1", () => ({ label: "openai", count: 1 }));
+        // namespaced layout on disk
+        const nested = readdirSync(dir).filter((f) => f === "openai");
+        assert.equal(nested.length, 1);
+        // same process: the write populated the discovery map
+        assert.ok(s.loadSync("ns-1"));
+        // a fresh store (next process) cannot know the namespaced path
+        // before discovery — loadSync probes only the flat default name
+        const next = store(dir, {
+            relPath: (id, payload) => path.join(payload.label, `${id}.json`),
+        });
+        assert.equal(next.loadSync("ns-1"), null);
+        // …but loadAll discovers it and subsequent loadSync resolves it
+        const all = await next.loadAll();
+        assert.deepEqual([...all.keys()], ["ns-1"]);
+        assert.ok(next.loadSync("ns-1"));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("flat legacy name is tolerated in loadAll alongside namespaced relPath", async () => {
+    const dir = tmpDir();
+    try {
+        // a record written flat by an older version of the downstream
+        writeFileSync(
+            path.join(dir, flatFileNameFor("legacy-1")),
+            JSON.stringify({ version: 1, savedAt: 0, id: "legacy-1", payload: { label: "old", count: 9 } }),
+            "utf8",
+        );
+        const s = store(dir, {
+            relPath: (id, payload) => path.join(payload.label, `${id}.json`),
+        });
+        const all = await s.loadAll();
+        assert.deepEqual([...all.keys()], ["legacy-1"]);
+        assert.deepEqual(all.get("legacy-1")?.payload, { label: "old", count: 9 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("relPath escaping the dir is rejected to the safe flat name", async () => {
+    const dir = tmpDir();
+    try {
+        const warned: string[] = [];
+        const s = store(dir, {
+            log: (level, msg) => {
+                if (level === "warn") warned.push(msg);
+            },
+            relPath: () => "../../escape.json",
+        });
+        await s.writeNow("esc-1", () => ({ label: "x", count: 0 }));
+        // landed flat inside dir, not outside
+        assert.ok(s.loadSync("esc-1"));
+        const outsideExists = readdirSync(path.dirname(dir)).includes(flatFileNameFor("esc-1"));
+        assert.equal(outsideExists, false);
+        assert.ok(warned.some((w) => w.includes("escapes dir")));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll walks nested namespaces recursively", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, {
+            relPath: (id, payload) => path.join("proto", payload.label, `${id}.json`),
+        });
+        await s.writeNow("deep-1", () => ({ label: "hostA", count: 1 }));
+        await s.writeNow("deep-2", () => ({ label: "hostB", count: 2 }));
+        mkdirSync(path.join(dir, "proto", "hostC"), { recursive: true });
+        writeFileSync(
+            path.join(dir, "proto", "hostC", "deep-3.json"),
+            JSON.stringify({ version: 1, savedAt: 0, id: "deep-3", payload: { label: "hostC", count: 3 } }),
+            "utf8",
+        );
+        const all = await s.loadAll();
+        assert.deepEqual([...all.keys()].sort(), ["deep-1", "deep-2", "deep-3"]);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("cancelAll drops pending writes without flushing", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { debounceMs: 5000 });
+        s.scheduleSave("sid-c", () => ({ label: "gone", count: 0 }));
+        s.cancelAll();
+        assert.equal(s.hasPending("sid-c"), false);
+        // deterministic: the debounce timer was the only write path, and it
+        // was cleared before firing — no file exists
+        assert.equal(s.loadSync("sid-c"), null);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("a store on a missing dir loads empty and creates the dir on first write", async () => {
+    const dir = path.join(tmpDir(), "not-created-yet");
+    try {
+        const s = store(dir);
+        assert.equal((await s.loadAll()).size, 0);
+        await s.writeNow("sid-m", () => ({ label: "m", count: 0 }));
+        assert.ok(s.loadSync("sid-m"));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("mergeCompressionState fills missing fields from a fresh state", () => {
+    const fresh = createInitialState();
+    const partial = { blocks: [] } as CompressionState;
+    const merged = mergeCompressionState(partial);
+    assert.deepEqual(merged.messageRefs, fresh.messageRefs);
+    assert.deepEqual(merged.nudge, fresh.nudge);
+    assert.deepEqual(merged.stats, fresh.stats);
+    assert.equal(merged.nextBlockId, fresh.nextBlockId);
+    assert.equal(merged.nextRunId, fresh.nextRunId);
+    assert.deepEqual(merged.tokenSnapshot, fresh.tokenSnapshot);
+});
+
+test("mergeCompressionState keeps parsed values over defaults", () => {
+    const parsed: CompressionState = {
+        ...createInitialState(),
+        nextBlockId: 41,
+        stats: { tokensCompressed: 1234, compressionCount: 7 },
+    };
+    const merged = mergeCompressionState(parsed);
+    assert.equal(merged.nextBlockId, 41);
+    assert.deepEqual(merged.stats, { tokensCompressed: 1234, compressionCount: 7 });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "lib": ["ES2022"],
+        "lib": ["ES2022", "ES2024.Promise"],
         "module": "ESNext",
         "moduleResolution": "Bundler",
         "strict": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/wire/index.ts", "src/panel/index.ts"],
+    entry: ["src/index.ts", "src/wire/index.ts", "src/panel/index.ts", "src/persist/index.ts"],
     format: ["esm"],
     dts: false,
     clean: false,


### PR DESCRIPTION
## What

New `acp-kernel/persist` subpath: a crash-safe, debounce-coalescing JSON state store (`StateStore<T>`) plus `mergeCompressionState`, lifted from billion-context proxy's `SessionStore` and generalized so downstream hosts (billion-context proxy, billion-context-omp) reuse one mechanism instead of forking it.

Per the agreed split (`billion-context` 进入内核一部分，下游复用):

- **kernel = mechanism**: atomic temp+rename writes, rename retries on Windows transient locks (EPERM/EBUSY/EACCES), per-id write serialization, debounced `scheduleSave` whose builder runs at write time (freshest state), corrupt-tolerant `loadAll` discovery (corrupt/tmp-orphan/id-mismatch files skipped, never block boot), path-escape guard for custom `relPath`, forward-compat `mergeCompressionState`.
- **downstream = policy**: directory location (constructor param — kernel has no default location), schema version, payload shape, validation hook, lifecycle.
- **the store never deletes files** — session cleanup is downstream policy (`理论上不应该删除`).

## Consumers (follow-up PRs)

- billion-context-omp #130 — restart `primeFold` mirror lies (`Blocks: none`) because fold state is reconstructed from the session view in a different fingerprint space than the live wire. Persisting `FoldSlot` state to a kernel `StateStore` makes restart load real state instead of guessing.
- billion-context proxy — swap `SessionStore` internals to this store; disk format stays byte-identical (v3 `PersistedSession` becomes the payload `T`).

## Tests

28 new tests in `tests/persist.test.ts`: round-trip, build-at-write-time, debounce coalescing (single build, freshest payload), builder-failure containment, flushSync cancel semantics, flushAll drain, 12-way concurrent write serialization (no `.tmp-` orphans, last-wins), corrupt/tmp/mismatch skip in loadAll, validate hook, namespaced relPath + legacy flat tolerance + escape guard + recursive walk, cancelAll, missing dir, merge fills/keeps fields.

Full suite: 456/456. typecheck clean. `npm run build` emits `dist/persist/*`.

Not a release bump — separate release PR after merge (0.0.40).