### PR TITLE
chore: release v0.0.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.41",
+    "version": "0.0.42",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Summary
- Release-only version bump `0.0.41` → `0.0.42` (package.json).
- Ships PR #135: ACP tool surface (`src/compress-tools.ts`, Phase K1) + compress-call detection/replay-guard (`src/wire/compress-detect.ts`, Phase K2).

## Model
GLM-5.3 (zhipuai-lb, via omp session)

## Release notes
- New exports (main index): COMPRESS_TOOL*, ACP_TOOLS_*, build*Prompt, parseCompressInput, ACP_TOOL_NAMES / ACP_MUTATING_TOOLS / ACP_READONLY_TOOLS
- New exports (wire subpath): compressToolArgs, findCompressCallsCore, toolCallNames, toolResultTextsCore, spanFingerprintCore*, boundary*Core, refOfPieceCore, staleRangeCore, rangeFingerprintsCore, rangePositionsCore, ReplayRangeVerdict, StreamCompressCall