### PR TITLE
release v0.0.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.39",
+    "version": "0.0.40",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.39",
+            "version": "0.0.40",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.39",
+    "version": "0.0.40",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Publishes the livelock fix from #127 (empty message-ref re-wrap guard, billion-context-pi#199).

- #127 already merged into master (81cb249); this release branch only bumps `0.0.39 → 0.0.40` (package.json + lock, same convention as v0.0.39).
- After merge + CI publish, billion-context-pi release PR #198 (v0.1.46) should bump its `acp-kernel` pin `0.0.39 → 0.0.40` before merging.