### PR TITLE
release v0.0.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.45",
+    "version": "0.0.46",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.45",
+            "version": "0.0.46",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.45",
+    "version": "0.0.46",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.46 — ships #162 (tier-2/3 distillation nudges fire on block COUNT, not summary token mass; restores `tier2Trigger`/`tier3Trigger` semantics documented since v0.0.2).

## What's in it
- #162 — fixes "T2 永不触发" (ranxianglei/billion-context-pi#224): count trigger ORs the token-mass path; T1 priority, growthFloor cadence, pressure-path arbitration unchanged. 6 new tests.

## Pre-flight
- `npm run typecheck` ✅
- `npm test` ✅ 540/540
- `npm run build` ✅

Merge → CI publishes `acp-kernel@0.0.46`. Downstream pin bumps (billion-context-pi first per its AGENTS.md §5) follow once live on npm.