### PR TITLE
release v0.0.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.42",
+    "version": "0.0.43",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
> **Model**: qwen3.8-27b (vllm)

## What
Bump version 0.0.42 → 0.0.43 to publish PR #111 (parseCompressArgs — lenient compress-arg parsing with diagnostics).

## Contents
- #111: parseCompressArgs (lenient parser with salvage + diagnostics)
- #137: stale-ref error message fix

## After merge
CI auto-publishes v0.0.43 to npm. Then downstream repos can bump acp-kernel to 0.0.43.