### PR TITLE
fix: size-aware emergency truncation (billion-context-pi#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.41",
+    "version": "0.0.42",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -376,6 +376,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
       messages: result.messages,
       state: result.state,
       nudge: result.effects.nudge,
+      toolResultCappedCount: result.effects.toolResultCappedCount,
     };
   }
 

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -11,7 +11,10 @@ import {
   blockVisibleInRange,
 } from "./boundaries.js";
 import type { ResolvedRange } from "./boundaries.js";
-import { truncateLargeToolOutputs } from "./truncate-tools.js";
+import {
+  truncateLargeToolOutputs,
+  capLargeToolResults,
+} from "./truncate-tools.js";
 import { hideConsumedCompressCalls } from "./hide-consumed.js";
 import { applyMessageFilters, listMessageFilters } from "./filter/index.js";
 import { createRenderRefsNode } from "./render-refs.js";
@@ -426,6 +429,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
       pruneNode,
       filterNode,
       hideCompressCallsNode,
+      toolResultCapNode,
       recommendNode,
       nudgeNode,
       emergencyTruncateNode,
@@ -585,6 +589,29 @@ const nudgeNode: PipelineNode = {
       ...io,
       state: { ...io.state, nudge: stamped },
       effects: { ...io.effects, nudge },
+    };
+  },
+};
+
+// Hard per-tool-result token cap. Runs on EVERY turn (no usage gate) and
+// ignores recency protection: a single oversized tool-result can consume a
+// double-digit share of the window while total usage still reads low, so no
+// percentage-gated valve can catch it. Placed after prune (no point rewriting
+// messages about to disappear) and before recommend/nudge (so downstream
+// token estimates reflect the capped sent view).
+const toolResultCapNode: PipelineNode = {
+  name: "tool-result-cap",
+  run(io, ctx) {
+    const capped = capLargeToolResults(
+      io.messages,
+      ctx.config,
+      ctx.countTokens,
+    );
+    if (capped.cappedCount === 0) return io;
+    return {
+      ...io,
+      messages: capped.messages,
+      effects: { ...io.effects, toolResultCappedCount: capped.cappedCount },
     };
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export function defaultConfig(
       tier2GrowthMultiplier: 1.5,
     },
     promotionThreshold: 5,
-    truncate: { threshold: 0.95 },
+    truncate: { threshold: 0.95, maxToolResultTokens: null },
     compress: {
       minCompressRange: 5000,
       maxSummaryLength: 20000,
@@ -65,6 +65,15 @@ export function validateConfig(config: Config): string[] {
   }
   if (config.truncate.threshold <= 0 || config.truncate.threshold > 1) {
     errors.push("truncate.threshold must be in (0, 1]");
+  }
+  if (
+    config.truncate.maxToolResultTokens != null &&
+    (!Number.isFinite(config.truncate.maxToolResultTokens) ||
+      config.truncate.maxToolResultTokens < 0)
+  ) {
+    errors.push(
+      "truncate.maxToolResultTokens must be null (auto), 0 (disabled), or a positive number",
+    );
   }
   for (const tier of [config.tiers.tier2Trigger, config.tiers.tier3Trigger]) {
     if (tier < 1) errors.push("tier triggers must be >= 1");

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,16 @@ export {
 } from "./compression-rules.js";
 export { defaultPrompts, resolvePrompts } from "./prompts.js";
 export type { Prompts, ResolvePromptsOptions } from "./prompts.js";
-export { truncateLargeToolOutputs } from "./truncate-tools.js";
-export type { TruncateOptions, TruncateResult } from "./truncate-tools.js";
+export {
+  truncateLargeToolOutputs,
+  capLargeToolResults,
+  resolveToolResultCap,
+} from "./truncate-tools.js";
+export type {
+  TruncateOptions,
+  TruncateResult,
+  ToolResultCapResult,
+} from "./truncate-tools.js";
 export {
   parseBlockIdArg,
   findBlocksOverlappingMessages,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,6 +10,7 @@ export interface NodeEffects {
   nudge?: NudgeDecision;
   recommendation?: import("./types.js").Recommendation;
   truncatedCount?: number;
+  toolResultCappedCount?: number;
   readonly [key: string]: unknown;
 }
 

--- a/src/truncate-tools.ts
+++ b/src/truncate-tools.ts
@@ -13,13 +13,94 @@ export interface TruncateResult {
     savedTokens: number;
 }
 
+export interface ToolResultCapResult {
+    messages: CoreMessage[];
+    cappedCount: number;
+    capTokens: number;
+}
+
 const TRUNCATION_MARKER = "[truncated for context space]";
+const CAP_MARKER_PREFIX = "[acp: tool-result truncated";
+const MAX_TOOL_RESULT_CAP = 16384;
+const AUTO_CAP_LIMIT_RATIO = 0.1;
+const MIN_KEEP_CHARS = 64;
 const DEFAULTS = {
     minOutputTokens: 1000,
     keepPrefixChars: 2000,
     keepSuffixChars: 2000,
     protectRecentMessages: 3,
 } as const;
+
+/** Effective per-tool-result token cap. `maxToolResultTokens` null (default)
+ *  means auto: min(10% of the model context limit, 16384). 0 disables. When
+ *  the context limit is unknown (<= 0), auto falls back to the absolute
+ *  ceiling — the cap is the one valve that must still fire. */
+export function resolveToolResultCap(config: Config): number {
+    const configured = config.truncate.maxToolResultTokens;
+    if (configured != null) {
+        return configured <= 0 ? 0 : Math.floor(configured);
+    }
+    if (config.modelContextLimit <= 0) return MAX_TOOL_RESULT_CAP;
+    return Math.min(
+        MAX_TOOL_RESULT_CAP,
+        Math.floor(config.modelContextLimit * AUTO_CAP_LIMIT_RATIO),
+    );
+}
+
+/** Hard per-message guard: no single tool-result may exceed the cap in the
+ *  outgoing context, regardless of total usage and regardless of recency
+ *  (recent/protected messages included). Byte-based host limits and the
+ *  usage-gated emergency truncation both missed the 2026-08-23 incident — a
+ *  31K-token tool-result under every byte cap while usage read 51.8%. */
+export function capLargeToolResults(
+    messages: CoreMessage[],
+    config: Config,
+    countTokens: (text: string) => number,
+): ToolResultCapResult {
+    const cap = resolveToolResultCap(config);
+    if (cap <= 0) return { messages, cappedCount: 0, capTokens: cap };
+
+    const edits = new Map<number, string>();
+    for (let index = 0; index < messages.length; index++) {
+        const message = messages[index]!;
+        if (message.contentType !== "tool-result") continue;
+        const text = message.text ?? "";
+        if (text.length === 0 || text.includes(CAP_MARKER_PREFIX)) continue;
+        const tokens = countTokens(text);
+        if (tokens <= cap) continue;
+        edits.set(index, capToTokens(text, tokens, cap, countTokens));
+    }
+
+    if (edits.size === 0) return { messages, cappedCount: 0, capTokens: cap };
+    const updated = messages.map((message, index) =>
+        edits.has(index) ? { ...message, text: edits.get(index)! } : message,
+    );
+    return { messages: updated, cappedCount: edits.size, capTokens: cap };
+}
+
+/** Head+tail rewrite that fits the token cap. The initial per-side char
+ *  budget assumes ~4 chars/token; CJK-dense text (1 char/token) overshoots,
+ *  so the loop halves until the CJK-aware count fits. */
+function capToTokens(
+    text: string,
+    tokens: number,
+    cap: number,
+    countTokens: (text: string) => number,
+): string {
+    const marker =
+        `\n\n...${CAP_MARKER_PREFIX}, original ~${tokens} tokens]...\n\n`;
+    let keepChars = Math.max(
+        MIN_KEEP_CHARS,
+        Math.floor(((cap - countTokens(marker)) / 2) * 4),
+    );
+    while (keepChars >= MIN_KEEP_CHARS) {
+        const replacement =
+            text.slice(0, keepChars) + marker + text.slice(-keepChars);
+        if (countTokens(replacement) <= cap) return replacement;
+        keepChars = Math.floor(keepChars / 2);
+    }
+    return marker;
+}
 
 export function truncateLargeToolOutputs(
     messages: CoreMessage[],
@@ -48,7 +129,12 @@ export function truncateLargeToolOutputs(
         const message = messages[index]!;
         if (message.contentType !== "tool-result") continue;
         const text = message.text ?? "";
-        if (text.length === 0 || text.includes(TRUNCATION_MARKER)) continue;
+        if (
+            text.length === 0 ||
+            text.includes(TRUNCATION_MARKER) ||
+            text.includes(CAP_MARKER_PREFIX)
+        )
+            continue;
         const tokens = countTokens(text);
         if (tokens < opts.minOutputTokens) continue;
         candidates.push({ index, tokens });

--- a/src/truncate-tools.ts
+++ b/src/truncate-tools.ts
@@ -34,11 +34,17 @@ export function truncateLargeToolOutputs(
     const threshold = config.truncate.threshold * config.modelContextLimit;
     if (tokenCount < threshold) return { messages, truncatedCount: 0, savedTokens: 0 };
 
-    const protectedIndex = messages.length - opts.protectRecentMessages;
+    // Collect ALL tool-result messages as candidates — including the most recent
+    // ones. The old hard protection of the last N messages was counterproductive
+    // when the most recent messages were the largest (e.g. decompress inline
+    // results): it prevented truncating the very messages causing the overflow.
+    // Instead, the size-based sort below naturally preserves small recent
+    // messages and truncates large ones regardless of recency. `protectRecentMessages`
+    // is kept in the API for backward compatibility but no longer hard-excludes
+    // recent messages from candidacy.
     const candidates: Array<{ index: number; tokens: number }> = [];
 
     for (let index = 0; index < messages.length; index++) {
-        if (index >= protectedIndex) break;
         const message = messages[index]!;
         if (message.contentType !== "tool-result") continue;
         const text = message.text ?? "";

--- a/src/truncate-tools.ts
+++ b/src/truncate-tools.ts
@@ -23,6 +23,14 @@ const TRUNCATION_MARKER = "[truncated for context space]";
 const CAP_MARKER_PREFIX = "[acp: tool-result truncated";
 const MAX_TOOL_RESULT_CAP = 16384;
 const AUTO_CAP_LIMIT_RATIO = 0.1;
+/** Auto-cap quantization step (power of two): learning the context limit only
+ *  moves the cap across power-of-two boundaries, not on every limit change. */
+const AUTO_CAP_QUANT_STEP = 1024;
+/** A stored capped view may re-estimate slightly above the cap across turns
+ *  (tokenizer drift); still count as already-capped below this margin. */
+const ALREADY_CAPPED_MARGIN = 1.25;
+/** Char prefilter: no tokenizer plausibly exceeds 4 tokens per char. */
+const MAX_TOKENS_PER_CHAR = 4;
 const MIN_KEEP_CHARS = 64;
 const DEFAULTS = {
     minOutputTokens: 1000,
@@ -32,18 +40,35 @@ const DEFAULTS = {
 } as const;
 
 /** Effective per-tool-result token cap. `maxToolResultTokens` null (default)
- *  means auto: min(10% of the model context limit, 16384). 0 disables. When
- *  the context limit is unknown (<= 0), auto falls back to the absolute
- *  ceiling — the cap is the one valve that must still fire. */
+ *  means auto: min(10% of the model context limit, 16384), quantized down to
+ *  a power of two. 0 disables. When the context limit is unknown (<= 0 or
+ *  non-finite), auto falls back to the absolute ceiling — the cap is the one
+ *  valve that must still fire. Non-finite config values also fall through to
+ *  auto: a NaN cap compares false against every bound and would replace
+ *  EVERY tool-result with the bare marker. */
 export function resolveToolResultCap(config: Config): number {
     const configured = config.truncate.maxToolResultTokens;
-    if (configured != null) {
-        return configured <= 0 ? 0 : Math.floor(configured);
+    if (configured != null && Number.isFinite(configured)) {
+        return configured <= 0 ? 0 : Math.max(1, Math.floor(configured));
     }
-    if (config.modelContextLimit <= 0) return MAX_TOOL_RESULT_CAP;
-    return Math.min(
+    const limit = config.modelContextLimit;
+    if (!Number.isFinite(limit) || limit <= 0) return MAX_TOOL_RESULT_CAP;
+    const raw = Math.min(
         MAX_TOOL_RESULT_CAP,
-        Math.floor(config.modelContextLimit * AUTO_CAP_LIMIT_RATIO),
+        Math.floor(limit * AUTO_CAP_LIMIT_RATIO),
+    );
+    if (raw <= 0) return 1;
+    // Quantize down to a power of two (>= AUTO_CAP_QUANT_STEP) so the cap —
+    // and with it the truncation point of already-sent messages — moves only
+    // when the learned limit crosses a power-of-two boundary. Hosts that
+    // re-derive modelContextLimit per request would otherwise shift the cap
+    // every turn and break the provider prefix cache each time.
+    return Math.min(
+        raw,
+        Math.max(
+            AUTO_CAP_QUANT_STEP,
+            2 ** Math.floor(Math.log2(raw)),
+        ),
     );
 }
 
@@ -65,7 +90,19 @@ export function capLargeToolResults(
         const message = messages[index]!;
         if (message.contentType !== "tool-result") continue;
         const text = message.text ?? "";
-        if (text.length === 0 || text.includes(CAP_MARKER_PREFIX)) continue;
+        if (text.length === 0) continue;
+        if (text.includes(CAP_MARKER_PREFIX)) {
+            // Host stored the capped view back into the session: skip while
+            // the stored form still fits. A legitimate oversized result that
+            // merely QUOTES the marker string must still be capped — the bare
+            // substring test let marker-quoting results escape the cap
+            // entirely (review finding #1, 2026-08-23).
+            if (countTokens(text) <= cap * ALREADY_CAPPED_MARGIN) continue;
+        } else if (text.length * MAX_TOKENS_PER_CHAR <= cap) {
+            // Cheap prefilter: skips re-tokenizing every small tool-result on
+            // every turn (matters for host-provided BPE tokenizers).
+            continue;
+        }
         const tokens = countTokens(text);
         if (tokens <= cap) continue;
         edits.set(index, capToTokens(text, tokens, cap, countTokens));
@@ -131,10 +168,15 @@ export function truncateLargeToolOutputs(
         const text = message.text ?? "";
         if (
             text.length === 0 ||
-            text.includes(TRUNCATION_MARKER) ||
-            text.includes(CAP_MARKER_PREFIX)
+            text.includes(TRUNCATION_MARKER)
         )
             continue;
+        // NOTE: cap-marked messages ("[acp: tool-result truncated") are NOT
+        // skipped here. At >=95% usage the prefix is already being broken by
+        // design; letting emergency shrink capped-but-still-large messages is
+        // the last valve (review finding #4, 2026-08-23). Stacked markers are
+        // acceptable — this path runs at most until usage drops below the
+        // threshold.
         const tokens = countTokens(text);
         if (tokens < opts.minOutputTokens) continue;
         candidates.push({ index, tokens });

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,10 @@ export interface ProcessTurnResult {
   messages: CoreMessage[];
   state: CompressionState;
   nudge?: NudgeDecision;
+  /** Tool-results rewritten by the hard per-message cap this turn. Hosts
+   *  should log/alert on this — a recurrence of the 31K-token incident
+   *  would otherwise be invisible. */
+  toolResultCappedCount?: number;
 }
 
 export interface StatusReport {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,12 @@ export interface TruncateConfig {
   // context limit. Removed GC age-deactivation/summary-truncation are gone;
   // this is the only "context near full" fallback that remains.
   threshold: number;
+  /** Hard per-tool-result token cap. A single tool-result may never exceed
+   *  this many tokens in the outgoing context, regardless of total usage or
+   *  recency (the 2026-08-23 incident: one 31K-token minified-JS tool-result
+   *  entered whole while total usage read 51.8%, so no usage-gated valve
+   *  fired). null = auto: min(10% of modelContextLimit, 16384). 0 disables. */
+  maxToolResultTokens?: number | null;
 }
 
 export interface CompressValidationConfig {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -30,11 +30,21 @@ test("defaultNodes exposes the canonical ordered pipeline", () => {
     "prune",
     "filter",
     "hide-compress-calls",
+    "tool-result-cap",
     "recommend",
     "nudge-inject",
     "emergency-truncate",
     "render-refs",
   ]);
+});
+
+test("tool-result-cap runs after prune and before recommend/emergency-truncate", () => {
+  const core = createCore();
+  const nodes = core.defaultNodes();
+  const idx = (name: string) => nodes.findIndex((n) => n.name === name);
+  assert.ok(idx("tool-result-cap") > idx("prune"));
+  assert.ok(idx("tool-result-cap") < idx("recommend"));
+  assert.ok(idx("tool-result-cap") < idx("emergency-truncate"));
 });
 
 test("emergency-truncate is the last token-reducing node; render-refs is final", () => {

--- a/tests/toolresult-token-cap.test.ts
+++ b/tests/toolresult-token-cap.test.ts
@@ -19,14 +19,25 @@ function msg(
   return { id, role: "user", contentType: type, text };
 }
 
-test("resolveToolResultCap: auto = min(10% of limit, 16384)", () => {
-  assert.equal(resolveToolResultCap(defaultConfig(100000)), 10000);
-  assert.equal(resolveToolResultCap(defaultConfig(131072)), 13107);
+test("resolveToolResultCap: auto = 10% of limit quantized down to a power of two, ceiling 16384", () => {
+  // 10% of 100000 = 10000 -> quantized down to 8192.
+  assert.equal(resolveToolResultCap(defaultConfig(100000)), 8192);
+  assert.equal(resolveToolResultCap(defaultConfig(131072)), 8192);
   // 10% of 500000 is 50000 — clamped by the absolute ceiling.
   assert.equal(resolveToolResultCap(defaultConfig(500000)), 16384);
   assert.equal(resolveToolResultCap(defaultConfig(163840)), 16384);
+  // Exactly on a power-of-two boundary stays put.
+  assert.equal(resolveToolResultCap(defaultConfig(81920)), 8192);
+  assert.equal(resolveToolResultCap(defaultConfig(65536)), 4096);
+  // Below the quantization step the raw 10% is kept (tiny-limit models).
+  assert.equal(resolveToolResultCap(defaultConfig(8192)), 819);
   // Unknown limit: auto still fires at the ceiling.
   assert.equal(resolveToolResultCap(defaultConfig(0)), 16384);
+  // Non-finite limit falls back to the ceiling, never NaN.
+  assert.equal(
+    resolveToolResultCap(defaultConfig(Number.NaN)),
+    16384,
+  );
 });
 
 test("resolveToolResultCap: explicit values and disable", () => {
@@ -57,7 +68,7 @@ test("capLargeToolResults rewrites an oversized tool-result over the cap", () =>
   const messages = [msg("a", "small text"), msg("t1", original, "tool-result")];
   const result = capLargeToolResults(messages, cfg, defaultCountTokens);
   assert.equal(result.cappedCount, 1);
-  assert.equal(result.capTokens, 10000);
+  assert.equal(result.capTokens, 8192);
   const rewritten = result.messages[1]!.text!;
   assert.ok(rewritten.includes("[acp: tool-result truncated"));
   assert.ok(rewritten.includes("original ~15000 tokens"));
@@ -65,7 +76,7 @@ test("capLargeToolResults rewrites an oversized tool-result over the cap", () =>
   assert.ok(rewritten.startsWith(original.slice(0, 100)));
   assert.ok(rewritten.endsWith(original.slice(-100)));
   // The rewrite itself fits the cap under the CJK-aware tokenizer.
-  assert.ok(defaultCountTokens(rewritten) <= 10000);
+  assert.ok(defaultCountTokens(rewritten) <= 8192);
   // Untouched messages keep their text verbatim.
   assert.equal(result.messages[0]!.text, "small text");
 });
@@ -94,8 +105,8 @@ test("capLargeToolResults uses the CJK-aware tokenizer (chars/4 would pass it)",
   // 30000 CJK chars: ~30000 real tokens, but a naive chars/4 estimate is
   // only 7500 — under the cap. The CJK-aware estimate must catch it.
   const cjk = "汉".repeat(30000);
-  assert.ok(defaultCountTokens(cjk) > 10000);
-  assert.ok(Math.ceil(cjk.length / 4) <= 10000);
+  assert.ok(defaultCountTokens(cjk) > 8192);
+  assert.ok(Math.ceil(cjk.length / 4) <= 8192);
   const result = capLargeToolResults(
     [msg("t", cjk, "tool-result")],
     cfg,
@@ -104,7 +115,7 @@ test("capLargeToolResults uses the CJK-aware tokenizer (chars/4 would pass it)",
   assert.equal(result.cappedCount, 1);
   const rewritten = result.messages[0]!.text!;
   assert.ok(rewritten.includes("original ~30000 tokens"));
-  assert.ok(defaultCountTokens(rewritten) <= 10000);
+  assert.ok(defaultCountTokens(rewritten) <= 8192);
 });
 
 test("capLargeToolResults disabled with maxToolResultTokens: 0", () => {
@@ -159,7 +170,9 @@ test("processTurn caps a fresh oversized tool-result below the emergency thresho
   // after the cap node (renderMessage strips the own tag before counting —
   // same convention here).
   const content = rewritten.replace(/^<acp [^>]*>m\d+<\/acp>\n?/, "");
-  assert.ok(defaultCountTokens(content) <= 10000);
+  assert.ok(defaultCountTokens(content) <= 8192);
+  // The cap is observable on the turn result (host logging/alerting).
+  assert.equal(result.toolResultCappedCount, 1);
 });
 
 test("processTurn leaves the whole session untouched when under the cap", () => {
@@ -176,9 +189,72 @@ test("processTurn leaves the whole session untouched when under the cap", () => 
     tokenCount: 3000,
   });
   assert.ok(!result.messages[1]!.text!.includes("[acp: tool-result truncated"));
+  assert.equal(result.toolResultCappedCount, undefined);
 });
 
-test("truncateLargeToolOutputs skips already-capped tool-results", () => {
+test("capLargeToolResults: a legitimate oversized result QUOTING the marker is still capped (marker-bypass regression)", () => {
+  const cfg = defaultConfig(100000); // cap 8192
+  // e.g. a grep/read of this repo's own source, a git diff, a log dump.
+  const quoting =
+    "[acp: tool-result truncated, original ~99999 tokens]" + "x".repeat(60000);
+  assert.ok(defaultCountTokens(quoting) > 8192);
+  const result = capLargeToolResults(
+    [msg("t", quoting, "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  assert.equal(result.cappedCount, 1);
+  assert.ok(
+    result.messages[0]!.text!.startsWith("[acp: tool-result truncated"),
+  );
+});
+
+test("capLargeToolResults: marker text within the cap (stored outbound view) stays skipped", () => {
+  const cfg = defaultConfig(100000); // cap 8192
+  const stored = capLargeToolResults(
+    [msg("t", "x".repeat(60000), "tool-result")],
+    cfg,
+    defaultCountTokens,
+  ).messages[0]!.text!;
+  assert.ok(stored.includes("[acp: tool-result truncated"));
+  // Re-run with the same cap: idempotent skip (within ALREADY_CAPPED_MARGIN).
+  const again = capLargeToolResults(
+    [msg("t", stored, "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  assert.equal(again.cappedCount, 0);
+});
+
+test("capLargeToolResults: non-finite maxToolResultTokens falls back to auto instead of truncating everything", () => {
+  // NaN compares false against every bound; pre-fix this replaced EVERY
+  // tool-result (even "hello world") with the bare marker.
+  const cfg = defaultConfig(100000, {
+    truncate: { maxToolResultTokens: Number.NaN },
+  });
+  assert.equal(resolveToolResultCap(cfg), 8192); // auto, not NaN
+  const result = capLargeToolResults(
+    [msg("t", "hello world", "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  assert.equal(result.cappedCount, 0);
+  assert.equal(result.messages[0]!.text, "hello world");
+});
+
+test("resolveToolResultCap: fractional explicit caps clamp to >= 1 token (never silently disable)", () => {
+  assert.equal(
+    resolveToolResultCap(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: 0.5 } }),
+    ),
+    1,
+  );
+});
+
+test("truncateLargeToolOutputs re-truncates capped tool-results at emergency (stacked markers allowed)", () => {
+  // Review finding #4: at >=95%/threshold usage the prefix is already broken
+  // by design — emergency must still be able to shrink capped-but-large
+  // messages. Pre-fix, the marker skip made them permanently untouchable.
   const cfg = defaultConfig(100000, { truncate: { threshold: 0.5 } });
   const capped = capLargeToolResults(
     [msg("t", "x".repeat(60000), "tool-result")],
@@ -192,8 +268,29 @@ test("truncateLargeToolOutputs skips already-capped tool-results", () => {
     defaultCountTokens,
     { minOutputTokens: 100, keepPrefixChars: 100, keepSuffixChars: 100 },
   );
+  assert.equal(result.truncatedCount, 1);
+  const text = result.messages[0]!.text!;
+  assert.ok(text.includes("[truncated for context space"));
+  assert.ok(defaultCountTokens(text) < 1000);
+});
+
+test("truncateLargeToolOutputs leaves capped tool-results alone when usage is already below target", () => {
+  const cfg = defaultConfig(100000, { truncate: { threshold: 0.5 } });
+  const capped = capLargeToolResults(
+    [msg("t", "x".repeat(60000), "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  // 44000 < threshold 50000: early return — capped messages are only
+  // re-touched when usage actually crosses the emergency threshold.
+  const result = truncateLargeToolOutputs(
+    capped.messages,
+    44000,
+    cfg,
+    defaultCountTokens,
+    { minOutputTokens: 100, keepPrefixChars: 100, keepSuffixChars: 100 },
+  );
   assert.equal(result.truncatedCount, 0);
-  // No double-truncation marker stacking.
   assert.equal(result.messages[0]!.text, capped.messages[0]!.text);
 });
 

--- a/tests/toolresult-token-cap.test.ts
+++ b/tests/toolresult-token-cap.test.ts
@@ -1,0 +1,222 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  truncateLargeToolOutputs,
+  capLargeToolResults,
+  resolveToolResultCap,
+} from "../src/truncate-tools.js";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { defaultConfig, validateConfig } from "../src/config.js";
+import { defaultCountTokens } from "../src/tokenize.js";
+import type { CoreMessage } from "../src/types.js";
+
+function msg(
+  id: string,
+  text: string,
+  type: CoreMessage["contentType"] = "text",
+): CoreMessage {
+  return { id, role: "user", contentType: type, text };
+}
+
+test("resolveToolResultCap: auto = min(10% of limit, 16384)", () => {
+  assert.equal(resolveToolResultCap(defaultConfig(100000)), 10000);
+  assert.equal(resolveToolResultCap(defaultConfig(131072)), 13107);
+  // 10% of 500000 is 50000 — clamped by the absolute ceiling.
+  assert.equal(resolveToolResultCap(defaultConfig(500000)), 16384);
+  assert.equal(resolveToolResultCap(defaultConfig(163840)), 16384);
+  // Unknown limit: auto still fires at the ceiling.
+  assert.equal(resolveToolResultCap(defaultConfig(0)), 16384);
+});
+
+test("resolveToolResultCap: explicit values and disable", () => {
+  assert.equal(
+    resolveToolResultCap(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: 5000 } }),
+    ),
+    5000,
+  );
+  assert.equal(
+    resolveToolResultCap(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: 0 } }),
+    ),
+    0,
+  );
+  // Explicit cap wins over auto even when larger.
+  assert.equal(
+    resolveToolResultCap(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: 20000 } }),
+    ),
+    20000,
+  );
+});
+
+test("capLargeToolResults rewrites an oversized tool-result over the cap", () => {
+  const cfg = defaultConfig(100000); // auto cap = 10000
+  const original = "L".repeat(60000); // 15000 tokens
+  const messages = [msg("a", "small text"), msg("t1", original, "tool-result")];
+  const result = capLargeToolResults(messages, cfg, defaultCountTokens);
+  assert.equal(result.cappedCount, 1);
+  assert.equal(result.capTokens, 10000);
+  const rewritten = result.messages[1]!.text!;
+  assert.ok(rewritten.includes("[acp: tool-result truncated"));
+  assert.ok(rewritten.includes("original ~15000 tokens"));
+  // Head and tail survive.
+  assert.ok(rewritten.startsWith(original.slice(0, 100)));
+  assert.ok(rewritten.endsWith(original.slice(-100)));
+  // The rewrite itself fits the cap under the CJK-aware tokenizer.
+  assert.ok(defaultCountTokens(rewritten) <= 10000);
+  // Untouched messages keep their text verbatim.
+  assert.equal(result.messages[0]!.text, "small text");
+});
+
+test("capLargeToolResults leaves small tool-results untouched", () => {
+  const cfg = defaultConfig(100000);
+  const messages = [
+    msg("a", "x".repeat(400), "tool-result"),
+    msg("b", "y".repeat(20000), "tool-result"), // 5000 tokens < 10000
+    msg("c", "plain text"),
+  ];
+  const result = capLargeToolResults(messages, cfg, defaultCountTokens);
+  assert.equal(result.cappedCount, 0);
+  assert.equal(result.messages, messages);
+});
+
+test("capLargeToolResults ignores huge non-tool-result messages", () => {
+  const cfg = defaultConfig(100000);
+  const messages = [msg("a", "x".repeat(60000))];
+  const result = capLargeToolResults(messages, cfg, defaultCountTokens);
+  assert.equal(result.cappedCount, 0);
+});
+
+test("capLargeToolResults uses the CJK-aware tokenizer (chars/4 would pass it)", () => {
+  const cfg = defaultConfig(100000); // cap = 10000
+  // 30000 CJK chars: ~30000 real tokens, but a naive chars/4 estimate is
+  // only 7500 — under the cap. The CJK-aware estimate must catch it.
+  const cjk = "汉".repeat(30000);
+  assert.ok(defaultCountTokens(cjk) > 10000);
+  assert.ok(Math.ceil(cjk.length / 4) <= 10000);
+  const result = capLargeToolResults(
+    [msg("t", cjk, "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  assert.equal(result.cappedCount, 1);
+  const rewritten = result.messages[0]!.text!;
+  assert.ok(rewritten.includes("original ~30000 tokens"));
+  assert.ok(defaultCountTokens(rewritten) <= 10000);
+});
+
+test("capLargeToolResults disabled with maxToolResultTokens: 0", () => {
+  const cfg = defaultConfig(100000, { truncate: { maxToolResultTokens: 0 } });
+  const messages = [msg("t", "x".repeat(60000), "tool-result")];
+  const result = capLargeToolResults(messages, cfg, defaultCountTokens);
+  assert.equal(result.cappedCount, 0);
+  assert.equal(result.capTokens, 0);
+  assert.equal(result.messages, messages);
+});
+
+test("capLargeToolResults honors an explicit smaller cap", () => {
+  const cfg = defaultConfig(100000, {
+    truncate: { maxToolResultTokens: 1000 },
+  });
+  const messages = [msg("t", "x".repeat(5000), "tool-result")]; // 1250 tokens
+  const result = capLargeToolResults(messages, cfg, defaultCountTokens);
+  assert.equal(result.cappedCount, 1);
+  assert.ok(defaultCountTokens(result.messages[0]!.text!) <= 1000);
+});
+
+test("capLargeToolResults is idempotent on already-capped text", () => {
+  const cfg = defaultConfig(100000);
+  const once = capLargeToolResults(
+    [msg("t", "x".repeat(60000), "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  const twice = capLargeToolResults(once.messages, cfg, defaultCountTokens);
+  assert.equal(twice.cappedCount, 0);
+  assert.equal(twice.messages, once.messages);
+});
+
+test("processTurn caps a fresh oversized tool-result below the emergency threshold", () => {
+  const cfg = defaultConfig(100000); // emergency needs >= 95000
+  const core = createCore();
+  const messages = [
+    msg("u1", "user question"),
+    msg("t1", "x".repeat(60000), "tool-result"), // 15000 tokens, MOST RECENT
+  ];
+  const result = core.processTurn({
+    messages,
+    state: createInitialState(),
+    config: cfg,
+    tokenCount: 20000, // 20% usage — far below every usage-gated valve
+  });
+  const rewritten = result.messages[1]!.text!;
+  assert.ok(rewritten.includes("[acp: tool-result truncated"));
+  // The usage-gated emergency truncation must NOT have fired on top.
+  assert.ok(!rewritten.includes("[truncated for context space"));
+  // Count the capped content, not the <acp> tag prefix render-refs added
+  // after the cap node (renderMessage strips the own tag before counting —
+  // same convention here).
+  const content = rewritten.replace(/^<acp [^>]*>m\d+<\/acp>\n?/, "");
+  assert.ok(defaultCountTokens(content) <= 10000);
+});
+
+test("processTurn leaves the whole session untouched when under the cap", () => {
+  const cfg = defaultConfig(100000);
+  const core = createCore();
+  const messages = [
+    msg("u1", "user question"),
+    msg("t1", "x".repeat(8000), "tool-result"), // 2000 tokens < 10000
+  ];
+  const result = core.processTurn({
+    messages,
+    state: createInitialState(),
+    config: cfg,
+    tokenCount: 3000,
+  });
+  assert.ok(!result.messages[1]!.text!.includes("[acp: tool-result truncated"));
+});
+
+test("truncateLargeToolOutputs skips already-capped tool-results", () => {
+  const cfg = defaultConfig(100000, { truncate: { threshold: 0.5 } });
+  const capped = capLargeToolResults(
+    [msg("t", "x".repeat(60000), "tool-result")],
+    cfg,
+    defaultCountTokens,
+  );
+  const result = truncateLargeToolOutputs(
+    capped.messages,
+    90000,
+    cfg,
+    defaultCountTokens,
+    { minOutputTokens: 100, keepPrefixChars: 100, keepSuffixChars: 100 },
+  );
+  assert.equal(result.truncatedCount, 0);
+  // No double-truncation marker stacking.
+  assert.equal(result.messages[0]!.text, capped.messages[0]!.text);
+});
+
+test("validateConfig rejects a negative maxToolResultTokens", () => {
+  const cfg = defaultConfig(100000, {
+    truncate: { maxToolResultTokens: -5 },
+  });
+  const errors = validateConfig(cfg);
+  assert.ok(
+    errors.some((e) => e.includes("maxToolResultTokens")),
+    `expected maxToolResultTokens error, got: ${errors.join("; ")}`,
+  );
+  // null (auto) and 0 (disabled) are both valid.
+  assert.equal(
+    validateConfig(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: null } }),
+    ).length,
+    0,
+  );
+  assert.equal(
+    validateConfig(
+      defaultConfig(100000, { truncate: { maxToolResultTokens: 0 } }),
+    ).length,
+    0,
+  );
+});

--- a/tests/truncate-keep-filter.test.ts
+++ b/tests/truncate-keep-filter.test.ts
@@ -45,7 +45,7 @@ test("truncateLargeToolOutputs truncates large tool outputs over threshold", () 
     assert.ok(result.messages[0]!.text!.includes("[truncated for context space"));
 });
 
-test("truncateLargeToolOutputs protects recent messages", () => {
+test("truncateLargeToolOutputs truncates large recent messages (size-aware, no hard recency protection)", () => {
     const cfg = defaultConfig(100000, { truncate: { threshold: 0.1 } });
     const big = "L".repeat(10000);
     const messages = [msg("only", big, "tool-result")];
@@ -53,7 +53,12 @@ test("truncateLargeToolOutputs protects recent messages", () => {
         minOutputTokens: 100,
         protectRecentMessages: 3,
     });
-    assert.equal(result.truncatedCount, 0);
+    // Size-aware: a large recent message IS truncated (recency no longer hard-protects).
+    // This is the fix for the decompress-inline overflow: the most recent tool-results
+    // (the inlined blocks) were the largest, and the old hard protection prevented
+    // truncating them.
+    assert.equal(result.truncatedCount, 1);
+    assert.ok(result.messages[0]!.text!.includes("[truncated for context space]"));
 });
 
 test("applyMessageFilters is a no-op when disabled", () => {


### PR DESCRIPTION
## Problem

The emergency truncation (src/truncate-tools.ts) hard-protected the last N messages (`protectRecentMessages: 3`). This was counterproductive when the most recent tool-results were the **largest** — e.g. `decompress inline:true` results.

In the 2026-08-22 overflow (billion-context-pi#12), the model inlined 6 blocks (574 msgs) in one turn at 21% usage. The 6 inlined tool-results were the **newest** messages, so the last 3 (~100K tokens) fell in the protected zone and were never truncated; only the older 3 were, which was insufficient to bring the context under the limit.

## Fix

All tool-results are now candidates for truncation (including recent ones), sorted **largest-first**. The size-based sort naturally preserves small recent messages and truncates large ones regardless of recency.

`protectRecentMessages` is kept in the API for backward compatibility but no longer hard-excludes recent messages from candidacy.

## Tests

- Updated `tests/truncate-keep-filter.test.ts`: the "protects recent messages" test now verifies a large recent message IS truncated (size-aware).
- All 463 tests pass.

## Related

- billion-context-pi#12 — pi 低上下文溢出, subagent调用失败
- Companion: billion-context-pi inline-cap fix (decompressInlineMaxChars config)