### PR TITLE
fix(prune): keep rendered summaries in the leading system prefix

### DIFF
--- a/src/boundaries.ts
+++ b/src/boundaries.ts
@@ -75,6 +75,11 @@ export interface ResolvedRange {
   boundaryKind: BoundaryKind;
   protectedGaps: number[];
   snappedBoundaries: string[];
+  // Numeric ref bounds of message-ref boundaries (null when either boundary is
+  // a block ref). Lets block detection fall back to a block's content refs when
+  // its raws are pruned and its summary sits in the leading system prefix.
+  refStart: number | null;
+  refEnd: number | null;
 }
 
 export function resolveBoundaries(
@@ -115,6 +120,14 @@ export function resolveBoundaries(
     [startIndex, endIndex] = [endIndex, startIndex];
   }
 
+  const bothMessageRefs = start.kind === "message" && end.kind === "message";
+  const refStart = bothMessageRefs
+    ? Math.min(start.numericId, end.numericId)
+    : null;
+  const refEnd = bothMessageRefs
+    ? Math.max(start.numericId, end.numericId)
+    : null;
+
   const messageIds: string[] = [];
   for (let index = startIndex; index <= endIndex; index++) {
     const message = input.messages[index];
@@ -131,7 +144,17 @@ export function resolveBoundaries(
   const nestedBlockIds: string[] = [];
   const nestedSeen = new Set<string>();
   for (const block of activeBlocks(input.state)) {
-    if (blockVisibleInRange(block, indexByMessageId, startIndex, endIndex)) {
+    if (
+      blockVisibleInRange(
+        block,
+        indexByMessageId,
+        startIndex,
+        endIndex,
+        input.state.messageRefs.byRaw,
+        refStart,
+        refEnd,
+      )
+    ) {
       if (!nestedSeen.has(block.blockId)) {
         nestedSeen.add(block.blockId);
         nestedBlockIds.push(block.blockId);
@@ -149,6 +172,8 @@ export function resolveBoundaries(
     boundaryKind,
     protectedGaps,
     snappedBoundaries,
+    refStart,
+    refEnd,
   };
 }
 
@@ -314,12 +339,19 @@ export function visibleBlockAnchor(
 // (rendered summary or earliest surviving raw) falls inside it. The summary
 // alone is not sufficient: when a block covers the session's first user
 // message, prune keeps that one raw and inserts the summary BEFORE it, so the
-// summary index can sit outside a range that still contains the raw.
+// summary index can sit outside a range that still contains the raw. The
+// content-ref fallback covers the inverse: a block whose raws are ALL pruned
+// (none survive in the view) while its summary sits in the leading system
+// prefix (also outside the range) — detected by its raw refs landing inside
+// the requested message-ref span.
 export function blockVisibleInRange(
   block: CompressionBlock,
   indexByMessageId: Map<string, number>,
   startIndex: number,
   endIndex: number,
+  byRaw: Record<string, string> = {},
+  refStart: number | null = null,
+  refEnd: number | null = null,
 ): boolean {
   const summaryIndex = indexByMessageId.get(summaryMessageId(block.blockId));
   if (
@@ -333,7 +365,28 @@ export function blockVisibleInRange(
     block.effectiveMessageIds,
     indexByMessageId,
   );
-  return rawIndex !== null && rawIndex >= startIndex && rawIndex <= endIndex;
+  if (rawIndex !== null && rawIndex >= startIndex && rawIndex <= endIndex) {
+    return true;
+  }
+  // Fallback only when NO raw of the block survives in the view (all pruned):
+  // that is the one case where neither the summary (now in the leading prefix)
+  // nor any raw can anchor the block inside the range. Gating on rawIndex===null
+  // keeps a block whose anchor raw is merely OUTSIDE the range (but present) from
+  // being wrongly treated as nested.
+  if (rawIndex === null && refStart !== null && refEnd !== null) {
+    for (const id of block.effectiveMessageIds) {
+      const ref = byRaw[id];
+      if (ref === undefined) continue;
+      const num = refNumber(ref);
+      if (num !== null && num >= refStart && num <= refEnd) return true;
+    }
+  }
+  return false;
+}
+
+function refNumber(ref: string): number | null {
+  const match = MESSAGE_REF_PATTERN.exec(ref);
+  return match ? Number(match[1]) : null;
 }
 
 export function earliestIndexOfIds(

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -697,7 +697,15 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
     for (const block of activeBlocks(input.state)) {
       if (nestedSeen.has(block.blockId)) continue;
       if (
-        blockVisibleInRange(block, indexByMessageId, adjustedStart, adjustedEnd)
+        blockVisibleInRange(
+          block,
+          indexByMessageId,
+          adjustedStart,
+          adjustedEnd,
+          input.state.messageRefs.byRaw,
+          resolved.refStart,
+          resolved.refEnd,
+        )
       ) {
         nestedSeen.add(block.blockId);
         resolved.nestedBlockIds.push(block.blockId);

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -54,6 +54,16 @@ export function prune(
   const firstUserIndex = messages.findIndex(
     (message) => message.role === "user",
   );
+  // Rendered summaries are `role: "system"`. Strict OpenAI backends reject a
+  // system message that follows any non-system message, so every summary
+  // anchor is clamped to the first non-system message — summaries always land
+  // in the leading system prefix (index 0 when the view has none). Clamping to
+  // the first non-system (not first user) message also covers hosts that lead
+  // with a non-user, non-system message.
+  const firstNonSystemIndex = messages.findIndex(
+    (message) => message.role !== "system",
+  );
+  const summaryClampIndex = firstNonSystemIndex >= 0 ? firstNonSystemIndex : 0;
 
   const indexById = new Map<string, number>();
   const summaryIndexById = new Map<string, number>();
@@ -64,7 +74,12 @@ export function prune(
   });
 
   const anchors = inject
-    ? collectSummaryAnchors(state, indexById, summaryIndexById)
+    ? collectSummaryAnchors(
+        state,
+        indexById,
+        summaryIndexById,
+        summaryClampIndex,
+      )
     : [];
 
   return stripOrphanedReasoning(
@@ -81,12 +96,16 @@ interface SummaryAnchor {
   summary: string;
   topic?: string;
   insertAt: number;
+  // Unclamped position, used only to order summaries chronologically after
+  // clamping folds several of them onto the same leading-prefix slot.
+  orderKey: number;
 }
 
 function collectSummaryAnchors(
   state: CompressionState,
   indexById: Map<string, number>,
   summaryIndexById: Map<string, number>,
+  clampIndex: number,
 ): SummaryAnchor[] {
   const anchors: SummaryAnchor[] = [];
   for (const block of activeBlocks(state)) {
@@ -99,7 +118,8 @@ function collectSummaryAnchors(
         blockId: block.blockId,
         summary: block.summary,
         topic: block.topic,
-        insertAt: existingIndex,
+        insertAt: Math.min(existingIndex, clampIndex),
+        orderKey: existingIndex,
       });
       continue;
     }
@@ -110,14 +130,16 @@ function collectSummaryAnchors(
         earliest = index;
       }
     }
+    const original = earliest ?? 0;
     anchors.push({
       blockId: block.blockId,
       summary: block.summary,
       topic: block.topic,
-      insertAt: earliest ?? 0,
+      insertAt: Math.min(original, clampIndex),
+      orderKey: original,
     });
   }
-  anchors.sort((left, right) => left.insertAt - right.insertAt);
+  anchors.sort((left, right) => left.orderKey - right.orderKey);
   return anchors;
 }
 

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -106,11 +106,13 @@ test("prune after applyCompression removes covered messages and injects summary"
   });
 
   const pruned = prune(messages, after);
+  // Summary is clamped into the leading system prefix (before the preserved
+  // first user message) so no system message lands mid-conversation.
   assert.deepEqual(
     pruned.map((m) => m.id),
-    ["u", "acp_summary_b1", "c", "d"],
+    ["acp_summary_b1", "u", "c", "d"],
   );
-  assert.ok(pruned[1]!.text!.includes("intro recap"));
+  assert.ok(pruned[0]!.text!.includes("intro recap"));
 });
 
 test("applyCompression auto-swaps reversed boundaries", () => {

--- a/tests/state-prune.test.ts
+++ b/tests/state-prune.test.ts
@@ -124,11 +124,13 @@ test("prune removes covered messages and injects summary at anchor", () => {
   const messages = [msg("m1"), msg("m2"), msg("m3"), msg("m4")];
   const result = prune(messages, state);
 
+  // The anchor is clamped to the leading system prefix: the summary precedes
+  // the preserved first user message (m1) so no system message is mid-conversation.
   assert.equal(result.length, 3);
-  assert.equal(result[0]!.id, "m1");
-  assert.equal(result[1]!.id, "acp_summary_b1");
-  assert.ok(result[1]!.text!.startsWith(SUMMARY_HEADER));
-  assert.ok(result[1]!.text!.includes("the summary"));
+  assert.equal(result[0]!.id, "acp_summary_b1");
+  assert.ok(result[0]!.text!.startsWith(SUMMARY_HEADER));
+  assert.ok(result[0]!.text!.includes("the summary"));
+  assert.equal(result[1]!.id, "m1");
   assert.equal(result[2]!.id, "m4");
 });
 
@@ -170,10 +172,76 @@ test("prune orders multiple summaries by their anchor position", () => {
   const messages = [msg("u", "user"), msg("w"), msg("x"), msg("z")];
   const result = prune(messages, state);
 
-  assert.equal(result[0]!.id, "u");
-  assert.equal(result[1]!.id, "acp_summary_b2");
-  assert.ok(result[1]!.text!.includes("earlier"));
-  assert.equal(result[2]!.id, "acp_summary_b1");
-  assert.ok(result[2]!.text!.includes("later"));
+  // Both anchors clamp to the leading prefix; they keep their chronological
+  // order by original position (b2 covers w before b1 covers x).
+  assert.equal(result[0]!.id, "acp_summary_b2");
+  assert.ok(result[0]!.text!.includes("earlier"));
+  assert.equal(result[1]!.id, "acp_summary_b1");
+  assert.ok(result[1]!.text!.includes("later"));
+  assert.equal(result[2]!.id, "u");
   assert.equal(result[3]!.id, "z");
+});
+
+function assertNoMidConversationSystem(messages: CoreMessage[]): void {
+  let seenNonSystem = false;
+  for (const m of messages) {
+    if (m.role !== "system") seenNonSystem = true;
+    else if (seenNonSystem)
+      assert.fail(`system message ${m.id} appears after a non-system message`);
+  }
+}
+
+test("prune never emits a system message after a non-system message (OpenAI wire validity)", () => {
+  const state = createInitialState();
+  // A range that starts AFTER the head — the normal "fold the old stuff, keep
+  // the tail" pattern that used to strand a system summary mid-conversation.
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "folded history",
+      effectiveMessageIds: ["a2", "u3", "a4"],
+    }),
+  );
+  const messages: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "u1" },
+    { id: "a2", role: "assistant", contentType: "text", text: "a2" },
+    { id: "u3", role: "user", contentType: "text", text: "u3" },
+    { id: "a4", role: "assistant", contentType: "text", text: "a4" },
+    { id: "u5", role: "user", contentType: "text", text: "u5" },
+    { id: "a6", role: "assistant", contentType: "text", text: "a6" },
+  ];
+  const result = prune(messages, state);
+
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["acp_summary_b1", "u1", "u5", "a6"],
+  );
+  assertNoMidConversationSystem(result);
+});
+
+test("prune keeps the summary in the leading prefix after an existing system message", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "folded",
+      effectiveMessageIds: ["a2", "u3"],
+    }),
+  );
+  const messages: CoreMessage[] = [
+    { id: "sys0", role: "system", contentType: "text", text: "host system" },
+    { id: "u1", role: "user", contentType: "text", text: "u1" },
+    { id: "a2", role: "assistant", contentType: "text", text: "a2" },
+    { id: "u3", role: "user", contentType: "text", text: "u3" },
+    { id: "a4", role: "assistant", contentType: "text", text: "a4" },
+  ];
+  const result = prune(messages, state);
+
+  // The summary clamps to the first non-system message (u1): it lands after the
+  // leading host system message but still ahead of the conversation proper.
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["sys0", "acp_summary_b1", "u1", "a4"],
+  );
+  assertNoMidConversationSystem(result);
 });


