### PR TITLE
fix: reject empty message-ref re-wraps of active blocks (billion-context-pi#199 livelock)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -762,6 +762,28 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
     );
   }
 
+  // Livelock guard (billion-context-pi#199): a message-ref range whose entire
+  // content is already owned by active block(s) — its raw ids are all covered
+  // or dropped as protected tool pairs — resolves with zero NEW direct
+  // messages. Creating a block here would be an empty same-tier rewrite
+  // (directMessageIds: []) that still reports blocksCreated>0: fake success.
+  // The caller's view does not change, so a model driven by that report
+  // repeats the identical call forever. Promote/merge must go through
+  // explicit block-boundary refs (bN..bM) instead.
+  if (
+    !isBlockBoundary &&
+    filteredIds.length === 0 &&
+    consumedBlockIds.length > 0
+  ) {
+    const first = consumedBlockIds[0]!;
+    const last = consumedBlockIds[consumedBlockIds.length - 1]!;
+    throw new Error(
+      `Range ${input.spec.startRef}..${input.spec.endRef} contains no new compressible messages — every message in it is already covered by active block(s) ${consumedBlockIds.join(
+        ", ",
+      )}. Nothing was compressed. To rewrite or merge those blocks, reference them by block ID (${first}..${last}); otherwise run acp_status and compress a range it reports as compressible.`,
+    );
+  }
+
   validateCompressionRange(input, filteredIds, consumedBlockIds.length);
 
   let compressedTokens = 0;

