### PR TITLE
fix(nudge): fire tier-2/3 distillation nudges on block COUNT, not summary token mass

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1111,9 +1111,12 @@ function decideNudge(input: NudgeInput): NudgeDecision {
 
   // Tier arbitration. Emergency (usage >= emergencyThresholdPct) ignores tier
   // priority and picks the tier with the MAX pending. Non-emergency defaults to
-  // T1; T2 and T3 override when each crossed the shared 1.5x threshold AND
-  // exceeds the effective pending of every lower tier (T2 > T1 effective;
-  // T3 > T2 and > T1 effective).
+  // T1; T2/T3 override via either path: (a) COUNT — the number of active
+  // lower-tier blocks reached tiers.tier2Trigger/tier3Trigger (the documented
+  // block-count trigger; summaries are ~10:1 condensed so a token comparison
+  // against raw pending starves), or (b) TOKEN MASS — crossed the shared 1.5x
+  // threshold AND exceeds the effective pending of every lower tier (T2 > T1
+  // effective; T3 > T2 and > T1 effective).
   const tier2Threshold = Math.round(
     nudgeGrowthTokens * (config.nudge.tier2GrowthMultiplier ?? 1.5),
   );
@@ -1123,6 +1126,8 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   const t1Eff = tiers[1]?.pending ?? 0;
   const t2Pen = tiers[2]?.pending ?? 0;
   const t3Pen = tiers[3]?.pending ?? 0;
+  const t2Count = tiers[2]?.targetBlocks.length ?? 0;
+  const t3Count = tiers[3]?.targetBlocks.length ?? 0;
 
   if (pressure) {
     // High pressure: pick the tier with the MAX pending so pressure can route
@@ -1158,28 +1163,33 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       injectedReason = `T1 effective ${t1Eff} >= ${nudgeGrowthTokens}, growth ${growthSinceReference}, usage ${Math.round(usage * 100)}%`;
     } else if (
       config.tiers.enabled &&
-      t2Pen >= tier2Threshold &&
-      t2Pen > t1Eff
+      (t2Count >= config.tiers.tier2Trigger ||
+        (t2Pen >= tier2Threshold && t2Pen > t1Eff))
     ) {
       const lastShown = state.nudge.lastShownByTier[2] ?? 0;
       const cadenceMet =
         lastShown === 0 || tokenCount - lastShown >= growthFloor;
       if (cadenceMet) {
         injectedTier = 2;
-        injectedReason = `T2 distill ready: ${tiers[2]!.targetBlocks.length} tier-1 blocks (${t2Pen} tokens) >= ${tier2Threshold} (1.5x) and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
+        injectedReason =
+          t2Count >= config.tiers.tier2Trigger
+            ? `T2 distill ready: ${t2Count} tier-1 blocks >= tier2Trigger ${config.tiers.tier2Trigger} (${t2Pen} tokens), usage ${Math.round(usage * 100)}%`
+            : `T2 distill ready: ${tiers[2]!.targetBlocks.length} tier-1 blocks (${t2Pen} tokens) >= ${tier2Threshold} (1.5x) and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
       }
     } else if (
       config.tiers.enabled &&
-      t3Pen >= tier2Threshold &&
-      t3Pen > t2Pen &&
-      t3Pen > t1Eff
+      (t3Count >= config.tiers.tier3Trigger ||
+        (t3Pen >= tier2Threshold && t3Pen > t2Pen && t3Pen > t1Eff))
     ) {
       const lastShown = state.nudge.lastShownByTier[3] ?? 0;
       const cadenceMet =
         lastShown === 0 || tokenCount - lastShown >= growthFloor;
       if (cadenceMet) {
         injectedTier = 3;
-        injectedReason = `T3 condense ready: ${tiers[3]!.targetBlocks.length} tier-2 blocks (${t3Pen} tokens) >= ${tier2Threshold} (1.5x) and > T2 ${t2Pen} and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
+        injectedReason =
+          t3Count >= config.tiers.tier3Trigger
+            ? `T3 condense ready: ${t3Count} tier-2 blocks >= tier3Trigger ${config.tiers.tier3Trigger} (${t3Pen} tokens), usage ${Math.round(usage * 100)}%`
+            : `T3 condense ready: ${tiers[3]!.targetBlocks.length} tier-2 blocks (${t3Pen} tokens) >= ${tier2Threshold} (1.5x) and > T2 ${t2Pen} and > T1 effective ${t1Eff}, usage ${Math.round(usage * 100)}%`;
       }
     }
   }
@@ -1192,23 +1202,33 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   } else if (pressure) {
     const label = emergencyOverride ? "EMERGENCY" : "OVER-LIMIT";
     reason = `${label}: usage ${Math.round(usage * 100)}% but no tier has effective compressible content (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}) — nudge suppressed to avoid offering ranges below minCompressRange`;
-  } else {
-    const tiersList = [1, 2, 3] as const;
-    const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
-    const ready = eligible
-      .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens)
-      .map((t) => `T${t} ${tiers[t]!.pending}`);
-    const readyHint = ready.length > 0 ? `, ready: ${ready.join(", ")}` : "";
-    const blocked = eligible
-      .filter(
-        (t) =>
-          (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens &&
-          (state.nudge.lastShownByTier[t] ?? 0) > 0 &&
-          tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor,
-      )
-      .map((t) => `T${t} (cadence)`);
-    const blockedHint =
-      blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
+   } else {
+     const tiersList = [1, 2, 3] as const;
+     const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
+     const countReady = (t: 1 | 2 | 3) =>
+       t === 2
+         ? t2Count >= config.tiers.tier2Trigger
+         : t === 3
+           ? t3Count >= config.tiers.tier3Trigger
+           : false;
+     const ready = eligible
+       .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens)
+       .map((t) => `T${t} ${tiers[t]!.pending}`);
+     const readyCount = eligible
+       .filter((t) => (tiers[t]?.pending ?? 0) < nudgeGrowthTokens && countReady(t))
+       .map((t) => `T${t} ${t === 2 ? t2Count : t3Count} blocks (count)`);
+     const readyAll = [...ready, ...readyCount];
+     const readyHint = readyAll.length > 0 ? `, ready: ${readyAll.join(", ")}` : "";
+     const blocked = eligible
+       .filter(
+         (t) =>
+           ((tiers[t]?.pending ?? 0) >= nudgeGrowthTokens || countReady(t)) &&
+           (state.nudge.lastShownByTier[t] ?? 0) > 0 &&
+           tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor,
+       )
+       .map((t) => `T${t} (cadence)`);
+     const blockedHint =
+       blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
     const maxPending = Math.max(
       0,
       ...Object.values(tiers).map((t) => t.pending),

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1203,32 +1203,32 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     const label = emergencyOverride ? "EMERGENCY" : "OVER-LIMIT";
     reason = `${label}: usage ${Math.round(usage * 100)}% but no tier has effective compressible content (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}) — nudge suppressed to avoid offering ranges below minCompressRange`;
    } else {
-     const tiersList = [1, 2, 3] as const;
-     const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
-     const countReady = (t: 1 | 2 | 3) =>
-       t === 2
-         ? t2Count >= config.tiers.tier2Trigger
-         : t === 3
-           ? t3Count >= config.tiers.tier3Trigger
-           : false;
-     const ready = eligible
-       .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens)
-       .map((t) => `T${t} ${tiers[t]!.pending}`);
-     const readyCount = eligible
-       .filter((t) => (tiers[t]?.pending ?? 0) < nudgeGrowthTokens && countReady(t))
-       .map((t) => `T${t} ${t === 2 ? t2Count : t3Count} blocks (count)`);
-     const readyAll = [...ready, ...readyCount];
-     const readyHint = readyAll.length > 0 ? `, ready: ${readyAll.join(", ")}` : "";
-     const blocked = eligible
-       .filter(
-         (t) =>
-           ((tiers[t]?.pending ?? 0) >= nudgeGrowthTokens || countReady(t)) &&
-           (state.nudge.lastShownByTier[t] ?? 0) > 0 &&
-           tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor,
-       )
-       .map((t) => `T${t} (cadence)`);
-     const blockedHint =
-       blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
+    const tiersList = [1, 2, 3] as const;
+    const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
+    const countReady = (t: 1 | 2 | 3) =>
+      t === 2
+        ? t2Count >= config.tiers.tier2Trigger
+        : t === 3
+          ? t3Count >= config.tiers.tier3Trigger
+          : false;
+    const ready = eligible
+      .filter((t) => (tiers[t]?.pending ?? 0) >= nudgeGrowthTokens)
+      .map((t) => `T${t} ${tiers[t]!.pending}`);
+    const readyCount = eligible
+      .filter((t) => (tiers[t]?.pending ?? 0) < nudgeGrowthTokens && countReady(t))
+      .map((t) => `T${t} ${t === 2 ? t2Count : t3Count} blocks (count)`);
+    const readyAll = [...ready, ...readyCount];
+    const readyHint = readyAll.length > 0 ? `, ready: ${readyAll.join(", ")}` : "";
+    const blocked = eligible
+      .filter(
+        (t) =>
+          ((tiers[t]?.pending ?? 0) >= nudgeGrowthTokens || countReady(t)) &&
+          (state.nudge.lastShownByTier[t] ?? 0) > 0 &&
+          tokenCount - (state.nudge.lastShownByTier[t] ?? 0) < growthFloor,
+      )
+      .map((t) => `T${t} (cadence)`);
+    const blockedHint =
+      blocked.length > 0 ? `, blocked: ${blocked.join(", ")}` : "";
     const maxPending = Math.max(
       0,
       ...Object.values(tiers).map((t) => t.pending),

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,12 @@ export interface CompressionState {
 
 export interface TierConfig {
   enabled: boolean;
+  /** Distill to tier 2 once the count of ACTIVE tier-1 blocks reaches this.
+   *  Default 5. Independent of raw-message pending: summaries are ~10:1
+   *  condensed, so a token-mass comparison against T1 pending would starve. */
   tier2Trigger: number;
+  /** Condense to tier 3 once the count of ACTIVE tier-2 blocks reaches this.
+   *  Default 10. */
   tier3Trigger: number;
 }
 

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -635,3 +635,77 @@ test("re-baseline after a tokenCount scale drop also resets per-tier cadence sta
   assert.equal(stamped.lastNudgeShownTokens, 0, "shared cadence baseline cleared");
   assert.deepEqual(stamped.lastShownByTier, {}, "per-tier cadence stamps must not survive a scale drop");
 });
+
+test("arbitration: T2 fires on tier-1 block COUNT (tier2Trigger) even when summary tokens are small", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  // 5 blocks x ~100-token summaries = ~500 pending tokens, far below the
+  // 9000 token gate — only the count path (5 >= tier2Trigger 5) can fire,
+  // and raw T1 is fully preserved so t1Eff cannot dominate.
+  state = { ...state, blocks: t1Blocks([["m1"], ["m2"], ["m3"], ["m4"], ["m5"]], 400) };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, `reason: ${turn.nudge.reason}`);
+  assert.equal(turn.nudge.tier, 2);
+  assert.match(turn.nudge.reason ?? "", /5 tier-1 blocks >= tier2Trigger 5/);
+  assert.equal(turn.nudge.tierTargetBlocks?.length, 5);
+});
+
+test("arbitration: below tier2Trigger count and below token gate -> no T2 nudge", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  state = { ...state, blocks: t1Blocks([["m1"], ["m2"], ["m3"], ["m4"]], 400) };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, false, `reason: ${turn.nudge.reason}`);
+  assert.match(turn.nudge.reason ?? "", /max compressible 400 < threshold 6000/);
+  assert.doesNotMatch(turn.nudge.reason ?? "", /tier2Trigger/);
+});
+
+test("arbitration: count-triggered T2 does not preempt ready T1 raw compression", () => {
+  const core = createCore();
+  const config = buildConfig({
+    compress: { minCompressRange: 5000, maxSummaryLength: 0, minSummaryLength: 0 },
+    preserveRecentMessages: 0,
+  });
+  const messages = makeMessages(10);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  state = { ...state, blocks: t1Blocks([["m1"], ["m2"], ["m3"], ["m4"], ["m5"]], 400) };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, `reason: ${turn.nudge.reason}`);
+  assert.equal(turn.nudge.tier, 1, "T1 raw pending still has priority over count-ready T2");
+  assert.match(turn.nudge.reason ?? "", /T1 effective/);
+});
+
+test("arbitration: count-triggered T2 still respects the growthFloor cadence", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  state = { ...state, blocks: t1Blocks([["m1"], ["m2"], ["m3"], ["m4"], ["m5"]], 400) };
+  const first = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(first.nudge.tier, 2, `reason: ${first.nudge.reason}`);
+  const second = core.processTurn({ messages, state: first.state, config, tokenCount: 61000 });
+  assert.equal(second.nudge.shouldInject, false, `reason: ${second.nudge.reason}`);
+  assert.match(second.nudge.reason ?? "", /T2 \(cadence\)/);
+});
+
+test("arbitration: T3 fires on tier-2 block COUNT (tier3Trigger) even when summary tokens are small", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  // 2 tier-1 blocks (below tier2Trigger) + 10 tier-2 blocks with ~100-token
+  // summaries: t3Pen ~1000 << 9000 token gate — only the count path fires.
+  state = {
+    ...state,
+    blocks: [...t1Blocks([["m1"], ["m2"]], 400), ...t2Blocks(10, 400, ["m3"])],
+  };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, true, `reason: ${turn.nudge.reason}`);
+  assert.equal(turn.nudge.tier, 3);
+  assert.match(turn.nudge.reason ?? "", /10 tier-2 blocks >= tier3Trigger 10/);
+  assert.equal(turn.nudge.tierTargetBlocks?.length, 10);
+});

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -709,3 +709,15 @@ test("arbitration: T3 fires on tier-2 block COUNT (tier3Trigger) even when summa
   assert.match(turn.nudge.reason ?? "", /10 tier-2 blocks >= tier3Trigger 10/);
   assert.equal(turn.nudge.tierTargetBlocks?.length, 10);
 });
+
+test("arbitration: tiers disabled -> count trigger cannot fire T2", () => {
+  const core = createCore();
+  const config = buildConfig({ tiers: { enabled: false, tier2Trigger: 5, tier3Trigger: 10 }, preserveRecentMessages: 30 });
+  const messages = makeMessages(30);
+  let state = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 50000 }).state;
+  state = { ...state, blocks: t1Blocks([["m1"], ["m2"], ["m3"], ["m4"], ["m5"], ["m6"], ["m7"]], 400) };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 60000 });
+  assert.equal(turn.nudge.shouldInject, false, `reason: ${turn.nudge.reason}`);
+  assert.equal(turn.nudge.tier, null);
+  assert.doesNotMatch(turn.nudge.reason ?? "", /tier2Trigger/);
+});


### PR DESCRIPTION
## Problem (billion-context-pi#224)

`tier2Trigger` / `tier3Trigger` (defaults 5 / 10) existed in config and validation, but `decideNudge` never read them. The non-pressure path gated T2 on:

```js
t2Pen >= tier2Threshold /* 1.5x nudgeGrowthTokens */ && t2Pen > t1Eff
```

Summaries are ~10:1 condensed by design, so `t2Pen` almost never reaches the 1.5x gate, and any fresh raw content keeps `t1Eff` larger than the summary total. Net effect: **the T2 nudge effectively never fires** and tier-1 blocks accumulate indefinitely — the user-visible "t2 永不触发" in billion-context-pi#224.

Empirical repro on 0.0.45 defaults (1M limit): 10 tier-1 blocks with ~1K-token summaries + raw messages present → no nudge (`max compressible 17136 < threshold 50000`); 80 blocks → T1 wins; only the corner case (all raw already compressed) fired T2.

## Fix

- Count-based trigger: active tier-1 blocks `>= tier2Trigger` (T3: tier-2 blocks `>= tier3Trigger`) now **ORs** with the existing token-mass path.
- T1 raw compression keeps priority when its effective pending reaches `nudgeGrowthTokens` (fresh content still gets compressed first).
- Per-tier `growthFloor` cadence still throttles re-firing.
- Diagnostics: count-ready tiers are listed as `T2 5 blocks (count)`; cadence-blocked tiers show `blocked: T2 (cadence)`.
- `TierConfig` docstrings document the count semantics.

## Verification

- 5 new tests in `tests/nudge.test.ts`: count-triggered T2 (fires with 5 blocks despite ~500-token summary mass), negative below trigger, T1-priority preserved, cadence respected, count-triggered T3.
- Full suite: 539/539 pass; `tsc --noEmit` clean; build clean.
- Repro re-run against this build: scenario A (10 blocks + raw present) now fires `T2 distill ready: 10 tier-1 blocks >= tier2Trigger 5`; scenario B (large raw pending) still routes to T1.