### PR DESCRIPTION
Fixes #170.

## Problem

`prune()` inserted a rendered summary (`role: "system"`) at the block's earliest covered-message index. Whenever a compress range started after the head — the normal "fold the old stuff, keep the tail" pattern — the summary landed **mid-conversation** (a system message after a user/assistant message). `coreToOpenai` serializes `role: "system"` verbatim at its position, so strict OpenAI-compatible backends reject every subsequent request with `400 System message must be at the beginning`, stranding the session (reproduced on sglang; ranxianglei/billion-context#355).

## Fix

**`src/prune.ts`** — clamp every summary anchor to the first non-system message so summaries always land in the leading system prefix. Clamping to the first *non-system* (not first *user*) message also covers hosts that lead with a non-user, non-system message. Summaries keep their chronological order via an unclamped `orderKey`, so multi-summary placement is unchanged apart from moving into the prefix.

**`src/boundaries.ts` / `src/compress.ts`** — moving the summary out of the range broke block detection for a block whose raws were all pruned (its summary was the only in-range representation), which regressed multi-tier distillation over a pruned region. `blockVisibleInRange` now falls back to the block's content refs when no raw survives in the view. The fallback is gated on `rawIndex === null` so a block whose anchor raw is merely outside the range (but present) is not wrongly treated as nested — that gate is what keeps the "covered by non-nested block" validation rejecting correctly.

## Tests

- 2 new regression tests pin the wire-validity invariant (no system message after a non-system message), including the leading-system-message case.
- 3 existing tests updated: their exact summary-position assertions reflected the old (buggy) mid-conversation placement.
- Full suite: 542 pass. typecheck + build clean.

Note: the issue's minimal proposal (`insertAt: Math.min(earliest ?? 0, firstUserIndex)`) is correct for placement but, on its own, regresses block consumption (the `promote-after-prune` "m-ref range spanning a pruned region" case) — the content-ref fallback here is required to keep distillation working.
