### PR TITLE
chore: release v0.0.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.40",
+    "version": "0.0.41",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.41 — persist legacy adoption + loadSync path hint (#130), for the billion-context proxy SessionStore swap.