--- a/tests/regression-empty-rewrap.test.ts
+++ b/tests/regression-empty-rewrap.test.ts
@@ -1,0 +1,200 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { summaryMessageId } from "../src/prune.js";
+import { assignRefs } from "../src/refs.js";
+import type { CompressionState, Config, CoreMessage } from "../src/types.js";
+
+// Regression tests for billion-context-pi#199: a message-ref range whose
+// entire content is already owned by active block(s) — the range spans only
+// a rendered summary plus always-protected compress tool pairs — must NOT
+// create a block. The real session looped 33 times: each call produced an
+// empty same-tier rewrite (directMessageIds: []) that reported
+// blocksCreated=1 (fake success) while the model's view stayed identical,
+// so it repeated the identical call forever.
+
+function msg(
+  id: string,
+  text: string,
+  role: CoreMessage["role"] = "user",
+): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function toolCallMsg(
+  id: string,
+  toolName: string,
+  callId: string,
+  args: string,
+): CoreMessage {
+  return {
+    id,
+    role: "assistant",
+    contentType: "tool-call",
+    toolName,
+    toolCallId: callId,
+    text: args,
+  };
+}
+
+function toolResultMsg(
+  id: string,
+  callId: string,
+  text: string,
+): CoreMessage {
+  return { id, role: "tool", contentType: "tool-result", toolCallId: callId, text };
+}
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+      tier2GrowthMultiplier: 1.5,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: ["compress"],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+    ...overrides,
+  };
+}
+
+function makeState(specs: {
+  blockId: string;
+  effectiveMessageIds: string[];
+}[]): CompressionState {
+  const state = createInitialState();
+  state.blocks = specs.map((spec) => ({
+    blockId: spec.blockId,
+    runId: "r1",
+    tier: 1 as const,
+    topic: undefined,
+    summary: `T1 summary for ${spec.blockId}.`,
+    directMessageIds: [...spec.effectiveMessageIds],
+    effectiveMessageIds: [...spec.effectiveMessageIds],
+    directBlockIds: [],
+    compressedTokens: 100,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young" as const,
+    active: true,
+  }));
+  state.nextBlockId = specs.length + 1;
+  return state;
+}
+
+// The looped session's post-prune view shape: the only messages left between
+// the two anchors are the rendered summary of the active block and the
+// always-protected compress tool-call pairs bracketing it.
+function loopedView(): CoreMessage[] {
+  return [
+    toolCallMsg("raw-1", "compress", "call-1", '{"content":[]}'),
+    toolResultMsg("tool-1", "call-1", "▣ ACP | 70K → 12K tokens"),
+    msg(summaryMessageId("b1"), "T1 summary for b1.", "system"),
+    toolCallMsg("raw-6", "compress", "call-2", '{"content":[]}'),
+    toolResultMsg("tool-2", "call-2", "▣ ACP | 57K → 55K tokens"),
+  ];
+}
+
+function withRefs(messages: CoreMessage[], state: CompressionState): CompressionState {
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+test("#199: message-ref range that only re-wraps an active block is rejected, not fake-success", () => {
+  const core = createCore();
+  const cfg = config();
+  const messages = loopedView();
+  const state = withRefs(
+    messages,
+    makeState([{ blockId: "b1", effectiveMessageIds: ["raw-2", "raw-3", "raw-4", "raw-5"] }]),
+  );
+  const startRef = state.messageRefs.byRaw["raw-1"]!;
+  const endRef = state.messageRefs.byRaw["tool-2"]!;
+
+  const applied = core.applyCompression({
+    ranges: [{ startRef, endRef, summary: "S".repeat(80) }],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.equal(applied.result.blocksCreated, 0, "must not create a block");
+  assert.equal(applied.result.errors.length, 1);
+  assert.match(applied.result.errors[0]!, /no new compressible/i);
+  assert.match(applied.result.errors[0]!, /b1/);
+  assert.match(applied.result.errors[0]!, /b1\.\.b1|block ID/i);
+  assert.equal(applied.state.blocks.length, 1, "no wrapper block appended");
+  assert.equal(applied.state.blocks[0]!.active, true, "b1 must stay active");
+});
+
+test("#199: promote via block-boundary refs (b1..b1) still works after the guard", () => {
+  const core = createCore();
+  const cfg = config();
+  const messages = loopedView();
+  const state = withRefs(
+    messages,
+    makeState([{ blockId: "b1", effectiveMessageIds: ["raw-2", "raw-3", "raw-4", "raw-5"] }]),
+  );
+
+  const applied = core.applyCompression({
+    ranges: [{ startRef: "b1", endRef: "b1", summary: "S".repeat(80) }],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.deepEqual(applied.result.errors, []);
+  assert.equal(applied.result.blocksCreated, 1);
+  const newBlock = applied.state.blocks[applied.state.blocks.length - 1]!;
+  assert.equal(newBlock.tier, 2);
+  assert.deepEqual(newBlock.directBlockIds, ["b1"]);
+  assert.equal(applied.state.blocks[0]!.active, false, "b1 consumed by promote");
+});
+
+test("#199: message-ref range that pulls in NEW messages plus a nested block is still allowed", () => {
+  const core = createCore();
+  const cfg = config();
+  const messages = [
+    ...loopedView().slice(0, 3),
+    msg("raw-9", "x".repeat(6000)),
+    ...loopedView().slice(3),
+  ];
+  const state = withRefs(
+    messages,
+    makeState([{ blockId: "b1", effectiveMessageIds: ["raw-2", "raw-3", "raw-4", "raw-5"] }]),
+  );
+  const startRef = state.messageRefs.byRaw["raw-1"]!;
+  const endRef = state.messageRefs.byRaw["tool-2"]!;
+
+  const applied = core.applyCompression({
+    ranges: [{ startRef, endRef, summary: "S".repeat(80) }],
+    messages,
+    state,
+    config: cfg,
+  });
+
+  assert.deepEqual(applied.result.errors, []);
+  assert.equal(applied.result.blocksCreated, 1);
+  const newBlock = applied.state.blocks[applied.state.blocks.length - 1]!;
+  assert.deepEqual(newBlock.directMessageIds, ["raw-9"]);
+  assert.deepEqual(newBlock.directBlockIds, ["b1"]);
+});


### PR DESCRIPTION
## 问题

#199 的死循环根因在 kernel:`applySingleRange` 允许创建 `directMessageIds: []` 的**空重写块**。

真实会话(bcp 0.1.45 / kernel 0.0.32)用模型原样重发同一 compress 调用 33 次(约 28 分钟);在 0.0.39 上用同一份会话数据回放,同一调用序列仍创建空重写块(`{direct:[], consumed:["b15"], blocksCreated:1, errors:[]}`),livelock 条件未关闭。

## 根因

message-ref 区间的锚点是**未被任何块覆盖的幸存消息**(典型:被保护区排除的 compress 工具调用对),区间解析成功并覆盖某个活跃块的渲染 summary;nested-discovery 发现该块(`resolveTargetTier` 对 message-ref 恒返回 1,活跃 T1 块被同层消费)。随后:

- 所有 in-range raw id 要么已被活跃块覆盖(`preExistingCoverage`),要么被 `filterProtectedToolMessages` / 保护带排除 → `filteredIds = []`
- `consumedBlockIds = ["b15"]` 非空 → 现有的"both empty"守卫(`compress.ts` `directMessageIds.length === 0 && consumedBlockCount === 0`)放行
- 产出空壳块并报告 `blocksCreated=1` = 伪成功;视图不变、模型自身调用被隐藏 → 无限重试

## 修复

`applySingleRange` 在保护带软排除之后新增守卫:**message-boundary 区间若 `filteredIds.length === 0` 且 `consumedBlockIds.length > 0`,terminal 拒绝**,错误信息指引用块边界 refs(`bN..bM`)做 promote/merge,或 `acp_status` 后重新选区。

- block-boundary promote(`b15..b15` → T2)不受影响 —— 这是 #195 修复的正规提升路径
- message-ref 吸收新消息 + 消费嵌套块(direct 非空)不受影响 —— 95f7530 的测试场景
- 拒绝后 `blocksCreated=0` + errors → bcp 适配层走 0-block panel → 计为失败 → 重试上限生效(issue #6/#182 既有机制),循环有界

## 对 #195 已合入修复的判断:**无需撤回**

- 8a4dc72(promote-after-prune)与 95f7530(nested-discovery 按任意可见表示匹配)修的都是真实问题,其测试在本次守卫下全部通过(全量 441 pass)
- livelock 并非这两个提交引入:0.0.32(两提交之前)以"wrapper 块"形态同样循环;0.0.39 只是换成"空重写块"形态。缺的是空重写守卫,本 PR 补上

## 验证

- 新增 `tests/regression-empty-rewrap.test.ts` 3 例:拒绝重写 / `b1..b1` promote 不回归 / 吸收新消息不回归(修复前第 1 例红,修复后全绿)
- 全量:`npm run typecheck` + `npm test` → **441 pass / 0 fail**
- 真实数据回放(looped 会话 jsonl 前 568 行 + 真实 `.acp.json` 裁剪到 b1..b17 + 第 569 行原始 compress 参数):
  - 修复前(0.0.39):创建 `b54 {direct:[], consumed:["b15"]}`,b15 被反激活,视图不变
  - 修复后:`blocksCreated: 0`,errors 含指引("already covered by active block(s) b15 … reference them by block ID (b15..b15)"),b15/b16/b17 全部保持 active

## 发布顺序提醒

billion-context-pi 需要在本 PR 合入、CI 发布 0.0.40 之后再 bump(严格顺序,见其 AGENTS.md);待合的 release 分支 `2026-08-22_release-v0.1.46` 目前 pin 0.0.39,建议发布前把 pin 提到 0.0.40 一并带上此修复。

Fixes ranxianglei/billion-context-pi#199(kernel 侧;适配层无需改动)。
