### PR TITLE
fix(compress): clarify stale-ref error to point at acp_status

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -272,7 +272,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
           unknownCount > 0
             ? `None of the ${input.ranges.length} requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then re-issue the compress in the same turn using only the refs it reports.`
             : consumedRanges.length > 0
-              ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}); remaining compressible content ${totalRangeChars} chars < min ${input.config.compress.minCompressRange}. Nothing to do.${liveHint}`
+              ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — your refs are stale: a prior compress renumbered the remaining refs, so this range now falls inside an active block. Run acp_status and re-issue the compress in the same turn using only the CURRENT compressible ranges it reports.${liveHint}`
               : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {
           state: input.state,

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -270,9 +270,9 @@ export function createCore(ports: Ports = {}): CompressionCore {
           resolvableCount === 0 &&
           consumedRanges.length === 0 &&
           unknownCount > 0
-            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then re-issue the compress in the same turn using only the refs it reports.`
+            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then call the compress tool again using only the refs it reports.`
             : consumedRanges.length > 0
-              ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — your refs are stale: a prior compress renumbered the remaining refs, so this range now falls inside an active block. Run acp_status and re-issue the compress in the same turn using only the CURRENT compressible ranges it reports.${liveHint}`
+              ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — your refs are stale: a prior compress renumbered the remaining refs, so this range now falls inside an active block. Run acp_status, then call the compress tool again using only the CURRENT compressible ranges it reports.${liveHint}`
               : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {
           state: input.state,

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -426,7 +426,8 @@ test("consumed plus fresh-but-small range is not misreported as too small", () =
   assert.equal(retry.result.blocksCreated, 0);
   assert.equal(retry.result.errors.length, 1);
   assert.match(retry.result.errors[0]!, /already compressed/);
-  assert.match(retry.result.errors[0]!, /remaining compressible content/);
+  assert.match(retry.result.errors[0]!, /your refs are stale/);
+  assert.match(retry.result.errors[0]!, /Run acp_status/);
   assert.doesNotMatch(retry.result.errors[0]!, /Combine more messages/);
 });
 


### PR DESCRIPTION
**Model: qwen3.8-27b (vllm)**

## Problem
When a compress call targets a range that is already compressed (stale refs from before a renumbering compress), the case-2 gate message was misleading:

> Requested range(s) already compressed (e.g. m00365..m00462); remaining compressible content 0 chars < min 5000. Nothing to do.

The "remaining compressible content 0 chars < min 5000. Nothing to do" framing reads as *there is nothing to compress* (give up), not *my refs are stale — re-check*. The model then spins on repeated failed compress attempts, each one adding its (unapplied) summary + error to the context as a net token loss. Observed live in a pi session: two failed compresses (m00365..m00462, m00210..m00211) both hit this message, and the model concluded "there's genuinely nothing to compress" instead of re-checking refs.

The all-unknown case (case 1) already has the correct actionable wording; case 2 did not.

## Fix
Rewrite the case-2 gate message (src/compress.ts) to lead with the actionable guidance, matching case 1:

> Requested range(s) already compressed (e.g. m00365..m00462) — your refs are stale: a prior compress renumbered the remaining refs, so this range now falls inside an active block. Run acp_status and re-issue the compress in the same turn using only the CURRENT compressible ranges it reports.

## Tests
- Updated tests/compress.test.ts assertion to verify the new actionable wording ("your refs are stale" + "Run acp_status").
- typecheck clean; all 479 tests pass.

Fixes billion-context-pi#178.