### PR TITLE
fix(persist): spill to side file on rename failure + per-entry compress invalid reasons

### DIFF
--- a/src/parse-compress-input.ts
+++ b/src/parse-compress-input.ts
@@ -45,6 +45,8 @@ export interface CompressParseDiagnostics {
     keys?: string[];
     /** Entries dropped because they were not valid ranges. */
     invalidItems: number;
+    /** One human-readable reason per dropped entry (index-prefixed). */
+    invalidReasons?: string[];
 }
 
 export interface ParsedCompressInput {
@@ -119,9 +121,9 @@ function parseObjectValue(value: Record<string, unknown>, callId: string | undef
         // Model drift: a single range at the top level (no content array).
         // The proxy defends against this shape; the kernel now owns it.
         const single = validateEntry(value, callId);
-        if (single) {
+        if ("range" in single) {
             diag.kind = "ok";
-            return finish([single], diag);
+            return finish([single.range], diag);
         }
         diag.kind = "missing-content";
         return finish([], diag);
@@ -147,7 +149,7 @@ function parseObjectValue(value: Record<string, unknown>, callId: string | undef
         return finish([], diag);
     }
 
-    const { ranges, invalid } = validateEntries(entries, callId);
+    const { ranges, invalid, reasons } = validateEntries(entries, callId);
     // Top-level fallbacks: topic and summaryMaxChars apply to every range
     // that does not specify its own (omp/pi schemas define both at the top
     // level; per-entry values win).
@@ -161,6 +163,7 @@ function parseObjectValue(value: Record<string, unknown>, callId: string | undef
         }
     }
     diag.invalidItems = invalid;
+    if (reasons.length > 0) diag.invalidReasons = reasons;
     diag.kind = salvaged ? "truncated" : ranges.length > 0 ? "ok" : "no-valid-ranges";
     return finish(ranges, diag);
 }
@@ -188,41 +191,50 @@ function finish(ranges: CompressRangeSpec[], diag: CompressParseDiagnostics): Pa
 }
 
 function finishSalvage(entries: unknown[], callId: string | undefined, diag: CompressParseDiagnostics, truncatedShape: boolean): ParsedCompressInput {
-    const { ranges, invalid } = validateEntries(entries, callId);
+    const { ranges, invalid, reasons } = validateEntries(entries, callId);
     diag.invalidItems = invalid;
+    if (reasons.length > 0) diag.invalidReasons = reasons;
     diag.kind = entries.length > 0 || truncatedShape ? "truncated" : "malformed-json";
     return finish(ranges, diag);
 }
 
