### PR TITLE
feat(persist): legacy record adoption + loadSync path hint

### DIFF
--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -18,6 +18,15 @@ export interface PersistedEnvelope<T> {
     payload: T;
 }
 
+/** A legacy (pre-envelope) record adopted on load. `version`/`savedAt`
+ * preserve the source record's own stamps when present. */
+export interface LegacyAdoption<T> {
+    id: string;
+    payload: T;
+    version?: number;
+    savedAt?: number;
+}
+
 export interface StateStoreOptions<T> {
     /**
      * Storage root. The kernel deliberately has NO default location: the
@@ -51,6 +60,15 @@ export interface StateStoreOptions<T> {
      */
     relPath?: (id: string, payload: T) => string;
     /**
+     * Adopt records written by an older, pre-envelope schema. Receives the
+     * parsed JSON of any file that failed the envelope-shape check; return
+     * an adoption to load it as an envelope, or null to skip it. Adopted
+     * records are re-persisted in the current envelope format on the next
+     * dirty write — files migrate organically, and old files keep loading
+     * (same policy billion-context's proxy used for its v1→v3 migration).
+     */
+    legacy?: (parsed: unknown) => LegacyAdoption<T> | null;
+    /**
      * Payload validation on load. Return false to skip a record (foreign
      * schema, corrupt content). Default: envelope-shape check only
      * (string id, non-null payload).
@@ -82,6 +100,7 @@ export class StateStore<T> {
     private readonly version: number;
     private readonly debounceMs: number;
     private readonly log: PersistLogger;
+    private readonly legacyFn?: (parsed: unknown) => LegacyAdoption<T> | null;
     private readonly relPathFn?: (id: string, payload: T) => string;
     private readonly validateFn: (envelope: PersistedEnvelope<T>) => boolean;
     private readonly timers = new Map<string, NodeJS.Timeout>();
@@ -99,6 +118,7 @@ export class StateStore<T> {
         this.enabled = opts.enabled ?? true;
         this.log = opts.log ?? ((_level, _msg) => {});
         this.relPathFn = opts.relPath;
+        this.legacyFn = opts.legacy;
         this.validateFn = opts.validate ?? defaultValidate;
     }
 
@@ -190,7 +210,6 @@ export class StateStore<T> {
                 }
             }
             if (lastErr) throw lastErr;
-            this.discovered.set(id, file);
             return true;
         } catch (e) {
             this.log("error", `[persist] flushSync failed for ${id}: ${errText(e)}`);
@@ -204,11 +223,19 @@ export class StateStore<T> {
     }
 
     /** Load one record. Checks the discovered path (from a prior
-     *  write/loadAll) and the flat default name. Returns null when absent,
-     *  disabled, corrupt, or rejected by validate. */
-    loadSync(id: string): PersistedEnvelope<T> | null {
+     *  write/loadAll), an optional relative-path hint, and the flat default
+     *  name. Returns null when absent, disabled, corrupt, or rejected by
+     *  validate. The hint covers namespaced records the store has not
+     *  discovered (e.g. an evicted session re-requested with its meta,
+     *  where the path depends on data the store cannot reconstruct from
+     *  the id alone). */
+    loadSync(id: string, hint?: string): PersistedEnvelope<T> | null {
         if (!this.enabled) return null;
-        const candidates = [this.discovered.get(id), path.join(this.dir, flatFileNameFor(id))];
+        const candidates = [
+            this.discovered.get(id),
+            hint ? path.join(this.dir, hint) : undefined,
+            path.join(this.dir, flatFileNameFor(id)),
+        ];
         for (const file of candidates) {
             if (!file) continue;
             const envelope = this.readEnvelope(file);
@@ -351,11 +378,35 @@ export class StateStore<T> {
             }
             return null;
         }
-        if (!isEnvelopeLike(parsed) || !this.validateFn(parsed as PersistedEnvelope<T>)) {
-            this.log("warn", `[persist] skipping invalid record ${rel(file, this.dir)}`);
+        if (isEnvelopeLike(parsed)) {
+            if (!this.validateFn(parsed as PersistedEnvelope<T>)) {
+                this.log("warn", `[persist] skipping invalid record ${rel(file, this.dir)}`);
+                return null;
+            }
+            return parsed as PersistedEnvelope<T>;
+        }
+        const adopted = this.adoptLegacy(parsed);
+        if (adopted) return adopted;
+        this.log("warn", `[persist] skipping invalid record ${rel(file, this.dir)}`);
+        return null;
+    }
+
+    /** Wrap a legacy (pre-envelope) record as an envelope via the `legacy`
+     *  hook, then validate the adopted payload like any other. */
+    private adoptLegacy(parsed: unknown): PersistedEnvelope<T> | null {
+        const adoption = this.legacyFn ? this.legacyFn(parsed) : null;
+        if (!adoption || typeof adoption.id !== "string" || adoption.id.length === 0 || adoption.payload == null) {
             return null;
         }
-        return parsed as PersistedEnvelope<T>;
+        const source = parsed as Partial<PersistedEnvelope<T>>;
+        const envelope: PersistedEnvelope<T> = {
+            version: adoption.version ?? source.version ?? this.version,
+            savedAt: adoption.savedAt ?? source.savedAt ?? 0,
+            id: adoption.id,
+            payload: adoption.payload,
+        };
+        if (!this.validateFn(envelope)) return null;
+        return envelope;
     }
 
     /** Iterative recursive walk (no readdir-recursive dependency), skipping

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { StateStore, flatFileNameFor } from "../src/persist/store.js";
@@ -368,4 +368,110 @@ test("mergeCompressionState keeps parsed values over defaults", () => {
     const merged = mergeCompressionState(parsed);
     assert.equal(merged.nextBlockId, 41);
     assert.deepEqual(merged.stats, { tokensCompressed: 1234, compressionCount: 7 });
+});
+
+test("legacy hook adopts pre-envelope records on loadAll and loadSync", async () => {
+    const dir = tmpDir();
+    try {
+        // A proxy-style flat record: no `payload` wrapper, id at top level.
+        const flat = {
+            version: 3,
+            savedAt: 12345,
+            id: "flat-1",
+            label: "adopted",
+            count: 9,
+        };
+        const flatFile = path.join(dir, flatFileNameFor("flat-1"));
+        writeFileSync(flatFile, JSON.stringify(flat), "utf8");
+        const s = store(dir, {
+            legacy: (parsed) => {
+                const p = parsed as { id?: unknown; label?: unknown; count?: unknown };
+                if (typeof p.id !== "string" || typeof p.label !== "string" || typeof p.count !== "number") return null;
+                return { id: p.id, payload: { label: p.label, count: p.count } };
+            },
+        });
+        const all = await s.loadAll();
+        assert.equal(all.size, 1);
+        const env = all.get("flat-1");
+        assert.ok(env);
+        assert.equal(env.id, "flat-1");
+        assert.deepEqual(env.payload, { label: "adopted", count: 9 });
+        // The source record's own stamps are preserved, not stamped fresh.
+        assert.equal(env.version, 3);
+        assert.equal(env.savedAt, 12345);
+        // loadSync finds it too (discovered by loadAll).
+        const direct = s.loadSync("flat-1");
+        assert.ok(direct);
+        assert.deepEqual(direct.payload, { label: "adopted", count: 9 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("legacy adoption is skipped when the hook returns null", async () => {
+    const dir = tmpDir();
+    try {
+        writeFileSync(
+            path.join(dir, flatFileNameFor("foreign-1")),
+            JSON.stringify({ totally: "unrelated", shape: true }),
+            "utf8",
+        );
+        const s = store(dir, { legacy: () => null });
+        assert.equal((await s.loadAll()).size, 0);
+        assert.equal(s.loadSync("foreign-1"), null);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("adopted legacy record re-persists as an envelope on the next write", async () => {
+    const dir = tmpDir();
+    try {
+        writeFileSync(
+            path.join(dir, flatFileNameFor("migrate-1")),
+            JSON.stringify({ version: 3, savedAt: 1, id: "migrate-1", label: "old", count: 0 }),
+            "utf8",
+        );
+        const s = store(dir, {
+            version: 4,
+            legacy: (parsed) => {
+                const p = parsed as { id?: string; label?: string; count?: number };
+                if (typeof p.id !== "string" || typeof p.label !== "string" || typeof p.count !== "number") return null;
+                return { id: p.id, payload: { label: p.label, count: p.count } };
+            },
+        });
+        await s.loadAll();
+        // Dirty write after adoption: the file on disk becomes an envelope
+        // stamped with the store's current version.
+        await s.writeNow("migrate-1", () => ({ label: "new", count: 5 }));
+        const raw = JSON.parse(readFileSync(path.join(dir, flatFileNameFor("migrate-1")), "utf8")) as {
+            version: number;
+            payload: { label: string };
+        };
+        assert.equal(raw.version, 4);
+        assert.deepEqual(raw.payload, { label: "new", count: 5 });
+        // And a FRESH store (no legacy hook) can read it — migration done.
+        const plain = store(dir);
+        assert.deepEqual(plain.loadSync("migrate-1")?.payload, { label: "new", count: 5 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadSync hint probes a namespaced path without loadAll", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { relPath: (id, payload) => path.join("proto", payload.label, `${id}.json`) });
+        await s.writeNow("hint-1", () => ({ label: "hostA", count: 1 }));
+        // A second store instance has NOT discovered the namespaced file —
+        // without the hint, loadSync misses (flat fallback only).
+        const s2 = store(dir, { relPath: (id, payload) => path.join("proto", payload.label, `${id}.json`) });
+        assert.equal(s2.loadSync("hint-1"), null);
+        // With the relative-path hint, the namespaced file resolves.
+        const hit = s2.loadSync("hint-1", path.join("proto", "hostA", "hint-1.json"));
+        assert.ok(hit);
+        assert.deepEqual(hit.payload, { label: "hostA", count: 1 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
 });


### PR DESCRIPTION
Extends the `acp-kernel/persist` StateStore (0.0.40) so downstreams owning a pre-envelope on-disk format can adopt it:

- `legacy` option: called for any file that fails the envelope-shape check; return `{id, payload, version?, savedAt?}` to load it as an envelope. Source stamps are preserved; the next dirty write re-persists as an envelope — files migrate organically, old files keep loading.
- `loadSync(id, hint)`: probe an extra relative path for namespaced records the store has not discovered (a store that did not run loadAll at boot, e.g. an evicted session re-requested with its meta).

Unblocks billion-context proxy's SessionStore swap to the kernel store (its on-disk format is a flat v3 record). 463/463.