### PR TITLE
feat(panel): prompt-cache hit-rate section (last + session avg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.40",
+    "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.40",
+            "version": "0.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.43",
+    "version": "0.0.44",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",

--- a/src/panel/cache.ts
+++ b/src/panel/cache.ts
@@ -1,0 +1,69 @@
+/** Cache hit-rate math for the /acp status panel.
+ *
+ *  Hosts feed per-request prompt-cache usage samples (from assistant
+ *  messages' provider-reported `usage`); the kernel derives the display
+ *  numbers. A request COUNTS only when the provider reported cache
+ *  activity for it (`cacheRead + cacheWrite > 0`): providers without
+ *  prompt-cache reporting (0/0 with plain `input`) must not drag the
+ *  average to a fabricated 0%. */
+
+export interface CacheUsageSample {
+  /** Non-cached conversation input tokens billed for the request. */
+  input: number;
+  /** Conversation tokens served from the prompt cache. */
+  cacheRead: number;
+  /** Conversation tokens written to the prompt cache (cache creation). */
+  cacheWrite: number;
+}
+
+export interface CacheHitSummary {
+  /** Session hit rate (0..1), weighted by billed prompt tokens.
+   *  Undefined when no request reported cache activity. */
+  session: number | undefined;
+  /** Hit rate (0..1) of the most recent request that reported cache
+   *  activity. Undefined when no request reported any. */
+  last: number | undefined;
+  /** Counted requests (provider reported cache activity). */
+  requests: number;
+  /** Cumulative tokens served from cache. */
+  cacheRead: number;
+  /** Cumulative billed prompt tokens (input + cacheRead + cacheWrite). */
+  billedPrompt: number;
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/** Aggregate per-request cache usage into panel display numbers. */
+export function cacheHitStats(usages: readonly CacheUsageSample[]): CacheHitSummary {
+  let cacheRead = 0;
+  let billedPrompt = 0;
+  let requests = 0;
+  let last: number | undefined;
+  for (const u of usages) {
+    const read = num(u?.cacheRead);
+    const write = num(u?.cacheWrite);
+    const input = num(u?.input);
+    // No cache signal on this request → excluded entirely (see header).
+    if (read + write <= 0) continue;
+    const total = read + write + input;
+    if (total <= 0) continue;
+    cacheRead += read;
+    billedPrompt += total;
+    requests += 1;
+    last = read / total;
+  }
+  return {
+    session: requests > 0 ? cacheRead / billedPrompt : undefined,
+    last,
+    requests,
+    cacheRead,
+    billedPrompt,
+  };
+}
+
+/** Format a 0..1 rate as a percentage with one decimal ("92.3%"). */
+export function formatHitRate(rate: number): string {
+  return `${(Math.max(0, Math.min(1, rate)) * 100).toFixed(1)}%`;
+}

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -2,3 +2,5 @@ export { topicFallback } from "./topic.js";
 export { formatCompactTokens } from "./format.js";
 export { buildStatusPanel } from "./panel.js";
 export type { StatusPanelInput } from "./panel.js";
+export { cacheHitStats, formatHitRate } from "./cache.js";
+export type { CacheUsageSample, CacheHitSummary } from "./cache.js";

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -4,6 +4,7 @@ import type { CompressionState, NudgeDecision } from "../types.js";
 import { formatCompactTokens } from "./format.js";
 import { topicFallback } from "./topic.js";
 import { viableRanges } from "../viable.js";
+import { cacheHitStats, formatHitRate, type CacheUsageSample } from "./cache.js";
 
 export interface StatusPanelInput {
   /** Adapter identifier for the header, e.g. "billion-context-omp@0.1.6".
@@ -30,6 +31,11 @@ export interface StatusPanelInput {
    *  from an estimate-scale number invents a third, meaningless scale
    *  (issue #18 "看板统计的和拆分的有差异"). */
   unprunedTokens?: number;
+  /** Per-request prompt-cache usage (from assistant messages' provider-
+   *  reported `usage`). Requests without cache reporting are excluded by
+   *  cacheHitStats; when no counted request remains, the section is
+   *  omitted entirely. Omit the field to hide the section. */
+  cacheUsages?: ReadonlyArray<CacheUsageSample>;
   /** Token formatter override (defaults to formatCompactTokens). */
   fmtTokens?: (n: number) => string;
 }
@@ -106,6 +112,16 @@ export function buildStatusPanel(input: StatusPanelInput): string {
       const pct = sentTotal > 0 ? Math.round((cat.value / sentTotal) * 100) : 0;
       const b = bar(cat.value, sentTotal);
       lines.push(`  ${cat.label.padEnd(10)} ${b} ${String(pct).padStart(3)}%  ${fmt(cat.value)}`);
+    }
+  }
+
+  if (input.cacheUsages) {
+    const cache = cacheHitStats(input.cacheUsages);
+    if (cache.requests > 0 && cache.session !== undefined && cache.last !== undefined) {
+      lines.push("");
+      lines.push(
+        `Prompt cache (provider-reported): ${formatHitRate(cache.last)} last · ${formatHitRate(cache.session)} session avg — ${fmt(cache.cacheRead)} of ${fmt(cache.billedPrompt)} billed prompt tokens served from cache (${cache.requests} req)`,
+      );
     }
   }
 

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildStatusPanel, topicFallback, formatCompactTokens } from "../src/panel/index.js";
+import { buildStatusPanel, topicFallback, formatCompactTokens, cacheHitStats, formatHitRate } from "../src/panel/index.js";
 import { VIABLE_RANGE_MIN_TOKENS } from "../src/viable.js";
 
 test("panel separates session accounting from sent view", () => {
@@ -102,4 +102,55 @@ test("formatCompactTokens matches host footer thresholds", () => {
   assert.equal(formatCompactTokens(9_500), "9.5k");
   assert.equal(formatCompactTokens(430_000), "430k");
   assert.equal(formatCompactTokens(1_500_000), "1.5M");
+});
+
+test("cacheHitStats weights the session average by billed prompt tokens", () => {
+  const out = cacheHitStats([
+    { input: 1_000, cacheRead: 99_000, cacheWrite: 0 }, // 99% of 100k billed
+    { input: 10_000, cacheRead: 0, cacheWrite: 90_000 }, // cold write, 0% served
+  ]);
+  assert.equal(out.requests, 2);
+  assert.equal(out.cacheRead, 99_000);
+  assert.equal(out.billedPrompt, 200_000);
+  assert.equal(out.session, 99_000 / 200_000);
+  assert.equal(out.last, 0); // write-only request still counts as last
+});
+
+test("cacheHitStats excludes requests without provider cache reporting", () => {
+  const out = cacheHitStats([
+    { input: 5_000, cacheRead: 0, cacheWrite: 0 }, // no cache signal → excluded
+    { input: 0, cacheRead: 80_000, cacheWrite: 0 },
+  ]);
+  assert.equal(out.requests, 1);
+  assert.equal(out.session, 1);
+  assert.equal(out.last, 1);
+  const none = cacheHitStats([{ input: 5_000, cacheRead: 0, cacheWrite: 0 }]);
+  assert.equal(none.requests, 0);
+  assert.equal(none.session, undefined);
+  assert.equal(none.last, undefined);
+});
+
+test("formatHitRate clamps and formats one decimal", () => {
+  assert.equal(formatHitRate(0.923), "92.3%");
+  assert.equal(formatHitRate(1), "100.0%");
+  assert.equal(formatHitRate(1.2), "100.0%");
+  assert.equal(formatHitRate(0), "0.0%");
+});
+
+test("panel renders prompt cache line and omits it without cache signal", () => {
+  const state = { blocks: [], messageRefs: { byRaw: {}, byRef: {} }, nudge: {}, stats: { tokensCompressed: 0 }, nextBlockId: 1, nextRunId: 1 };
+  const base = { tokenCount: 430_000, systemPromptTokens: 0, state: state as never, nudge: undefined, modelContextLimit: 1_000_000 };
+  const withCache = buildStatusPanel({
+    ...base,
+    cacheUsages: [
+      { input: 1_000, cacheRead: 99_000, cacheWrite: 0 },
+      { input: 0, cacheRead: 180_000, cacheWrite: 20_000 },
+    ],
+  });
+  // session = (99k + 180k) / (100k + 200k) = 93.0%; last = 180k/200k = 90.0%
+  assert.match(withCache, /Prompt cache \(provider-reported\): 90\.0% last · 93\.0% session avg — 279k of 300k billed prompt tokens served from cache \(2 req\)/);
+  const noSignal = buildStatusPanel({ ...base, cacheUsages: [{ input: 5_000, cacheRead: 0, cacheWrite: 0 }] });
+  assert.doesNotMatch(noSignal, /Prompt cache/, "omitted when no request reported cache activity");
+  const omitted = buildStatusPanel(base);
+  assert.doesNotMatch(omitted, /Prompt cache/, "omitted without cacheUsages field");
 });


### PR DESCRIPTION
**Model: Claude Sonnet 4.5**

为 /acp 看板增加提示缓存命中率指标(用户请求 m00327)。需要 #111 之类的前置吗?无 —— 纯增量,零宿主依赖破坏(`cacheUsages` 可选字段,不传则整段省略,与现有面板行为完全一致)。

## 内容
- `src/panel/cache.ts` — `cacheHitStats(usages)`:
  - **session 平均**:按 billed prompt 加权 `cacheRead / (input+cacheRead+cacheWrite)`
  - **last 实时**:最近一次有缓存报告的请求
  - **计数口径**:仅 `cacheRead+cacheWrite>0` 的请求计入;无缓存报告的 provider(0/0)整条排除,不会把均值拉成假 0%
- `StatusPanelInput.cacheUsages?: ReadonlyArray<CacheUsageSample>` — 渲染一行:
  `Prompt cache (provider-reported): 90.0% last · 93.0% session avg — 279k of 300k billed prompt tokens served from cache (2 req)`
  放在 Token Breakdown 之后、Nudge 之前;无数据整段省略
- 数据源:宿主从 assistant 消息的 provider-reported `usage` 抽取(pi/omp 宿主侧接线随后提 PR,omp 还可直接用 `sessionManager.getUsageStatistics()`)

## 测试
- 新增 4 用例:加权平均、无信号排除、formatHitRate 边界、面板渲染/省略
- `npm test` 519/519 pass;typecheck/build 干净

等待 CI 绿后请人工审阅合并(遵守合并规则,不自主合并)。