-function validateEntries(entries: unknown[], callId: string | undefined): { ranges: CompressRangeSpec[]; invalid: number } {
+function validateEntries(entries: unknown[], callId: string | undefined): { ranges: CompressRangeSpec[]; invalid: number; reasons: string[] } {
     const ranges: CompressRangeSpec[] = [];
+    const reasons: string[] = [];
     let invalid = 0;
-    for (const entry of entries) {
-        const range = validateEntry(entry, callId);
-        if (range !== null) ranges.push(range);
-        else invalid++;
+    for (let i = 0; i < entries.length; i++) {
+        const outcome = validateEntry(entries[i], callId);
+        if ("range" in outcome) ranges.push(outcome.range);
+        else {
+            invalid++;
+            reasons.push(`entry ${i}: ${outcome.reason}`);
+        }
     }
-    return { ranges, invalid };
+    return { ranges, invalid, reasons };
 }
 
-function validateEntry(entry: unknown, callId: string | undefined): CompressRangeSpec | null {
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return null;
+type EntryOutcome = { range: CompressRangeSpec } | { reason: string };
+
+function validateEntry(entry: unknown, callId: string | undefined): EntryOutcome {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return { reason: "not an object" };
     const e = entry as Record<string, unknown>;
     // Field-name variants: startRef/endRef are canonical; startId/endId is
     // model drift (and the legacy rebuild.ts spelling); messageId is the
     // startId-less messageRef from the historical API.
     const start = stringOr(e["startRef"]) ?? stringOr(e["startId"]) ?? stringOr(e["messageId"]);
     const end = stringOr(e["endRef"]) ?? stringOr(e["endId"]) ?? stringOr(e["messageId"]);
-    if (start === undefined || end === undefined) return null;
+    if (start === undefined || end === undefined) {
+        return { reason: "missing range bounds (need startRef/startId and endRef/endId)" };
+    }
     const summary = stringOr(e["summary"]);
-    if (summary === undefined) return null;
+    if (summary === undefined) return { reason: "missing summary" };
     const range: CompressRangeSpec = { startRef: start, endRef: end, summary };
     const topic = stringOr(e["topic"]);
     if (topic !== undefined) range.topic = topic;
     const maxChars = e["summaryMaxChars"];
     if (typeof maxChars === "number" && Number.isFinite(maxChars)) range.summaryMaxChars = maxChars;
     if (callId !== undefined) range.compressCallId = callId;
-    return range;
+    return { range };
 }
 
 function stringOr(value: unknown): string | undefined {

--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -74,6 +74,18 @@ export interface StateStoreOptions<T> {
      * (string id, non-null payload).
      */
     validate?: (envelope: PersistedEnvelope<T>) => boolean;
+    /**
+     * Rename-retry policy for Windows transient locks (EPERM/EBUSY/EACCES
+     * from AV scan, search indexer, SMB). Exponential backoff: the delay
+     * after attempt i is min(retryBaseMs * 2^i, retryMaxMs). Defaults
+     * (6 attempts, 50ms base, 1600ms cap) give a ~1.5s window — long enough
+     * for most AV locks to release, short enough not to stall a sync flush.
+     * When the window is exhausted the write spills to a side file (see
+     * spillPath) instead of dropping the data.
+     */
+    retryAttempts?: number;
+    retryBaseMs?: number;
+    retryMaxMs?: number;
 }
 
 /**
@@ -82,17 +94,22 @@ export interface StateStoreOptions<T> {
  *
  * - atomic writes: temp file + rename, so a crash mid-write never leaves a
  *   truncated record (readers see either the old or the new file)
- * - rename retries on Windows transient locks (EPERM/EBUSY/EACCES)
+ * - rename retries with exponential backoff on Windows transient locks
+ *   (EPERM/EBUSY/EACCES); when the window is exhausted the record spills to
+ *   a side file (`<name>.fb.json`) instead of being dropped, so a lock held
+ *   by AV/indexer/SMB never silently loses session data
  * - per-id serialization so concurrent writeNow calls never interleave
  *   temp-file names or reorders writes
  * - debounced scheduleSave coalesces bursts into one write; the record is
  *   built at WRITE time from a builder, so late mutations are picked up
  * - loadAll skips `.tmp-*` orphans, corrupt JSON, and records whose
- *   filename does not match their id — one bad file never blocks boot
+ *   filename does not match their id — one bad file never blocks boot; it
+ *   reconciles a canonical record against its spill by savedAt (freshest wins)
  *
- * The store never deletes files. Session cleanup is a downstream policy
- * decision (kernel position: persisted state should not be deleted
- * opportunistically).
+ * The store never deletes a record's data. On a successful canonical write it
+ * removes a now-stale spill of the SAME id (a duplicate, not distinct data).
+ * Session cleanup is a downstream policy decision (kernel position: persisted
+ * state should not be deleted opportunistically).
  */
 export class StateStore<T> {
     readonly enabled: boolean;
@@ -103,11 +120,16 @@ export class StateStore<T> {
     private readonly legacyFn?: (parsed: unknown) => LegacyAdoption<T> | null;
     private readonly relPathFn?: (id: string, payload: T) => string;
     private readonly validateFn: (envelope: PersistedEnvelope<T>) => boolean;
+    private readonly retryAttempts: number;
+    private readonly retryBaseMs: number;
+    private readonly retryMaxMs: number;
     private readonly timers = new Map<string, NodeJS.Timeout>();
     private readonly pending = new Map<string, () => T>();
     private readonly writeChains = new Map<string, Promise<void>>();
     /** id → absolute path, populated by writes and loadAll. */
     private readonly discovered = new Map<string, string>();
+    /** id → cumulative write-failure count, for rate-limited alerting. */
+    private readonly failCounts = new Map<string, number>();
     /** Monotonic counter for unique temp filenames within a process. */
     private tmpSeq = 0;
 
@@ -120,6 +142,9 @@ export class StateStore<T> {
         this.relPathFn = opts.relPath;
         this.legacyFn = opts.legacy;
         this.validateFn = opts.validate ?? defaultValidate;
+        this.retryAttempts = Math.max(1, opts.retryAttempts ?? 6);
+        this.retryBaseMs = Math.max(1, opts.retryBaseMs ?? 50);
+        this.retryMaxMs = Math.max(this.retryBaseMs, opts.retryMaxMs ?? 1600);
     }
 
     /** Debounced save. Coalesces bursts; the builder runs at write time, so
@@ -190,36 +215,48 @@ export class StateStore<T> {
             this.log("warn", `[persist] could not create dir ${path.dirname(file)}: ${errText(e)}`);
         }
         const tmp = this.tempPath(file);
-        try {
-            fs.writeFileSync(tmp, data, "utf8");
-            // renameSync can throw EPERM/EBUSY on Windows when the dest is
-            // briefly held (AV scanner, indexer, SMB). Retry briefly —
-            // transient locks usually release within ms.
-            let lastErr: unknown;
-            for (let attempt = 0; attempt < 3; attempt++) {
-                try {
-                    fs.renameSync(tmp, file);
-                    lastErr = undefined;
-                    break;
-                } catch (e) {
-                    lastErr = e;
-                    const code = (e as NodeJS.ErrnoException).code;
-                    if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
-                    // brief sync backoff (Atomics.wait is the sync sleep)
-                    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20 * (attempt + 1));
-                }
-            }
-            if (lastErr) throw lastErr;
-            return true;
-        } catch (e) {
-            this.log("error", `[persist] flushSync failed for ${id}: ${errText(e)}`);
+        let lastErr: unknown;
+        for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
             try {
-                fs.unlinkSync(tmp);
-            } catch {
-                // best-effort cleanup of the orphan temp
+                fs.writeFileSync(tmp, data, "utf8");
+                fs.renameSync(tmp, file);
+                lastErr = undefined;
+                break;
+            } catch (e) {
+                lastErr = e;
+                try {
+                    fs.unlinkSync(tmp);
+                } catch {
+                    // temp never created or already gone
+                }
+                const code = (e as NodeJS.ErrnoException).code;
+                if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
+                if (attempt === this.retryAttempts - 1) break;
+                // sync sleep (Atomics.wait) — backoff grows per attempt
+                Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, this.backoffMs(attempt));
             }
-            return false;
         }
+        if (!lastErr) {
+            this.discovered.set(id, file);
+            this.clearFailure(id);
+            this.removeSpillSync(file);
+            return true;
+        }
+        // The canonical rename outlived the retry window (Windows lock held by
+        // AV/indexer/SMB). Spill to a side file so the data still lands on
+        // disk instead of being dropped — loadAll picks the freshest of the
+        // canonical and the spill.
+        let spillPath: string | null = null;
+        try {
+            const spill = this.spillPathFor(file);
+            fs.writeFileSync(spill, data, "utf8");
+            spillPath = spill;
+            this.discovered.set(id, spill);
+        } catch {
+            // spillover also failed (dir read-only / disk full) — data at risk
+        }
+        this.recordFailure(id, lastErr, spillPath);
+        return spillPath !== null;
     }
 
     /** Load one record. Checks the discovered path (from a prior
@@ -255,15 +292,31 @@ export class StateStore<T> {
         for (const file of files) {
             const envelope = this.readEnvelope(file);
             if (!envelope) continue;
-            const expected =
-                path.basename(this.relPathOf(envelope.id, envelope.payload)) === path.basename(file) ||
-                flatFileNameFor(envelope.id) === path.basename(file);
-            if (!expected) {
+            const base = path.basename(file);
+            const relBase = path.basename(this.relPathOf(envelope.id, envelope.payload));
+            const flatBase = flatFileNameFor(envelope.id);
+            // A file is a valid record for its envelope id when its name is the
+            // canonical name OR a spill (`.fb`) of the canonical name. This lets
+            // a spilled record (written while the canonical was locked) be
+            // discovered and reconciled against the canonical by savedAt.
+            let owner: string | null = null;
+            if (base === relBase || base === flatBase) {
+                owner = envelope.id;
+            } else if (base.endsWith(".fb.json")) {
+                const canonicalBase = `${base.slice(0, -".fb.json".length)}.json`;
+                if (canonicalBase === relBase || canonicalBase === flatBase) {
+                    owner = envelope.id;
+                }
+            }
+            if (owner === null) {
                 this.log("warn", `[persist] skipping ${rel(file, this.dir)}: filename does not match record id`);
                 continue;
             }
-            this.discovered.set(envelope.id, file);
-            out.set(envelope.id, envelope);
+            const existing = out.get(owner);
+            if (!existing || envelope.savedAt >= existing.savedAt) {
+                out.set(owner, envelope);
+                this.discovered.set(owner, file);
+            }
         }
         return out;
     }
@@ -323,15 +376,30 @@ export class StateStore<T> {
             this.log("warn", `[persist] could not create dir ${path.dirname(file)}: ${errText(e)}`);
         }
         const tmp = this.tempPath(file);
+        const env = this.envelope(id, payload);
         try {
-            await fsp.writeFile(tmp, JSON.stringify(this.envelope(id, payload)), "utf8");
-            await renameWithRetry(tmp, file);
+            await fsp.writeFile(tmp, JSON.stringify(env), "utf8");
+            await this.renameWithRetry(tmp, file);
             this.discovered.set(id, file);
+            this.clearFailure(id);
+            await this.removeSpill(file);
         } catch (e) {
-            // Wrap so a failure cleans up the .tmp orphan instead of leaving
-            // it for the next write to collide with.
+            // Clean up the .tmp orphan so the next write doesn't collide with it.
             await fsp.unlink(tmp).catch(() => {});
-            this.log("error", `[persist] write failed for ${id}: ${errText(e)}`);
+            // The canonical rename outlived the retry window (Windows lock held
+            // by AV/indexer/SMB). Spill to a side file so the data still lands
+            // on disk instead of being dropped — loadAll picks the freshest of
+            // the canonical and the spill.
+            let spillPath: string | null = null;
+            try {
+                const spill = this.spillPathFor(file);
+                await fsp.writeFile(spill, JSON.stringify(env), "utf8");
+                spillPath = spill;
+                this.discovered.set(id, spill);
+            } catch {
+                // spillover also failed (dir read-only / disk full) — data at risk
+            }
+            this.recordFailure(id, e, spillPath);
             throw e;
         }
     }
@@ -362,6 +430,76 @@ export class StateStore<T> {
     private tempPath(dest: string): string {
         const seq = this.tmpSeq++;
         return path.join(path.dirname(dest), `.tmp-${path.basename(dest, ".json")}-${process.pid}-${seq}`);
+    }
+
+    private backoffMs(attempt: number): number {
+        return Math.min(this.retryBaseMs * 2 ** attempt, this.retryMaxMs);
+    }
+
+    /** Side file for a record whose canonical write keeps failing: the
+     *  canonical name with a `.fb` (fallback) infix, e.g. `a.json` →
+     *  `a.fb.json`. One slot per id, overwritten on each spill, so a stuck
+     *  lock never accumulates files. Ends in `.json` so loadAll discovers it. */
+    private spillPathFor(file: string): string {
+        const base = path.basename(file);
+        const dot = base.lastIndexOf(".");
+        const stem = dot > 0 ? base.slice(0, dot) : base;
+        const ext = dot > 0 ? base.slice(dot) : ".json";
+        return path.join(path.dirname(file), `${stem}.fb${ext}`);
+    }
+
+    /** Remove a stale spill after a successful canonical write (best-effort). */
+    private async removeSpill(file: string): Promise<void> {
+        await fsp.unlink(this.spillPathFor(file)).catch(() => {});
+    }
+
+    private removeSpillSync(file: string): void {
+        try {
+            fs.unlinkSync(this.spillPathFor(file));
+        } catch {
+            // no spill or still locked — loadAll reconciles by savedAt
+        }
+    }
+
+    /** Rate-limited failure alerting: log on the first failure and at each
+     *  power-of-two count (1,2,4,8,…), so a long lock yields ~log2(N) lines
+     *  instead of one per write. Includes the spill path so the operator can
+     *  see where the data landed. */
+    private recordFailure(id: string, err: unknown, spillPath: string | null): void {
+        const count = (this.failCounts.get(id) ?? 0) + 1;
+        this.failCounts.set(id, count);
+        const alertAt = count === 1 || (count >= 2 && (count & (count - 1)) === 0);
+        if (!alertAt) return;
+        const where = spillPath
+            ? `; data spilled to ${rel(spillPath, this.dir)}`
+            : "; SPILLOVER ALSO FAILED — data at risk";
+        this.log(count === 1 ? "error" : "warn", `[persist] write failed for ${id} (total ${count}x): ${errText(err)}${where}`);
+    }
+
+    private clearFailure(id: string): void {
+        this.failCounts.delete(id);
+    }
+
+    /** fs.rename with exponential-backoff retries on Windows transient locks
+     *  (EPERM/EBUSY/EACCES from AV scan, search indexer, SMB). Other errors
+     *  are real and rethrown immediately. */
+    private async renameWithRetry(src: string, dest: string): Promise<void> {
+        let lastErr: unknown;
+        for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
+            try {
+                await fsp.rename(src, dest);
+                return;
+            } catch (e) {
+                lastErr = e;
+                const code = (e as NodeJS.ErrnoException).code;
+                if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") throw e;
+                if (attempt === this.retryAttempts - 1) throw e;
+                const { promise, resolve } = Promise.withResolvers<void>();
+                setTimeout(resolve, this.backoffMs(attempt));
+                await promise;
+            }
+        }
+        throw lastErr;
     }
 
     /** Parse + validate one file. Corrupt or invalid records return null
@@ -448,27 +586,6 @@ function isEnvelopeLike(value: unknown): value is PersistedEnvelope<unknown> {
  *  names stay greppable. */
 export function flatFileNameFor(id: string): string {
     return createHash("sha256").update(id, "utf8").digest("hex").slice(0, 24) + ".json";
-}
-
-/** fs.rename with brief retries on Windows transient locks (EPERM/EBUSY/
- *  EACCES from AV scan, search indexer, SMB). A short delay + retry almost
- *  always succeeds; other errors are real and rethrown immediately. */
-async function renameWithRetry(src: string, dest: string): Promise<void> {
-    let lastErr: unknown;
-    for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-            await fsp.rename(src, dest);
-            return;
-        } catch (e) {
-            lastErr = e;
-            const code = (e as NodeJS.ErrnoException).code;
-            if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") throw e;
-            const { promise, resolve } = Promise.withResolvers<void>();
-            setTimeout(resolve, 20 * (attempt + 1));
-            await promise;
-        }
-    }
-    throw lastErr;
 }
 
 function errText(e: unknown): string {

--- a/tests/parse-compress-input.test.ts
+++ b/tests/parse-compress-input.test.ts
@@ -226,6 +226,41 @@ test("parseCompressArgs counts invalid entries and keeps the valid ones", () => 
     assert.equal(diagnostics.invalidItems, 5);
 });
 
+test("parseCompressArgs reports per-entry invalid reasons", () => {
+    const input = {
+        content: [
+            { startRef: "m00001", endRef: "m00002", summary: "good" },
+            { summary: "missing refs" },
+            { startRef: "m00003", endRef: "m00004" },
+            "garbage",
+        ],
+    };
+    const { diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.invalidItems, 3);
+    assert.deepEqual(diagnostics.invalidReasons, [
+        "entry 1: missing range bounds (need startRef/startId and endRef/endId)",
+        "entry 2: missing summary",
+        "entry 3: not an object",
+    ]);
+});
+
+test("parseCompressArgs reports invalid reasons for no-valid-ranges", () => {
+    const input = {
+        content: [
+            { startRef: "m00001", endRef: "m00002" },
+            { summary: "no bounds" },
+        ],
+    };
+    const { diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "no-valid-ranges");
+    assert.equal(diagnostics.invalidItems, 2);
+    assert.deepEqual(diagnostics.invalidReasons, [
+        "entry 0: missing summary",
+        "entry 1: missing range bounds (need startRef/startId and endRef/endId)",
+    ]);
+});
+
 test("parseCompressArgs reports no-valid-ranges for an empty content array", () => {
     const { ranges, diagnostics } = parseCompressArgs({ content: [] });
     assert.equal(diagnostics.kind, "no-valid-ranges");

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from "node:fs";
+import fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { StateStore, flatFileNameFor } from "../src/persist/store.js";
@@ -467,11 +469,166 @@ test("loadSync hint probes a namespaced path without loadAll", async () => {
         // without the hint, loadSync misses (flat fallback only).
         const s2 = store(dir, { relPath: (id, payload) => path.join("proto", payload.label, `${id}.json`) });
         assert.equal(s2.loadSync("hint-1"), null);
-        // With the relative-path hint, the namespaced file resolves.
-        const hit = s2.loadSync("hint-1", path.join("proto", "hostA", "hint-1.json"));
-        assert.ok(hit);
-        assert.deepEqual(hit.payload, { label: "hostA", count: 1 });
+    // With the relative-path hint, the namespaced file resolves.
+    const hit = s2.loadSync("hint-1", path.join("proto", "hostA", "hint-1.json"));
+    assert.ok(hit);
+    assert.deepEqual(hit.payload, { label: "hostA", count: 1 });
     } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function spillNameFor(id: string): string {
+    return flatFileNameFor(id).replace(/\.json$/, ".fb.json");
+}
+
+function eperm(): NodeJS.ErrnoException {
+    const e = new Error("EPERM: operation not permitted, rename") as NodeJS.ErrnoException;
+    e.code = "EPERM";
+    return e;
+}
+
+test("rename failure spills to a side file instead of dropping data", async (t) => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { retryAttempts: 2, retryBaseMs: 1, retryMaxMs: 2 });
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        let threw = false;
+        try {
+            await s.writeNow("sid-spill", () => ({ label: "kept", count: 1 }));
+        } catch {
+            threw = true;
+        }
+        assert.equal(threw, true);
+        const spillFile = path.join(dir, spillNameFor("sid-spill"));
+        assert.ok(existsSync(spillFile), "spill file exists");
+        const env = JSON.parse(readFileSync(spillFile, "utf8")) as { id: string; payload: Payload };
+        assert.equal(env.id, "sid-spill");
+        assert.deepEqual(env.payload, { label: "kept", count: 1 });
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll discovers a spilled record and reconciles against the canonical by savedAt", async (t) => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { retryAttempts: 2, retryBaseMs: 1, retryMaxMs: 2 });
+        await s.writeNow("sid-r", () => ({ label: "old", count: 1 }));
+        await new Promise((r) => setTimeout(r, 5));
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        await s.writeNow("sid-r", () => ({ label: "new", count: 2 })).catch(() => {});
+        t.mock.restoreAll();
+        const next = store(dir);
+        const all = await next.loadAll();
+        assert.deepEqual(all.get("sid-r")?.payload, { label: "new", count: 2 });
+        assert.deepEqual(next.loadSync("sid-r")?.payload, { label: "new", count: 2 });
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("a canonical newer than the spill wins on load, and the stale spill is cleaned on success", async () => {
+    const dir = tmpDir();
+    try {
+        const spillFile = path.join(dir, spillNameFor("sid-c"));
+        writeFileSync(spillFile, JSON.stringify({ version: 1, savedAt: 1, id: "sid-c", payload: { label: "stale", count: 0 } }), "utf8");
+        const s = store(dir);
+        await s.writeNow("sid-c", () => ({ label: "fresh", count: 5 }));
+        assert.equal(existsSync(spillFile), false, "stale spill removed after canonical success");
+        assert.deepEqual(s.loadSync("sid-c")?.payload, { label: "fresh", count: 5 });
+        const next = store(dir);
+        assert.deepEqual((await next.loadAll()).get("sid-c")?.payload, { label: "fresh", count: 5 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("write failures alert on the first and power-of-two counts, not every write", async (t) => {
+    const dir = tmpDir();
+    try {
+        const logs: { level: string; msg: string }[] = [];
+        const s = store(dir, {
+            retryAttempts: 2,
+            retryBaseMs: 1,
+            retryMaxMs: 2,
+            log: (level, msg) => logs.push({ level, msg }),
+        });
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        for (let i = 0; i < 5; i++) {
+            await s.writeNow("sid-f", () => ({ label: "x", count: i })).catch(() => {});
+        }
+        t.mock.restoreAll();
+        const failLogs = logs.filter((l) => l.msg.includes("write failed for sid-f"));
+        assert.equal(failLogs.length, 3);
+        assert.equal(failLogs[0].level, "error");
+        assert.ok(failLogs[0].msg.includes("total 1x"));
+        assert.ok(failLogs[0].msg.includes("data spilled to"));
+        assert.equal(failLogs[1].level, "warn");
+        assert.ok(failLogs[1].msg.includes("total 2x"));
+        assert.equal(failLogs[2].level, "warn");
+        assert.ok(failLogs[2].msg.includes("total 4x"));
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("flushSync spills to a side file when the rename keeps failing", (t) => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { retryAttempts: 2, retryBaseMs: 1, retryMaxMs: 2 });
+        t.mock.method(fs, "renameSync", () => {
+            throw eperm();
+        });
+        const ok = s.flushSync("sid-fs", () => ({ label: "sync", count: 9 }));
+        assert.equal(ok, true);
+        const spillFile = path.join(dir, spillNameFor("sid-fs"));
+        assert.ok(existsSync(spillFile), "spill file exists");
+        const env = JSON.parse(readFileSync(spillFile, "utf8")) as { id: string; payload: Payload };
+        assert.equal(env.id, "sid-fs");
+        assert.deepEqual(env.payload, { label: "sync", count: 9 });
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("a successful write clears the failure counter so alerting restarts", async (t) => {
+    const dir = tmpDir();
+    try {
+        const logs: { level: string; msg: string }[] = [];
+        const s = store(dir, {
+            retryAttempts: 2,
+            retryBaseMs: 1,
+            retryMaxMs: 2,
+            log: (level, msg) => logs.push({ level, msg }),
+        });
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        await s.writeNow("sid-reset", () => ({ label: "a", count: 0 })).catch(() => {});
+        t.mock.restoreAll();
+        await s.writeNow("sid-reset", () => ({ label: "b", count: 1 }));
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        await s.writeNow("sid-reset", () => ({ label: "c", count: 2 })).catch(() => {});
+        t.mock.restoreAll();
+        const failLogs = logs.filter((l) => l.msg.includes("write failed for sid-reset"));
+        assert.equal(failLogs.length, 2);
+        assert.ok(failLogs[0].msg.includes("total 1x"));
+        assert.ok(failLogs[1].msg.includes("total 1x"));
+    } finally {
+        t.mock.restoreAll();
         rmSync(dir, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
Addresses billion-context#362 (Windows persist EPERM storm + compress no-valid-ranges).

## 1. Persist: stop silently dropping session data on rename failure (main)

**Root cause.** On Windows, file locks (AV real-time scan / indexers) are held long enough that the ~120ms rename retry window always exhausted. Each failed persist then unlinked the temp file — permanently losing that round of session state. In the field: 4,879 EPERM lines, 117 sessions, and the top-3 failing sessions (2062/271/214 failures) had **no file on disk at all** — never persisted. All silent except the error log lines.

**Fix** (`src/persist/store.ts`):
- **Exponential-backoff retry** — default 6 attempts, 50ms base, 1600ms cap (was 3 attempts, 20/40/60ms). Configurable via `retryAttempts`/`retryBaseMs`/`retryMaxMs`.
- **Spill on final failure** — instead of unlinking the temp file, write the envelope to `<name>.fb.json` (one slot per id, overwritten) so the data is on disk. `loadAll` discovers spills and reconciles canonical vs spill by `savedAt` (freshest wins); a successful canonical write removes the now-stale spill of the same id.
- **Rate-limited alerting** — 1x error, then warn at powers of two (2x, 4x, 8x…), instead of one error line per failed write.

The store still never deletes a record's data; it only removes a temp file it itself created or a stale spill superseded by a newer canonical write.

## 2. Compress: report per-entry invalid reasons (secondary)

**Root cause.** When a compress call is rejected with `no-valid-ranges`, hosts only knew `invalidItems=N`, not *why* each entry was invalid — so the model blind-retried the same payload (5x in the field). 

**Fix** (`src/parse-compress-input.ts`): add `diagnostics.invalidReasons` — one index-prefixed, human-readable reason per dropped entry (`missing range bounds` / `missing summary` / `not an object`). Hosts can surface the specific reason to the model so it self-corrects.

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — 548 pass, 0 fail (+8 new: 6 persist spill/retry/alert, 2 compress reasons)
- `npm run build` — success

## Note for billion-context
This ships as a kernel release; billion-context must bump `acp-kernel` to the new version (after it is live on npm) to pick up the persist fix, and can then use `invalidReasons` in its compress error message. The spill files end in `.json` so existing `loadAll` discovery and the billion-context `relPathFor`/`flatFileNameFor` reconciliation both pick them up with no proxy-side change.

Requires review by ≥2 agents per acp-kernel AGENTS.md.