### PR TITLE
release v0.0.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.1.0",
+    "version": "0.0.45",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.1.0",
+            "version": "0.0.45",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.44",
+    "version": "0.0.45",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release commit bumping version to 0.0.45. Ships the absorb API merged in #139 (applyAbsorb / appendAbsorbPrompts / hideAbsorbedMessages / ABSORB_TOOL / buildAbsorbSystemPrompt) — required by billion-context-pi#208 and the billion-context proxy absorb adaptation.

Verification: 534/534 tests pass, tsc clean, tsup build clean. CI publishes to npm on merge (per release workflow).