### PR TITLE
feat: absorb — instant tool-result compression (billion-context-pi#14)

### DIFF
--- a/src/absorb.ts
+++ b/src/absorb.ts
@@ -1,0 +1,338 @@
+import { rawForRef, refForRaw, BLOCKED_REF } from "./refs.js";
+import { ACP_TOOL_NAMES, ABSORB_TOOL_NAME } from "./compress-tools.js";
+import { isMessageProtected, matchToolPattern } from "./protected.js";
+import type {
+  AbsorbConfig,
+  AbsorbRecord,
+  Config,
+  CompressionState,
+  CoreMessage,
+} from "./types.js";
+
+/**
+ * Instant tool-result absorption ("absorb") — the middle layer between
+ * "let output pile up until a 50K-token nudge fires" and "the model can't
+ * work at a 10K window". When enabled, the kernel appends a FORCED prompt to
+ * every eligible large tool result demanding the model immediately distill it
+ * via absorb({ ref, summary }); the original tool-call + tool-result pair is
+ * then hidden from all subsequent turns, leaving the model's absorb call as
+ * the durable record. Absorb calls are ordinary messages: the regular
+ * compression pipeline can fold them later (orthogonal by design).
+ */
+
+export const ABSORB_PROMPT_MARKER = "[ACP absorb]";
+
+export const DEFAULT_ABSORB_CONFIG: AbsorbConfig = {
+  enabled: false,
+  toolName: ABSORB_TOOL_NAME,
+  minToolTokens: 1000,
+  contextThresholdPct: 0,
+  excludeTools: [],
+};
+
+export function resolveAbsorbConfig(config: Config): AbsorbConfig {
+  return { ...DEFAULT_ABSORB_CONFIG, ...(config.absorb ?? {}) };
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) return String(tokens);
+  if (tokens < 10000) return (tokens / 1000).toFixed(1) + "K";
+  return Math.round(tokens / 1000) + "K";
+}
+
+export function buildAbsorbPrompt(
+  ref: string,
+  tokens: number,
+  toolName: string = ABSORB_TOOL_NAME,
+): string {
+  return (
+    `${ABSORB_PROMPT_MARKER} This tool result (~${formatTokenCount(tokens)} tokens) will be REMOVED from context. ` +
+    `Your IMMEDIATE next action: call ${toolName}({ ref: "${ref}", summary: "..." }) — summary = distilled essentials only ` +
+    `(outcome, key values, exact paths:lines, error text verbatim, decisions). ` +
+    `Afterwards work from your summary; do NOT re-run this tool. ` +
+    `If the result contains nothing you need, call ${toolName} with summary "(nothing needed)".`
+  );
+}
+
+/** System-prompt section for adapters with absorb enabled. */
+export function buildAbsorbSystemPrompt(
+  toolName: string = ABSORB_TOOL_NAME,
+): string {
+  return `INSTANT TOOL-RESULT ABSORPTION (${toolName})
+
+Some tool results end with a ${ABSORB_PROMPT_MARKER} instruction. When you see one, your IMMEDIATE next action must be calling ${toolName}({ ref, summary }) — distill that tool result's essentials into summary: outcome, key values, exact paths:lines, error text verbatim, decisions. The original output is then removed from context; your ${toolName} summary becomes the only durable record of it, so distill carefully. Never call another tool or answer the user before absorbing a marked result. Do not re-run the original tool afterwards — work from your summary. ${toolName} calls are ordinary context: the regular compression system may fold them later like any other message.`;
+}
+
+function isAcpOrConfiguredTool(
+  toolName: string | undefined,
+  cfg: AbsorbConfig,
+): boolean {
+  if (!toolName) return false;
+  if (toolName === cfg.toolName) return true;
+  return ACP_TOOL_NAMES.has(toolName);
+}
+
+/** True when a tool-result message is in scope for absorption prompting:
+ *  a tool-result of a non-ACP, non-excluded, non-protected tool. */
+export function isAbsorbCandidate(msg: CoreMessage, config: Config): boolean {
+  if (msg.contentType !== "tool-result" || !msg.toolCallId) return false;
+  const cfg = resolveAbsorbConfig(config);
+  if (isAcpOrConfiguredTool(msg.toolName, cfg)) return false;
+  if (isMessageProtected(msg, config)) return false;
+  for (const pattern of cfg.excludeTools) {
+    if (msg.toolName && matchToolPattern(msg.toolName, pattern)) return false;
+  }
+  return true;
+}
+
+/** Drop tool-call + tool-result pairs recorded in state.absorbed. Both halves
+ *  go together so the provider-visible conversation stays structurally valid;
+ *  prune's orphan stripping cleans up any straddling leftovers. */
+export function hideAbsorbedMessages(
+  messages: CoreMessage[],
+  state: CompressionState,
+): CoreMessage[] {
+  const records = state.absorbed ?? [];
+  if (records.length === 0) return messages;
+  const hidden = new Set<string>();
+  for (const record of records) {
+    if (record.callMessageId) hidden.add(record.callMessageId);
+    if (record.resultMessageId) hidden.add(record.resultMessageId);
+  }
+  return messages.filter((msg) => !hidden.has(msg.id));
+}
+
+export interface AppendAbsorbPromptsResult {
+  messages: CoreMessage[];
+  promptedCount: number;
+}
+
+/** Append the forced absorb prompt to every eligible, un-absorbed, large
+ *  tool result in the visible view. Per-turn view-only text (never persisted
+ *  by the kernel): the prompt re-appears each turn until the model absorbs,
+ *  and disappears once the pair is hidden by hideAbsorbedMessages. */
+export function appendAbsorbPrompts(
+  messages: CoreMessage[],
+  state: CompressionState,
+  config: Config,
+  tokenCount: number,
+  countTokens: (text: string) => number,
+): AppendAbsorbPromptsResult {
+  const cfg = resolveAbsorbConfig(config);
+  if (!cfg.enabled) return { messages, promptedCount: 0 };
+
+  const limit = config.modelContextLimit;
+  if (
+    cfg.contextThresholdPct > 0 &&
+    limit > 0 &&
+    tokenCount < cfg.contextThresholdPct * limit
+  ) {
+    return { messages, promptedCount: 0 };
+  }
+
+  const absorbedIds = new Set<string>();
+  for (const record of state.absorbed ?? []) {
+    if (record.resultMessageId) absorbedIds.add(record.resultMessageId);
+  }
+
+  let promptedCount = 0;
+  const out = messages.map((msg) => {
+    if (!isAbsorbCandidate(msg, config)) return msg;
+    if (absorbedIds.has(msg.id)) return msg;
+    const text = msg.text ?? "";
+    if (text.includes(ABSORB_PROMPT_MARKER)) return msg;
+    const tokens = countTokens(text);
+    if (tokens < cfg.minToolTokens) return msg;
+    const ref = refForRaw(state.messageRefs, msg.id);
+    if (!ref || ref === BLOCKED_REF) return msg;
+    promptedCount++;
+    return {
+      ...msg,
+      text: text + "\n\n" + buildAbsorbPrompt(ref, tokens, cfg.toolName),
+    };
+  });
+  return { messages: out, promptedCount };
+}
+
+export interface ParsedAbsorb {
+  ref: string;
+  summary: string;
+  absorbCallId?: string;
+}
+
+/** Lenient parse of an absorb tool-call argument object. Accepts `ref`
+ *  spellings ref/messageId/of and summary spellings summary/content, plus a
+ *  JSON-encoded string payload (stringifying providers). */
+export function parseAbsorbInput(
+  input: unknown,
+  callId?: string,
+  onWarn?: (message: string) => void,
+): ParsedAbsorb | null {
+  let obj: Record<string, unknown> | null = null;
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input);
+      if (parsed && typeof parsed === "object") {
+        obj = parsed as Record<string, unknown>;
+      }
+    } catch {
+      obj = null;
+    }
+  } else if (input && typeof input === "object") {
+    obj = input as Record<string, unknown>;
+  }
+  if (!obj) {
+    onWarn?.(`[acp-absorb-input] rejected: not an object (${typeof input})`);
+    return null;
+  }
+  const ref = pickString(obj, "ref", "messageId", "of");
+  const summary = pickString(obj, "summary", "content");
+  if (typeof ref !== "string" || typeof summary !== "string") {
+    onWarn?.(
+      `[acp-absorb-input] rejected: need ref (string) + summary (string); keys: ${Object.keys(obj).join(",")}`,
+    );
+    return null;
+  }
+  return {
+    ref: ref.trim(),
+    summary,
+    ...(callId ? { absorbCallId: callId } : {}),
+  };
+}
+
+function pickString(
+  obj: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+export interface AbsorbInput {
+  ref: string;
+  summary: string;
+  absorbCallId?: string;
+  messages: CoreMessage[];
+  state: CompressionState;
+  config: Config;
+  countTokens?: (text: string) => number;
+}
+
+export interface AbsorbOutcome {
+  state: CompressionState;
+  ok: boolean;
+  resultText: string;
+}
+
+/** Apply a model-issued absorb call: validate the target tool-result, record
+ *  the absorption in state, and report. The pair is hidden on the NEXT
+ *  processTurn (hideAbsorbedMessages), never mid-turn. */
+export function applyAbsorb(input: AbsorbInput): AbsorbOutcome {
+  const countTokens =
+    input.countTokens ?? ((text: string) => Math.ceil(text.length / 4));
+  const summary = input.summary?.trim() ?? "";
+  if (!summary) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText:
+        "absorb failed: summary is empty — provide the distilled key info of the tool result.",
+    };
+  }
+
+  const cfg = resolveAbsorbConfig(input.config);
+  const rawId = rawForRef(input.state.messageRefs, input.ref.trim());
+  if (!rawId) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ref ${input.ref} does not exist in this session (it may be hidden, already compressed, or stale).`,
+    };
+  }
+  const target = input.messages.find((m) => m.id === rawId);
+  if (!target) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ref ${input.ref} is not visible in this session (hidden or compressed).`,
+    };
+  }
+  if (target.contentType !== "tool-result") {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ref ${input.ref} is a ${target.contentType}, not a tool result.`,
+    };
+  }
+  if (isAcpOrConfiguredTool(target.toolName, cfg)) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ${target.toolName} is an ACP-managed tool result — it is not absorbable.`,
+    };
+  }
+  if (isMessageProtected(target, input.config)) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ${target.toolName} is a protected tool — its results must stay visible.`,
+    };
+  }
+  if (!target.toolCallId) {
+    return {
+      state: input.state,
+      ok: false,
+      resultText: `absorb failed: ref ${input.ref} has no tool-call id — cannot pair it for hiding.`,
+    };
+  }
+
+  const existing = (input.state.absorbed ?? []).find(
+    (record) =>
+      record.resultMessageId === target.id ||
+      record.toolCallId === target.toolCallId,
+  );
+  if (existing) {
+    return {
+      state: input.state,
+      ok: true,
+      resultText: `already absorbed (${input.ref}) — no change.`,
+    };
+  }
+
+  const call = input.messages.find(
+    (m) => m.contentType === "tool-call" && m.toolCallId === target.toolCallId,
+  );
+  const tokens = countTokens(target.text ?? "");
+  const summaryTokens = countTokens(summary);
+
+  const record: AbsorbRecord = {
+    toolCallId: target.toolCallId,
+    callMessageId: call?.id ?? "",
+    resultMessageId: target.id,
+    ...(input.absorbCallId ? { absorbCallId: input.absorbCallId } : {}),
+    summary,
+    tokensReclaimed: tokens,
+    createdAt: Date.now(),
+  };
+  const state: CompressionState = {
+    ...input.state,
+    absorbed: [...(input.state.absorbed ?? []), record],
+    stats: {
+      ...input.state.stats,
+      absorbedTokens: (input.state.stats.absorbedTokens ?? 0) + tokens,
+    },
+  };
+
+  const bloat =
+    summaryTokens >= tokens && tokens > 0
+      ? ` WARNING: your summary (~${formatTokenCount(summaryTokens)} tokens) is not smaller than the original (~${formatTokenCount(tokens)} tokens) — distill harder next time.`
+      : "";
+  return {
+    state,
+    ok: true,
+    resultText: `absorbed ${input.ref} (~${formatTokenCount(tokens)} tokens → summary ~${formatTokenCount(summaryTokens)}). The original tool output is now hidden; your summary is the durable record.${bloat}`,
+  };
+}

--- a/src/absorb.ts
+++ b/src/absorb.ts
@@ -252,6 +252,16 @@ export function applyAbsorb(input: AbsorbInput): AbsorbOutcome {
       resultText: `absorb failed: ref ${input.ref} does not exist in this session (it may be hidden, already compressed, or stale).`,
     };
   }
+  const existing = (input.state.absorbed ?? []).find(
+    (record) => record.resultMessageId === rawId,
+  );
+  if (existing) {
+    return {
+      state: input.state,
+      ok: true,
+      resultText: `already absorbed (${input.ref}) — no change.`,
+    };
+  }
   const target = input.messages.find((m) => m.id === rawId);
   if (!target) {
     return {
@@ -286,19 +296,6 @@ export function applyAbsorb(input: AbsorbInput): AbsorbOutcome {
       state: input.state,
       ok: false,
       resultText: `absorb failed: ref ${input.ref} has no tool-call id — cannot pair it for hiding.`,
-    };
-  }
-
-  const existing = (input.state.absorbed ?? []).find(
-    (record) =>
-      record.resultMessageId === target.id ||
-      record.toolCallId === target.toolCallId,
-  );
-  if (existing) {
-    return {
-      state: input.state,
-      ok: true,
-      resultText: `already absorbed (${input.ref}) — no change.`,
     };
   }
 

--- a/src/compress-tools.ts
+++ b/src/compress-tools.ts
@@ -15,6 +15,7 @@ export const COMPRESS_TOOL_NAME = "compress";
 export const DECOMPRESS_TOOL_NAME = "decompress";
 export const SEARCH_CONTEXT_TOOL_NAME = "search_context";
 export const ACP_STATUS_TOOL_NAME = "acp_status";
+export const ABSORB_TOOL_NAME = "absorb";
 
 /** Text-protocol trigger tags. The model emits these in its text output to
  *  request compression (used when host client tools cannot coexist with a
@@ -30,38 +31,51 @@ export const ACP_DECOMPRESS_OPEN = "<acp_decompress>";
 export const ACP_DECOMPRESS_CLOSE = "</acp_decompress>";
 
 export const COMPRESS_TOOL = {
-    name: COMPRESS_TOOL_NAME,
-    description:
-        "Replace a contiguous range of older conversation with a detailed summary you write. Use when content is genuinely consumed. Batch form: content=[{startId,endId,summary,topic?}]. REQUIRED — compress without content is invalid.",
-    input_schema: {
-        type: "object",
-        properties: {
-            topic: { type: "string", description: "Optional short title for the compressed range" },
-            content: {
-                type: "array",
-                description: "One or more ranges to compress into separate summary blocks",
-                items: {
-                    type: "object",
-                    properties: {
-                        topic: { type: "string" },
-                        startId: { type: "string", description: "mNNNNN ref at the start of the range" },
-                        endId: { type: "string", description: "mNNNNN ref at the end of the range" },
-                        summary: { type: "string", description: "Self-contained summary replacing the range" },
-                    },
-                    required: ["startId", "endId", "summary"],
-                },
+  name: COMPRESS_TOOL_NAME,
+  description:
+    "Replace a contiguous range of older conversation with a detailed summary you write. Use when content is genuinely consumed. Batch form: content=[{startId,endId,summary,topic?}]. REQUIRED — compress without content is invalid.",
+  input_schema: {
+    type: "object",
+    properties: {
+      topic: {
+        type: "string",
+        description: "Optional short title for the compressed range",
+      },
+      content: {
+        type: "array",
+        description:
+          "One or more ranges to compress into separate summary blocks",
+        items: {
+          type: "object",
+          properties: {
+            topic: { type: "string" },
+            startId: {
+              type: "string",
+              description: "mNNNNN ref at the start of the range",
             },
+            endId: {
+              type: "string",
+              description: "mNNNNN ref at the end of the range",
+            },
+            summary: {
+              type: "string",
+              description: "Self-contained summary replacing the range",
+            },
+          },
+          required: ["startId", "endId", "summary"],
         },
-        required: ["content"],
+      },
     },
+    required: ["content"],
+  },
 };
 
 export type ParsedRange = {
-    startRef: string;
-    endRef: string;
-    summary: string;
-    topic?: string;
-    compressCallId?: string;
+  startRef: string;
+  endRef: string;
+  summary: string;
+  topic?: string;
+  compressCallId?: string;
 };
 
 /** Lenient parse of a compress tool-call argument object into ranges.
@@ -70,86 +84,112 @@ export type ParsedRange = {
  *  range object at the top level, and both startId/startRef spellings.
  *  `onWarn` receives diagnostics for rejected shapes — the kernel stays
  *  side-effect free, downstream wires its logger. */
-export function parseCompressInput(input: unknown, callId?: string, onWarn?: (message: string) => void): ParsedRange[] {
-    if (!input || typeof input !== "object") {
-        onWarn?.(`[acp-compress-input] rejected: not object (${typeof input})`);
-        return [];
+export function parseCompressInput(
+  input: unknown,
+  callId?: string,
+  onWarn?: (message: string) => void,
+): ParsedRange[] {
+  if (!input || typeof input !== "object") {
+    onWarn?.(`[acp-compress-input] rejected: not object (${typeof input})`);
+    return [];
+  }
+  const obj = input as Record<string, unknown>;
+  let content: unknown = obj.content;
+  if (typeof content === "string") {
+    try {
+      content = JSON.parse(content);
+    } catch {
+      onWarn?.(
+        "[acp-compress-input] content is a string but not valid JSON; parsed 0 valid ranges",
+      );
+      return [];
     }
-    const obj = input as Record<string, unknown>;
-    let content: unknown = obj.content;
-    if (typeof content === "string") {
-        try {
-            content = JSON.parse(content);
-        } catch {
-            onWarn?.("[acp-compress-input] content is a string but not valid JSON; parsed 0 valid ranges");
-            return [];
-        }
-    }
-    const single = toRange(obj);
-    const ranges = Array.isArray(content)
-        ? content
-              .map((r) => toRange(r as Record<string, unknown>))
-              .filter((r): r is ParsedRange => r !== null)
-        : single
-          ? [single]
-          : [];
-    if (ranges.length === 0) {
-        onWarn?.(`[acp-compress-input] parsed 0 valid ranges. top keys: ${Object.keys(obj).join(",")}`);
-    }
-    if (callId) for (const r of ranges) r.compressCallId = callId;
-    return ranges;
+  }
+  const single = toRange(obj);
+  const ranges = Array.isArray(content)
+    ? content
+        .map((r) => toRange(r as Record<string, unknown>))
+        .filter((r): r is ParsedRange => r !== null)
+    : single
+      ? [single]
+      : [];
+  if (ranges.length === 0) {
+    onWarn?.(
+      `[acp-compress-input] parsed 0 valid ranges. top keys: ${Object.keys(obj).join(",")}`,
+    );
+  }
+  if (callId) for (const r of ranges) r.compressCallId = callId;
+  return ranges;
 }
 
 function toRange(r: Record<string, unknown>): ParsedRange | null {
-    const startRef = pick(r, "startId", "startRef");
-    const endRef = pick(r, "endId", "endRef");
-    const summary = r.summary;
-    if (typeof startRef !== "string" || typeof endRef !== "string" || typeof summary !== "string") {
-        return null;
-    }
-    const topic = typeof r.topic === "string" ? r.topic : undefined;
-    return { startRef, endRef, summary, ...(topic ? { topic } : {}) };
+  const startRef = pick(r, "startId", "startRef");
+  const endRef = pick(r, "endId", "endRef");
+  const summary = r.summary;
+  if (
+    typeof startRef !== "string" ||
+    typeof endRef !== "string" ||
+    typeof summary !== "string"
+  ) {
+    return null;
+  }
+  const topic = typeof r.topic === "string" ? r.topic : undefined;
+  return { startRef, endRef, summary, ...(topic ? { topic } : {}) };
 }
 
 function pick(r: Record<string, unknown>, ...keys: string[]): unknown {
-    for (const k of keys) {
-        if (r[k] !== undefined) return r[k];
-    }
-    return undefined;
+  for (const k of keys) {
+    if (r[k] !== undefined) return r[k];
+  }
+  return undefined;
 }
 
 export const COMPRESS_TOOL_OPENAI = {
-    type: "function" as const,
-    function: {
-        name: COMPRESS_TOOL_NAME,
-        description: COMPRESS_TOOL.description,
-        parameters: {
+  type: "function" as const,
+  function: {
+    name: COMPRESS_TOOL_NAME,
+    description: COMPRESS_TOOL.description,
+    parameters: {
+      type: "object",
+      properties: {
+        topic: {
+          type: "string",
+          description: "Optional short title for the compressed range",
+        },
+        content: {
+          type: "array",
+          description:
+            "One or more ranges to compress into separate summary blocks. REQUIRED — compress without content is invalid.",
+          items: {
             type: "object",
             properties: {
-                topic: { type: "string", description: "Optional short title for the compressed range" },
-                content: {
-                    type: "array",
-                    description:
-                        "One or more ranges to compress into separate summary blocks. REQUIRED — compress without content is invalid.",
-                    items: {
-                        type: "object",
-                        properties: {
-                            topic: { type: "string" },
-                            startId: { type: "string", description: "mNNNNN ref at the start of the range" },
-                            endId: { type: "string", description: "mNNNNN ref at the end of the range" },
-                            summary: { type: "string", description: "Self-contained summary replacing the range" },
-                        },
-                        required: ["startId", "endId", "summary"],
-                    },
-                },
+              topic: { type: "string" },
+              startId: {
+                type: "string",
+                description: "mNNNNN ref at the start of the range",
+              },
+              endId: {
+                type: "string",
+                description: "mNNNNN ref at the end of the range",
+              },
+              summary: {
+                type: "string",
+                description: "Self-contained summary replacing the range",
+              },
             },
-            required: ["content"],
+            required: ["startId", "endId", "summary"],
+          },
         },
+      },
+      required: ["content"],
     },
+  },
 };
 
-export function buildCompressSystemPrompt(prompts: Prompts = defaultPrompts): string {
-    return `${prompts.compressPhilosophy}
+export function buildCompressSystemPrompt(
+  prompts: Prompts = defaultPrompts,
+): string {
+  return `${prompts.compressPhilosophy}
 
 ${prompts.howToCompressRules}
 
@@ -180,8 +220,10 @@ When you see past compress tool calls in the conversation, their summary paramet
  *  the trigger tags in its text output instead of calling a function tool.
  *  Only compress is available via this protocol (decompress/search/status
  *  require real tools). */
-export function buildCompressTextSystemPrompt(prompts: Prompts = defaultPrompts): string {
-    return `${prompts.compressPhilosophy}
+export function buildCompressTextSystemPrompt(
+  prompts: Prompts = defaultPrompts,
+): string {
+  return `${prompts.compressPhilosophy}
 
 ${prompts.howToCompressRules}
 
@@ -230,8 +272,10 @@ Rules for ALL triggers:
  *  acp_status are real function tools the model calls directly. The compress
  *  loop already merges text triggers and function tool_calls, so both paths
  *  coexist in one turn. */
-export function buildCompressHybridSystemPrompt(prompts: Prompts = defaultPrompts): string {
-    return `${prompts.compressPhilosophy}
+export function buildCompressHybridSystemPrompt(
+  prompts: Prompts = defaultPrompts,
+): string {
+  return `${prompts.compressPhilosophy}
 
 ${prompts.howToCompressRules}
 
@@ -264,58 +308,67 @@ Note: compress is ONLY available via the text marker above (it needs batch range
 }
 
 export const DECOMPRESS_TOOL_OPENAI = {
-    type: "function" as const,
-    function: {
-        name: DECOMPRESS_TOOL_NAME,
-        description:
-            "Restores previously compressed content. Use when you need exact details lost in compression. By default restores one tier up. Use full:true for all the way to original messages. Use toFile to write to file instead of inflating context.",
-        parameters: {
-            type: "object",
-            properties: {
-                blockId: { type: "string", description: "Block ID to decompress (e.g. b5)" },
-                toFile: { type: "string", description: "Optional: write content to file instead of context" },
-                full: { type: "boolean", description: "Restore all the way to original messages" },
-            },
-            required: ["blockId"],
+  type: "function" as const,
+  function: {
+    name: DECOMPRESS_TOOL_NAME,
+    description:
+      "Restores previously compressed content. Use when you need exact details lost in compression. By default restores one tier up. Use full:true for all the way to original messages. Use toFile to write to file instead of inflating context.",
+    parameters: {
+      type: "object",
+      properties: {
+        blockId: {
+          type: "string",
+          description: "Block ID to decompress (e.g. b5)",
         },
+        toFile: {
+          type: "string",
+          description: "Optional: write content to file instead of context",
+        },
+        full: {
+          type: "boolean",
+          description: "Restore all the way to original messages",
+        },
+      },
+      required: ["blockId"],
     },
+  },
 };
 
 export const SEARCH_CONTEXT_TOOL_OPENAI = {
-    type: "function" as const,
-    function: {
-        name: SEARCH_CONTEXT_TOOL_NAME,
-        description:
-            "Search through compressed block summaries by keyword. Use BEFORE decompressing to find the right block.",
-        parameters: {
-            type: "object",
-            properties: {
-                query: { type: "string", description: "Search query" },
-                limit: { type: "number", description: "Max results (default 5)" },
-            },
-            required: ["query"],
-        },
+  type: "function" as const,
+  function: {
+    name: SEARCH_CONTEXT_TOOL_NAME,
+    description:
+      "Search through compressed block summaries by keyword. Use BEFORE decompressing to find the right block.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+        limit: { type: "number", description: "Max results (default 5)" },
+      },
+      required: ["query"],
     },
+  },
 };
 
 export const ACP_STATUS_TOOL_OPENAI = {
-    type: "function" as const,
-    function: {
-        name: ACP_STATUS_TOOL_NAME,
-        description:
-            "Show context usage and compressible ranges. No args = overview. Use to find what to compress next.",
-        parameters: {
-            type: "object",
-            properties: {},
-        },
+  type: "function" as const,
+  function: {
+    name: ACP_STATUS_TOOL_NAME,
+    description:
+      "Show context usage and compressible ranges. No args = overview. Use to find what to compress next.",
+    parameters: {
+      type: "object",
+      properties: {},
     },
+  },
 };
 
 export const ACP_TOOLS_OPENAI = [
-    COMPRESS_TOOL_OPENAI,
-    DECOMPRESS_TOOL_OPENAI,
-    SEARCH_CONTEXT_TOOL_OPENAI,
-    ACP_STATUS_TOOL_OPENAI,
+  COMPRESS_TOOL_OPENAI,
+  DECOMPRESS_TOOL_OPENAI,
+  SEARCH_CONTEXT_TOOL_OPENAI,
+  ACP_STATUS_TOOL_OPENAI,
 ] as const;
 
 /** Anthropic-format tools (name + description + input_schema). The Anthropic
@@ -324,65 +377,65 @@ export const ACP_TOOLS_OPENAI = [
  *  prompt describes all four, so declaring only COMPRESS_TOOL left the model
  *  able to see the docs but unable to call the rest. */
 export const DECOMPRESS_TOOL = {
-    name: DECOMPRESS_TOOL_NAME,
-    description: DECOMPRESS_TOOL_OPENAI.function.description,
-    input_schema: DECOMPRESS_TOOL_OPENAI.function.parameters,
+  name: DECOMPRESS_TOOL_NAME,
+  description: DECOMPRESS_TOOL_OPENAI.function.description,
+  input_schema: DECOMPRESS_TOOL_OPENAI.function.parameters,
 };
 
 export const SEARCH_CONTEXT_TOOL = {
-    name: SEARCH_CONTEXT_TOOL_NAME,
-    description: SEARCH_CONTEXT_TOOL_OPENAI.function.description,
-    input_schema: SEARCH_CONTEXT_TOOL_OPENAI.function.parameters,
+  name: SEARCH_CONTEXT_TOOL_NAME,
+  description: SEARCH_CONTEXT_TOOL_OPENAI.function.description,
+  input_schema: SEARCH_CONTEXT_TOOL_OPENAI.function.parameters,
 };
 
 export const ACP_STATUS_TOOL = {
-    name: ACP_STATUS_TOOL_NAME,
-    description: ACP_STATUS_TOOL_OPENAI.function.description,
-    input_schema: ACP_STATUS_TOOL_OPENAI.function.parameters,
+  name: ACP_STATUS_TOOL_NAME,
+  description: ACP_STATUS_TOOL_OPENAI.function.description,
+  input_schema: ACP_STATUS_TOOL_OPENAI.function.parameters,
 };
 
 export const ACP_TOOLS_ANTHROPIC = [
-    COMPRESS_TOOL,
-    DECOMPRESS_TOOL,
-    SEARCH_CONTEXT_TOOL,
-    ACP_STATUS_TOOL,
+  COMPRESS_TOOL,
+  DECOMPRESS_TOOL,
+  SEARCH_CONTEXT_TOOL,
+  ACP_STATUS_TOOL,
 ] as const;
 
 // Responses API flat format (defined after the OpenAI chat constants).
 export const COMPRESS_TOOL_RESPONSES = {
-    type: "function" as const,
-    name: COMPRESS_TOOL_NAME,
-    description: COMPRESS_TOOL.description,
-    parameters: COMPRESS_TOOL_OPENAI.function.parameters,
+  type: "function" as const,
+  name: COMPRESS_TOOL_NAME,
+  description: COMPRESS_TOOL.description,
+  parameters: COMPRESS_TOOL_OPENAI.function.parameters,
 };
 
 export const DECOMPRESS_TOOL_RESPONSES = {
-    type: "function" as const,
-    name: DECOMPRESS_TOOL_OPENAI.function.name,
-    description: DECOMPRESS_TOOL_OPENAI.function.description,
-    parameters: DECOMPRESS_TOOL_OPENAI.function.parameters,
+  type: "function" as const,
+  name: DECOMPRESS_TOOL_OPENAI.function.name,
+  description: DECOMPRESS_TOOL_OPENAI.function.description,
+  parameters: DECOMPRESS_TOOL_OPENAI.function.parameters,
 };
 
 export const SEARCH_CONTEXT_TOOL_RESPONSES = {
-    type: "function" as const,
-    name: SEARCH_CONTEXT_TOOL_OPENAI.function.name,
-    description: SEARCH_CONTEXT_TOOL_OPENAI.function.description,
-    parameters: SEARCH_CONTEXT_TOOL_OPENAI.function.parameters,
+  type: "function" as const,
+  name: SEARCH_CONTEXT_TOOL_OPENAI.function.name,
+  description: SEARCH_CONTEXT_TOOL_OPENAI.function.description,
+  parameters: SEARCH_CONTEXT_TOOL_OPENAI.function.parameters,
 };
 
 export const ACP_STATUS_TOOL_RESPONSES = {
-    type: "function" as const,
-    name: ACP_STATUS_TOOL_OPENAI.function.name,
-    description: ACP_STATUS_TOOL_OPENAI.function.description,
-    parameters: ACP_STATUS_TOOL_OPENAI.function.parameters,
+  type: "function" as const,
+  name: ACP_STATUS_TOOL_OPENAI.function.name,
+  description: ACP_STATUS_TOOL_OPENAI.function.description,
+  parameters: ACP_STATUS_TOOL_OPENAI.function.parameters,
 };
 
 /** All ACP tools in Responses API flat format, matching ACP_TOOL_NAMES. */
 export const ACP_TOOLS_RESPONSES = [
-    COMPRESS_TOOL_RESPONSES,
-    DECOMPRESS_TOOL_RESPONSES,
-    SEARCH_CONTEXT_TOOL_RESPONSES,
-    ACP_STATUS_TOOL_RESPONSES,
+  COMPRESS_TOOL_RESPONSES,
+  DECOMPRESS_TOOL_RESPONSES,
+  SEARCH_CONTEXT_TOOL_RESPONSES,
+  ACP_STATUS_TOOL_RESPONSES,
 ] as const;
 
 /** Read-only ACP tools (no compress) in Responses flat format. Used for the
@@ -392,29 +445,68 @@ export const ACP_TOOLS_RESPONSES = [
  *  Empirically (direct comfly A/B) declaring these tools does NOT disable
  *  codex code_mode — the earlier "tools can't coexist" assumption was wrong. */
 export const ACP_READONLY_TOOLS_RESPONSES = [
-    DECOMPRESS_TOOL_RESPONSES,
-    SEARCH_CONTEXT_TOOL_RESPONSES,
-    ACP_STATUS_TOOL_RESPONSES,
+  DECOMPRESS_TOOL_RESPONSES,
+  SEARCH_CONTEXT_TOOL_RESPONSES,
+  ACP_STATUS_TOOL_RESPONSES,
 ] as const;
 
-/** All ACP tool names (dynamic membership — Set, not a static record). */
+/** All ACP tool names (dynamic membership — Set, not a static record). Does
+ *  NOT include absorb: it is opt-in (config.absorb.enabled) and hosts only
+ *  register/inject it when the feature is on. */
 export const ACP_TOOL_NAMES: ReadonlySet<string> = new Set([
-    COMPRESS_TOOL_NAME,
-    DECOMPRESS_TOOL_NAME,
-    SEARCH_CONTEXT_TOOL_NAME,
-    ACP_STATUS_TOOL_NAME,
+  COMPRESS_TOOL_NAME,
+  DECOMPRESS_TOOL_NAME,
+  SEARCH_CONTEXT_TOOL_NAME,
+  ACP_STATUS_TOOL_NAME,
 ]);
 
 /** compress/decompress: mutate history → must drive the compress loop (their
  *  result is folded into the request before the model continues). */
 export const ACP_MUTATING_TOOLS: ReadonlySet<string> = new Set([
-    COMPRESS_TOOL_NAME,
-    DECOMPRESS_TOOL_NAME,
+  COMPRESS_TOOL_NAME,
+  DECOMPRESS_TOOL_NAME,
 ]);
 
 /** acp_status/search_context: read-only → must NOT loop. Looping them made the
  *  model re-call until the 5× limit and discarded the whole turn. */
 export const ACP_READONLY_TOOLS: ReadonlySet<string> = new Set([
-    SEARCH_CONTEXT_TOOL_NAME,
-    ACP_STATUS_TOOL_NAME,
+  SEARCH_CONTEXT_TOOL_NAME,
+  ACP_STATUS_TOOL_NAME,
 ]);
+
+/** Opt-in absorb tool (instant tool-result absorption). Inject/register only
+ *  when config.absorb.enabled — NOT part of ACP_TOOLS_* arrays. */
+export const ABSORB_TOOL_DESCRIPTION =
+  "Distill a tool result into a compact summary you write. REQUIRED immediately after a tool result ends with an [ACP absorb] instruction: pass its ref and the distilled essentials (outcome, key values, paths:lines, errors, decisions). The original output is then removed from context; your summary is the durable record.";
+
+const ABSORB_PARAMETERS = {
+  type: "object" as const,
+  properties: {
+    ref: {
+      type: "string",
+      description:
+        "mNNNNN ref of the tool result to absorb (from the [ACP absorb] instruction)",
+    },
+    summary: {
+      type: "string",
+      description:
+        "Distilled essentials of the tool result — this replaces the original output in context",
+    },
+  },
+  required: ["ref", "summary"],
+};
+
+export const ABSORB_TOOL = {
+  name: ABSORB_TOOL_NAME,
+  description: ABSORB_TOOL_DESCRIPTION,
+  input_schema: ABSORB_PARAMETERS,
+};
+
+export const ABSORB_TOOL_OPENAI = {
+  type: "function" as const,
+  function: {
+    name: ABSORB_TOOL_NAME,
+    description: ABSORB_TOOL_DESCRIPTION,
+    parameters: ABSORB_PARAMETERS,
+  },
+};

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -13,6 +13,7 @@ import {
 import type { ResolvedRange } from "./boundaries.js";
 import { truncateLargeToolOutputs } from "./truncate-tools.js";
 import { hideConsumedCompressCalls } from "./hide-consumed.js";
+import { appendAbsorbPrompts, hideAbsorbedMessages } from "./absorb.js";
 import { applyMessageFilters, listMessageFilters } from "./filter/index.js";
 import { createRenderRefsNode } from "./render-refs.js";
 import type { RenderStrategy } from "./render-refs.js";
@@ -424,6 +425,8 @@ export function createCore(ports: Ports = {}): CompressionCore {
       assignRefsNode,
       syncBlocksNode,
       pruneNode,
+      absorbHideNode,
+      absorbPromptNode,
       filterNode,
       hideCompressCallsNode,
       recommendNode,
@@ -480,6 +483,33 @@ const pruneNode: PipelineNode = {
   name: "prune",
   run(io) {
     return { ...io, messages: prune(io.messages, io.state) };
+  },
+};
+
+const absorbHideNode: PipelineNode = {
+  name: "absorb-hide",
+  enabled: (io) => (io.state.absorbed?.length ?? 0) > 0,
+  run(io) {
+    return { ...io, messages: hideAbsorbedMessages(io.messages, io.state) };
+  },
+};
+
+const absorbPromptNode: PipelineNode = {
+  name: "absorb-prompt",
+  enabled: (_io, ctx) => ctx.config.absorb?.enabled === true,
+  run(io, ctx) {
+    const applied = appendAbsorbPrompts(
+      io.messages,
+      io.state,
+      ctx.config,
+      ctx.tokenCount,
+      ctx.countTokens,
+    );
+    return {
+      ...io,
+      messages: applied.messages,
+      effects: { ...io.effects, absorbPromptedCount: applied.promptedCount },
+    };
   },
 };
 
@@ -1283,6 +1313,7 @@ function cloneState(state: CompressionState): CompressionState {
     tokenSnapshot: { ...(state.tokenSnapshot ?? {}) },
     nudge: { ...state.nudge, anchors: { ...state.nudge.anchors } },
     stats: { ...state.stats },
+    absorbed: (state.absorbed ?? []).map((record) => ({ ...record })),
     nextBlockId: state.nextBlockId,
     nextRunId: state.nextRunId,
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,13 @@ export function defaultConfig(
     preserveRecentMessages: 5,
     preserveRecentTokens: 5000,
     modelContextLimit,
+    absorb: {
+      enabled: false,
+      toolName: "absorb",
+      minToolTokens: 1000,
+      contextThresholdPct: 0,
+      excludeTools: [],
+    },
   };
   return {
     ...base,
@@ -39,6 +46,9 @@ export function defaultConfig(
     nudge: { ...base.nudge, ...overrides.nudge },
     truncate: { ...base.truncate, ...overrides.truncate },
     compress: { ...base.compress, ...overrides.compress },
+    absorb: overrides.absorb
+      ? { ...base.absorb, ...overrides.absorb }
+      : base.absorb,
   };
 }
 
@@ -71,6 +81,23 @@ export function validateConfig(config: Config): string[] {
   }
   if (config.tiers.tier3Trigger <= config.tiers.tier2Trigger) {
     errors.push("tiers.tier3Trigger must be greater than tiers.tier2Trigger");
+  }
+  if (config.absorb) {
+    if (config.absorb.enabled && !config.absorb.toolName) {
+      errors.push("absorb.toolName must be a non-empty string when enabled");
+    }
+    if (
+      !Number.isFinite(config.absorb.minToolTokens) ||
+      config.absorb.minToolTokens < 0
+    ) {
+      errors.push("absorb.minToolTokens must be >= 0");
+    }
+    if (
+      config.absorb.contextThresholdPct < 0 ||
+      config.absorb.contextThresholdPct > 1
+    ) {
+      errors.push("absorb.contextThresholdPct must be in [0, 1]");
+    }
   }
   return errors;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,29 @@ export { buildStatusReport, buildRecap } from "./report.js";
 export type { StatusReportOptions } from "./report.js";
 export { hideConsumedCompressCalls } from "./hide-consumed.js";
 export type { HideConsumedResult } from "./hide-consumed.js";
+export {
+  ABSORB_TOOL_NAME,
+  ABSORB_TOOL,
+  ABSORB_TOOL_OPENAI,
+} from "./compress-tools.js";
+export {
+  ABSORB_PROMPT_MARKER,
+  DEFAULT_ABSORB_CONFIG,
+  resolveAbsorbConfig,
+  buildAbsorbPrompt,
+  buildAbsorbSystemPrompt,
+  isAbsorbCandidate,
+  hideAbsorbedMessages,
+  appendAbsorbPrompts,
+  parseAbsorbInput,
+  applyAbsorb,
+} from "./absorb.js";
+export type {
+  AbsorbInput,
+  AbsorbOutcome,
+  ParsedAbsorb,
+  AppendAbsorbPromptsResult,
+} from "./absorb.js";
 export { rebuildCompressionState } from "./rebuild.js";
 export type { RebuildResult, RebuildPorts } from "./rebuild.js";
 export {

--- a/src/persist/state-merge.ts
+++ b/src/persist/state-merge.ts
@@ -19,5 +19,6 @@ export function mergeCompressionState(parsed: CompressionState): CompressionStat
     nextBlockId: parsed.nextBlockId ?? fresh.nextBlockId,
     nextRunId: parsed.nextRunId ?? fresh.nextRunId,
     tokenSnapshot: parsed.tokenSnapshot ?? fresh.tokenSnapshot,
+    absorbed: parsed.absorbed ?? fresh.absorbed,
   };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,7 +12,8 @@ export function createInitialState(): CompressionState {
       anchors: {},
       lastShownByTier: {},
     },
-    stats: { tokensCompressed: 0, compressionCount: 0 },
+    stats: { tokensCompressed: 0, compressionCount: 0, absorbedTokens: 0 },
+    absorbed: [],
     nextBlockId: 1,
     nextRunId: 1,
   };

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -31,6 +31,7 @@ export function syncBlocks(
     tokenSnapshot: { ...(state.tokenSnapshot ?? {}) },
     nudge: { ...state.nudge, anchors: { ...state.nudge.anchors } },
     stats: { ...state.stats },
+    absorbed: (state.absorbed ?? []).map((record) => ({ ...record })),
     nextBlockId: state.nextBlockId,
     nextRunId: state.nextRunId,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,33 @@ export interface NudgeState {
 export interface CompressionStats {
   tokensCompressed: number;
   compressionCount: number;
+  /** Cumulative tokens reclaimed by absorb (instant tool-result hiding). Optional for pre-absorb persisted states. */
+  absorbedTokens?: number;
+}
+
+/** One instant tool-result absorption: the original tool-call + tool-result
+ *  pair is hidden from view once recorded; the model's absorb call (carrying
+ *  the distilled summary) remains as the durable record. */
+export interface AbsorbRecord {
+  toolCallId: string;
+  callMessageId: string;
+  resultMessageId: string;
+  absorbCallId?: string;
+  summary: string;
+  tokensReclaimed: number;
+  createdAt: number;
+}
+
+export interface AbsorbConfig {
+  enabled: boolean;
+  /** Model-facing absorb tool name (adapters may rename, e.g. acp_absorb). */
+  toolName: string;
+  /** Only tool results >= this many tokens get the forced absorb prompt. 0 = all. */
+  minToolTokens: number;
+  /** Only prompt when context usage >= this fraction of modelContextLimit. 0 = size gate alone. */
+  contextThresholdPct: number;
+  /** Tool-name patterns (glob suffix allowed) never absorbable, independent of protectedTools. */
+  excludeTools: string[];
 }
 
 export interface CompressionState {
@@ -71,6 +98,8 @@ export interface CompressionState {
   tokenSnapshot: Record<string, number>;
   nudge: NudgeState;
   stats: CompressionStats;
+  /** Instant tool-result absorption records. Optional: pre-absorb persisted states lack it. */
+  absorbed?: AbsorbRecord[];
   nextBlockId: number;
   nextRunId: number;
 }
@@ -134,6 +163,8 @@ export interface Config {
   preserveRecentMessages: number;
   preserveRecentTokens: number;
   modelContextLimit: number;
+  /** Instant tool-result absorption (see absorb.ts). Absent/disabled = feature off. */
+  absorb?: AbsorbConfig;
   messageFilters?: import("./filter/types.js").MessageFiltersConfig;
 }
 

--- a/tests/absorb.test.ts
+++ b/tests/absorb.test.ts
@@ -1,0 +1,481 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyAbsorb,
+  appendAbsorbPrompts,
+  buildAbsorbPrompt,
+  buildAbsorbSystemPrompt,
+  hideAbsorbedMessages,
+  isAbsorbCandidate,
+  parseAbsorbInput,
+  ABSORB_PROMPT_MARKER,
+} from "../src/absorb.js";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { defaultConfig, validateConfig } from "../src/config.js";
+import { assignRefs, refForRaw } from "../src/refs.js";
+import { isRenderedSummaryMessage } from "../src/prune.js";
+import type { CompressionState, Config, CoreMessage } from "../src/types.js";
+
+const countTokens = (text: string) => Math.ceil(text.length / 4);
+
+function bigResult(id: string, callId: string, toolName = "read"): CoreMessage {
+  return {
+    id,
+    role: "tool",
+    contentType: "tool-result",
+    toolName,
+    toolCallId: callId,
+    text: "x".repeat(4800),
+  };
+}
+
+function smallResult(
+  id: string,
+  callId: string,
+  toolName = "read",
+): CoreMessage {
+  return {
+    id,
+    role: "tool",
+    contentType: "tool-result",
+    toolName,
+    toolCallId: callId,
+    text: "ok",
+  };
+}
+
+function toolCall(id: string, callId: string, toolName = "read"): CoreMessage {
+  return {
+    id,
+    role: "assistant",
+    contentType: "tool-call",
+    toolName,
+    toolCallId: callId,
+    text: `args-${callId}`,
+  };
+}
+
+function session(): CoreMessage[] {
+  return [
+    { id: "u1", role: "user", contentType: "text", text: "run the build" },
+    toolCall("c1", "call1"),
+    bigResult("r1", "call1"),
+    toolCall("c2", "call2", "bash"),
+    smallResult("r2", "call2", "bash"),
+  ];
+}
+
+function absorbConfig(
+  overrides: Partial<Config["absorb"]> = {},
+): Config["absorb"] {
+  return {
+    enabled: true,
+    toolName: "absorb",
+    minToolTokens: 1000,
+    contextThresholdPct: 0,
+    excludeTools: [],
+    ...overrides,
+  };
+}
+
+function stateWithRefs(messages: CoreMessage[]): CompressionState {
+  const state = createInitialState();
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+test("appendAbsorbPrompts: disabled config is a no-op", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000);
+  const result = appendAbsorbPrompts(
+    messages,
+    state,
+    config,
+    5000,
+    countTokens,
+  );
+  assert.equal(result.promptedCount, 0);
+  assert.equal(result.messages, messages);
+});
+
+test("appendAbsorbPrompts: appends prompt to large un-absorbed tool result, citing its ref", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const result = appendAbsorbPrompts(
+    messages,
+    state,
+    config,
+    5000,
+    countTokens,
+  );
+  assert.equal(result.promptedCount, 1);
+  const r1 = result.messages.find((m) => m.id === "r1")!;
+  assert.ok(r1.text!.includes(ABSORB_PROMPT_MARKER));
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  assert.ok(r1.text!.includes(`ref: "${ref}"`));
+  assert.ok(r1.text!.startsWith("x".repeat(10)));
+  const r2 = result.messages.find((m) => m.id === "r2")!;
+  assert.ok(!r2.text!.includes(ABSORB_PROMPT_MARKER));
+});
+
+test("appendAbsorbPrompts: skips ACP tools, protected tools, and excluded tools", () => {
+  const messages: CoreMessage[] = [
+    toolCall("c1", "call1", "read"),
+    bigResult("r1", "call1", "read"),
+    toolCall("c2", "call2", "search_context"),
+    bigResult("r2", "call2", "search_context"),
+    toolCall("c3", "call3", "grep"),
+    bigResult("r3", "call3", "grep"),
+    toolCall("c4", "call4", "absorb"),
+    bigResult("r4", "call4", "absorb"),
+  ];
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, {
+    absorb: absorbConfig({ excludeTools: ["gr*"] }),
+    protectedTools: ["read"],
+  });
+  const result = appendAbsorbPrompts(
+    messages,
+    state,
+    config,
+    5000,
+    countTokens,
+  );
+  assert.equal(result.promptedCount, 0);
+  assert.ok(!isAbsorbCandidate(messages[1]!, config));
+  assert.ok(!isAbsorbCandidate(messages[3]!, config));
+  assert.ok(!isAbsorbCandidate(messages[5]!, config));
+  assert.ok(!isAbsorbCandidate(messages[7]!, config));
+});
+
+test("appendAbsorbPrompts: respects the context-usage gate", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(10000, {
+    absorb: absorbConfig({ contextThresholdPct: 0.5 }),
+  });
+  const below = appendAbsorbPrompts(messages, state, config, 4000, countTokens);
+  assert.equal(below.promptedCount, 0);
+  const at = appendAbsorbPrompts(messages, state, config, 5000, countTokens);
+  assert.equal(at.promptedCount, 1);
+});
+
+test("appendAbsorbPrompts: never double-appends (idempotent marker check)", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const once = appendAbsorbPrompts(messages, state, config, 5000, countTokens);
+  const twice = appendAbsorbPrompts(
+    once.messages,
+    state,
+    config,
+    5000,
+    countTokens,
+  );
+  assert.equal(twice.promptedCount, 0);
+  const r1 = twice.messages.find((m) => m.id === "r1")!;
+  assert.equal(r1.text!.split(ABSORB_PROMPT_MARKER).length - 1, 1);
+});
+
+test("applyAbsorb: happy path records the pair and updates stats", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  const outcome = applyAbsorb({
+    ref,
+    summary: "build ok, 45 tests",
+    absorbCallId: "abs-call-1",
+    messages,
+    state,
+    config,
+  });
+  assert.ok(outcome.ok, outcome.resultText);
+  assert.equal(outcome.state.absorbed!.length, 1);
+  const record = outcome.state.absorbed![0]!;
+  assert.equal(record.toolCallId, "call1");
+  assert.equal(record.callMessageId, "c1");
+  assert.equal(record.resultMessageId, "r1");
+  assert.equal(record.absorbCallId, "abs-call-1");
+  assert.ok(record.tokensReclaimed >= 1000);
+  assert.equal(outcome.state.stats.absorbedTokens, record.tokensReclaimed);
+});
+
+test("applyAbsorb: rejects empty summary, unknown ref, non-tool-result, ACP tool, protected tool", () => {
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "hi" },
+    toolCall("c1", "call1", "read"),
+    bigResult("r1", "call1", "read"),
+    toolCall("c2", "call2", "search_context"),
+    bigResult("r2", "call2", "search_context"),
+    toolCall("c3", "call3", "todo"),
+    bigResult("r3", "call3", "todo"),
+  ];
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, {
+    absorb: absorbConfig(),
+    protectedTools: ["todo"],
+  });
+  const refUser = refForRaw(state.messageRefs, "u1")!;
+  const refAcp = refForRaw(state.messageRefs, "r2")!;
+  const refProtected = refForRaw(state.messageRefs, "r3")!;
+
+  const empty = applyAbsorb({
+    ref: refUser,
+    summary: "  ",
+    messages,
+    state,
+    config,
+  });
+  assert.equal(empty.ok, false);
+
+  const unknown = applyAbsorb({
+    ref: "m99999",
+    summary: "s",
+    messages,
+    state,
+    config,
+  });
+  assert.equal(unknown.ok, false);
+  assert.ok(unknown.resultText.includes("does not exist"));
+
+  const notToolResult = applyAbsorb({
+    ref: refUser,
+    summary: "s",
+    messages,
+    state,
+    config,
+  });
+  assert.equal(notToolResult.ok, false);
+  assert.ok(notToolResult.resultText.includes("not a tool result"));
+
+  const acp = applyAbsorb({
+    ref: refAcp,
+    summary: "s",
+    messages,
+    state,
+    config,
+  });
+  assert.equal(acp.ok, false);
+  assert.ok(acp.resultText.includes("ACP-managed"));
+
+  const protectedTool = applyAbsorb({
+    ref: refProtected,
+    summary: "s",
+    messages,
+    state,
+    config,
+  });
+  assert.equal(protectedTool.ok, false);
+  assert.ok(protectedTool.resultText.includes("protected"));
+});
+
+test("applyAbsorb: second absorb of the same target is idempotent", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  const first = applyAbsorb({ ref, summary: "s1", messages, state, config });
+  assert.ok(first.ok);
+  const second = applyAbsorb({
+    ref,
+    summary: "s2",
+    messages,
+    state: first.state,
+    config,
+  });
+  assert.ok(second.ok);
+  assert.ok(second.resultText.includes("already absorbed"));
+  assert.equal(second.state.absorbed!.length, 1);
+  assert.equal(
+    second.state.stats.absorbedTokens,
+    first.state.stats.absorbedTokens,
+  );
+});
+
+test("applyAbsorb: warns when the summary is not smaller than the original", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  const outcome = applyAbsorb({
+    ref,
+    summary: "y".repeat(messages[2]!.text!.length),
+    messages,
+    state,
+    config,
+  });
+  assert.ok(outcome.ok);
+  assert.ok(outcome.resultText.includes("distill harder"));
+});
+
+test("hideAbsorbedMessages: drops both halves of the recorded pair only", () => {
+  const messages = session();
+  const state = stateWithRefs(messages);
+  const config = defaultConfig(200000, { absorb: absorbConfig() });
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  const absorbed = applyAbsorb({
+    ref,
+    summary: "s",
+    messages,
+    state,
+    config,
+  }).state;
+  const visible = hideAbsorbedMessages(messages, absorbed);
+  assert.deepEqual(
+    visible.map((m) => m.id),
+    ["u1", "c2", "r2"],
+  );
+});
+
+test("full processTurn: prompt appears, then pair is hidden after absorb while the absorb call survives", () => {
+  const core = createCore({ countTokens });
+  const config = defaultConfig(10000, { absorb: absorbConfig() });
+  let state = createInitialState();
+  let messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "read the file" },
+    toolCall("c1", "call1", "read"),
+    bigResult("r1", "call1", "read"),
+  ];
+
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 3000 });
+  state = turn1.state;
+  const prompted = turn1.messages.find((m) => m.id === "r1")!;
+  assert.ok(prompted.text!.includes(ABSORB_PROMPT_MARKER));
+  const ref = refForRaw(state.messageRefs, "r1")!;
+
+  messages = [
+    ...messages,
+    toolCall("c2", "call2", "absorb"),
+    {
+      id: "r2",
+      role: "tool",
+      contentType: "tool-result",
+      toolName: "absorb",
+      toolCallId: "call2",
+      text: "absorbed m00003",
+    },
+  ];
+  const outcome = applyAbsorb({
+    ref,
+    summary: "file defines foo(a,b) at src/foo.ts:12",
+    absorbCallId: "call2",
+    messages,
+    state,
+    config,
+  });
+  assert.ok(outcome.ok);
+  state = outcome.state;
+
+  const turn2 = core.processTurn({ messages, state, config, tokenCount: 3200 });
+  const ids = turn2.messages.map((m) => m.id);
+  assert.ok(!ids.includes("c1"), "original tool-call hidden");
+  assert.ok(!ids.includes("r1"), "original tool-result hidden");
+  assert.ok(ids.includes("c2"), "absorb call kept");
+  assert.ok(ids.includes("r2"), "absorb result kept");
+  assert.ok(
+    !turn2.messages
+      .find((m) => m.id === "r2")!
+      .text!.includes(ABSORB_PROMPT_MARKER),
+  );
+  for (const m of turn2.messages) {
+    if (m.contentType === "tool-result" && m.toolName !== "absorb") {
+      assert.ok(!m.text!.includes(ABSORB_PROMPT_MARKER), "no prompts remain");
+    }
+  }
+  assert.equal(turn2.messages.filter(isRenderedSummaryMessage).length, 0);
+});
+
+test("absorbed records survive applyCompression cloning", () => {
+  const core = createCore({ countTokens });
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "go" },
+    toolCall("c1", "call1", "read"),
+    bigResult("r1", "call1", "read"),
+    { id: "u2", role: "user", contentType: "text", text: "done" },
+  ];
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config: defaultConfig(200000),
+    tokenCount: 100,
+  }).state;
+  const config = defaultConfig(200000, {
+    compress: {
+      minCompressRange: 0,
+      maxSummaryLength: 20000,
+      minSummaryLength: 0,
+    },
+  });
+  const ref = refForRaw(state.messageRefs, "r1")!;
+  state = applyAbsorb({ ref, summary: "s", messages, state, config }).state;
+  const applied = core.applyCompression({
+    ranges: [
+      { startRef: "m00001", endRef: "m00002", summary: "sum of the range" },
+    ],
+    messages,
+    state,
+    config,
+  });
+  assert.equal(applied.result.blocksCreated, 1);
+  assert.equal(applied.state.absorbed!.length, 1);
+  assert.equal(applied.state.stats.absorbedTokens, state.stats.absorbedTokens);
+});
+
+test("parseAbsorbInput: object, aliases, JSON string, and rejects malformed", () => {
+  const warns: string[] = [];
+  const plain = parseAbsorbInput(
+    { ref: "m00003", summary: "s" },
+    "call9",
+    (w) => warns.push(w),
+  );
+  assert.deepEqual(plain, {
+    ref: "m00003",
+    summary: "s",
+    absorbCallId: "call9",
+  });
+
+  const aliased = parseAbsorbInput({ of: "m00004", content: "s2" });
+  assert.deepEqual(aliased, { ref: "m00004", summary: "s2" });
+
+  const jsonString = parseAbsorbInput('{"messageId":"m00005","summary":"s3"}');
+  assert.deepEqual(jsonString, { ref: "m00005", summary: "s3" });
+
+  assert.equal(parseAbsorbInput("not json"), null);
+  assert.equal(parseAbsorbInput({ ref: 1, summary: "s" }), null);
+  assert.equal(parseAbsorbInput(null), null);
+  assert.ok(
+    warns.length === 0 ||
+      warns.every((w) => w.startsWith("[acp-absorb-input]")),
+  );
+});
+
+test("buildAbsorbPrompt and buildAbsorbSystemPrompt carry the tool name and marker", () => {
+  const prompt = buildAbsorbPrompt("m00007", 1234, "acp_absorb");
+  assert.ok(prompt.includes(ABSORB_PROMPT_MARKER));
+  assert.ok(prompt.includes('ref: "m00007"'));
+  assert.ok(prompt.includes("acp_absorb"));
+  assert.ok(prompt.includes("~1.2K tokens"));
+  const system = buildAbsorbSystemPrompt("acp_absorb");
+  assert.ok(system.includes("acp_absorb"));
+  assert.ok(system.includes(ABSORB_PROMPT_MARKER));
+});
+
+test("absorb config validation reports range errors", () => {
+  const config = defaultConfig(200000, {
+    absorb: absorbConfig({ minToolTokens: -5, contextThresholdPct: 1.5 }),
+  });
+  const errors = validateConfig(config);
+  assert.ok(
+    errors.some((e) => e.includes("absorb.minToolTokens")),
+    "expected minToolTokens error",
+  );
+  assert.ok(errors.some((e) => e.includes("absorb.contextThresholdPct")));
+});

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -367,7 +367,7 @@ test("mergeCompressionState keeps parsed values over defaults", () => {
     };
     const merged = mergeCompressionState(parsed);
     assert.equal(merged.nextBlockId, 41);
-    assert.deepEqual(merged.stats, { tokensCompressed: 1234, compressionCount: 7 });
+    assert.deepEqual(merged.stats, { tokensCompressed: 1234, compressionCount: 7, absorbedTokens: 0 });
 });
 
 test("legacy hook adopts pre-envelope records on loadAll and loadSync", async () => {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -28,6 +28,8 @@ test("defaultNodes exposes the canonical ordered pipeline", () => {
     "assign-refs",
     "sync-blocks",
     "prune",
+    "absorb-hide",
+    "absorb-prompt",
     "filter",
     "hide-compress-calls",
     "recommend",
@@ -58,8 +60,14 @@ test("renderVisibleRefs derives tags from the ref map (single source of truth)",
   const messages = [msg("a", "alpha"), msg("b", "beta")];
   const state = stateWithRefs(messages);
   const rendered = renderVisibleRefs(messages, state);
-  assert.match(rendered[0]!.text!, /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/);
-  assert.match(rendered[1]!.text!, /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/);
+  assert.match(
+    rendered[0]!.text!,
+    /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/,
+  );
+  assert.match(
+    rendered[1]!.text!,
+    /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/,
+  );
 });
 
 test("renderVisibleRefs is idempotent: running twice yields the same result", () => {
@@ -67,7 +75,10 @@ test("renderVisibleRefs is idempotent: running twice yields the same result", ()
   const state = stateWithRefs(messages);
   const once = renderVisibleRefs(messages, state);
   const twice = renderVisibleRefs(once, state);
-  assert.deepEqual(twice.map((m) => m.text), once.map((m) => m.text));
+  assert.deepEqual(
+    twice.map((m) => m.text),
+    once.map((m) => m.text),
+  );
 });
 
 test("renderVisibleRefs preserves non-own ref-like content and re-derives the own tag", () => {
@@ -76,7 +87,10 @@ test("renderVisibleRefs preserves non-own ref-like content and re-derives the ow
   const messages = [msg("a", "[m00009] alpha")];
   const state = stateWithRefs(messages); // authoritative ref for "a" is m00001
   const rendered = renderVisibleRefs(messages, state);
-  assert.match(rendered[0]!.text!, /^<acp tokens="\d+" type="text">m00001<\/acp>\n\[m00009\] alpha$/);
+  assert.match(
+    rendered[0]!.text!,
+    /^<acp tokens="\d+" type="text">m00001<\/acp>\n\[m00009\] alpha$/,
+  );
 });
 
 test("renderVisibleRefs peels the message's own stale tag before re-deriving", () => {
@@ -85,7 +99,10 @@ test("renderVisibleRefs peels the message's own stale tag before re-deriving", (
   const messages = [msg("a", staleTag)];
   const state = stateWithRefs(messages); // own ref for "a" is m00001
   const rendered = renderVisibleRefs(messages, state);
-  assert.match(rendered[0]!.text!, /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/);
+  assert.match(
+    rendered[0]!.text!,
+    /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/,
+  );
 });
 
 test("renderVisibleRefs leaves messages without a ref (BLOCKED/unmapped) untagged", () => {
@@ -127,9 +144,28 @@ test("runPipeline threads messages, state, and effects through nodes in order", 
 test("runPipeline skips nodes whose enabled predicate returns false", () => {
   const seen: string[] = [];
   const nodes: PipelineNode[] = [
-    { name: "a", run: (io) => { seen.push("a"); return io; } },
-    { name: "b", enabled: () => false, run: (io) => { seen.push("b"); return io; } },
-    { name: "c", run: (io) => { seen.push("c"); return io; } },
+    {
+      name: "a",
+      run: (io) => {
+        seen.push("a");
+        return io;
+      },
+    },
+    {
+      name: "b",
+      enabled: () => false,
+      run: (io) => {
+        seen.push("b");
+        return io;
+      },
+    },
+    {
+      name: "c",
+      run: (io) => {
+        seen.push("c");
+        return io;
+      },
+    },
   ];
   runPipeline(nodes, makeIO([], createInitialState()), {
     config: defaultConfig(100000),
@@ -149,15 +185,28 @@ test("processTurn tags every mapped message with a derived ref (end-to-end)", ()
     config: defaultConfig(100000),
     tokenCount: 100,
   });
-  assert.match(result.messages[0]!.text!, /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/);
-  assert.match(result.messages[1]!.text!, /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/);
+  assert.match(
+    result.messages[0]!.text!,
+    /^<acp tokens="\d+" type="text">m00001<\/acp>\nalpha$/,
+  );
+  assert.match(
+    result.messages[1]!.text!,
+    /^<acp tokens="\d+" type="text">m00002<\/acp>\nbeta$/,
+  );
 });
 
-test("processTurn renderTags:\"all\" (default) injects tags into every message", () => {
+test('processTurn renderTags:"all" (default) injects tags into every message', () => {
   const core = createCore();
   const messages: CoreMessage[] = [
     { id: "u1", role: "user", contentType: "text", text: "run echo" },
-    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
+    {
+      id: "a1",
+      role: "assistant",
+      contentType: "tool-call",
+      toolName: "bash",
+      toolCallId: "tc1",
+      text: '{"command":"echo hello"}',
+    },
     { id: "a2", role: "assistant", contentType: "text", text: "Done." },
   ];
   const state = createInitialState();
@@ -172,16 +221,38 @@ test("processTurn renderTags:\"all\" (default) injects tags into every message",
   });
 
   assert.match(result.messages[0]!.text!, /m00001<\/acp>/, "user text tagged");
-  assert.match(result.messages[1]!.text!, /m00002<\/acp>/, "tool-call tagged (all strategy)");
-  assert.match(result.messages[2]!.text!, /m00003<\/acp>/, "assistant text tagged");
+  assert.match(
+    result.messages[1]!.text!,
+    /m00002<\/acp>/,
+    "tool-call tagged (all strategy)",
+  );
+  assert.match(
+    result.messages[2]!.text!,
+    /m00003<\/acp>/,
+    "assistant text tagged",
+  );
 });
 
-test("processTurn renderTags:\"text-only\" tags text but leaves tool messages pristine (proxy mode)", () => {
+test('processTurn renderTags:"text-only" tags text but leaves tool messages pristine (proxy mode)', () => {
   const core = createCore();
   const messages: CoreMessage[] = [
     { id: "u1", role: "user", contentType: "text", text: "run echo" },
-    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
-    { id: "t1", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc1", text: "hello" },
+    {
+      id: "a1",
+      role: "assistant",
+      contentType: "tool-call",
+      toolName: "bash",
+      toolCallId: "tc1",
+      text: '{"command":"echo hello"}',
+    },
+    {
+      id: "t1",
+      role: "tool",
+      contentType: "tool-result",
+      toolName: "bash",
+      toolCallId: "tc1",
+      text: "hello",
+    },
     { id: "a2", role: "assistant", contentType: "text", text: "Done." },
   ];
   const state = createInitialState();
@@ -197,11 +268,23 @@ test("processTurn renderTags:\"text-only\" tags text but leaves tool messages pr
 
   // Text messages get tags (LLM can reference them for compress ranges).
   assert.match(result.messages[0]!.text!, /m00001<\/acp>/, "user text tagged");
-  assert.match(result.messages[3]!.text!, /m00004<\/acp>/, "assistant text tagged");
+  assert.match(
+    result.messages[3]!.text!,
+    /m00004<\/acp>/,
+    "assistant text tagged",
+  );
 
   // Tool messages are pristine — structured content not polluted by a tag.
-  assert.equal(result.messages[1]!.text, '{"command":"echo hello"}', "tool-call args unmodified");
-  assert.equal(result.messages[2]!.text, "hello", "tool-result content unmodified");
+  assert.equal(
+    result.messages[1]!.text,
+    '{"command":"echo hello"}',
+    "tool-call args unmodified",
+  );
+  assert.equal(
+    result.messages[2]!.text,
+    "hello",
+    "tool-result content unmodified",
+  );
 
   // But refs ARE assigned — tool messages are in the map too.
   const refs = result.state.messageRefs;
@@ -211,11 +294,18 @@ test("processTurn renderTags:\"text-only\" tags text but leaves tool messages pr
   assert.equal(refs.byRaw["a2"], "m00004");
 });
 
-test("processTurn renderTags:\"none\" assigns refs but leaves all text untouched", () => {
+test('processTurn renderTags:"none" assigns refs but leaves all text untouched', () => {
   const core = createCore();
   const messages: CoreMessage[] = [
     { id: "u1", role: "user", contentType: "text", text: "run echo" },
-    { id: "a1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "tc1", text: '{"command":"echo hello"}' },
+    {
+      id: "a1",
+      role: "assistant",
+      contentType: "tool-call",
+      toolName: "bash",
+      toolCallId: "tc1",
+      text: '{"command":"echo hello"}',
+    },
     { id: "a2", role: "assistant", contentType: "text", text: "Done." },
   ];
   const state = createInitialState();


### PR DESCRIPTION
## What

Implements the kernel side of instant tool-result compression for small-context scenarios (billion-context-pi#14): after a large tool result, the model is forced to immediately distill it via a new `absorb` tool; the original tool-call+result pair is hidden from later turns and the absorb call (carrying the summary) becomes the durable record. Absorb calls remain ordinary, compressible content — orthogonal to the block compression system.

## API

- `applyAbsorb(input): AbsorbOutcome` — validates ref/summary, records `AbsorbRecord` in `state.absorbed`, updates `stats.absorbedTokens`. Idempotent (`already absorbed`), guards empty summary, non-tool-result refs, ACP/protected tools.
- `appendAbsorbPrompts(messages, state, config, tokenCount, countTokens)` — appends the forced `[ACP absorb]` prompt to eligible tool results (≥ `minToolTokens`, gated by `contextThresholdPct`, skips ACP/protected/excluded tools).
- `hideAbsorbedMessages(messages, state)` — drops absorbed pairs by message id.
- `parseAbsorbInput` (lenient arg parsing), `buildAbsorbSystemPrompt`, `ABSORB_TOOL`/`ABSORB_TOOL_OPENAI` definitions, `DEFAULT_ABSORB_CONFIG`.

## Wiring

- Config: `absorb: { enabled, toolName, minToolTokens=1000, contextThresholdPct=0, excludeTools }` (absent = off).
- Pipeline nodes: `absorb-hide` (after prune), `absorb-prompt` (before filter).
- State: `CompressionState.absorbed` copied in syncBlocks + state-merge (forward-compatible with old persisted states).

## Tests

15 new tests in `tests/absorb.test.ts`; full suite 494/494 pass, tsc clean.

Adapter side: ranxianglei/billion-context-pi branch `2026-08-23_absorb-tool` (its release will bump the kernel pin after this ships to npm, per AGENTS.md §5).