### PR TITLE
fix: stale-ref gate messages report true causes with diagnostics

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,4 +1,4 @@
-import { assignRefs, highestUsedIndex } from "./refs.js";
+import { assignRefs, highestUsedIndex, indexToRef } from "./refs.js";
 import { prune, isSummaryMessageId } from "./prune.js";
 import { syncBlocks } from "./sync.js";
 import { advanceSurvival, activeBlocks, blockById } from "./state.js";
@@ -9,6 +9,7 @@ import {
   BoundaryNotFoundError,
   resolveBoundaries,
   blockVisibleInRange,
+  parseBoundary,
 } from "./boundaries.js";
 import type { ResolvedRange } from "./boundaries.js";
 import { truncateLargeToolOutputs } from "./truncate-tools.js";
@@ -124,6 +125,38 @@ function rangeError(
 function numericBlockId(id: string): number {
   const parsed = /^b(\d+)$/.exec(id);
   return parsed ? Number(parsed[1]) : 0;
+}
+
+function refGateDiagnostics(
+  state: CompressionState,
+  requestedRanges: number,
+  unknownCount: number,
+): string {
+  const highest = highestUsedIndex(state.messageRefs);
+  const highestRef = highest > 0 ? indexToRef(highest) : "none";
+  return `[diagnostics: session highest ref=${highestRef}, unknown ranges in request=${unknownCount}/${requestedRanges}, session history=${state.stats.compressionCount} compression(s), ${state.blocks.length} block(s)]`;
+}
+
+function danglingMessageRefs(
+  state: CompressionState,
+  messages: CoreMessage[],
+  spec: { startRef: string; endRef: string },
+): string[] {
+  const visible = new Set(messages.map((m) => m.id));
+  const dangling: string[] = [];
+  for (const ref of [spec.startRef, spec.endRef]) {
+    const parsed = parseBoundary(ref);
+    if (!parsed || parsed.kind !== "message") continue;
+    const rawId =
+      state.messageRefs.byRef[parsed.raw] ??
+      state.messageRefs.byRef[indexToRef(parsed.numericId)];
+    if (!rawId || visible.has(rawId)) continue;
+    const covered = state.blocks.some(
+      (block) => block.active && block.effectiveMessageIds.includes(rawId),
+    );
+    if (!covered) dangling.push(parsed.raw);
+  }
+  return dangling;
 }
 
 export function createCore(ports: Ports = {}): CompressionCore {
@@ -267,13 +300,23 @@ export function createCore(ports: Ports = {}): CompressionCore {
           live.length > 0
             ? ` Current active blocks span ${live[0]}..${live[live.length - 1]} — retry with startId/endId set to active block IDs in that span.`
             : "";
+        const diagnostics = refGateDiagnostics(
+          state,
+          input.ranges.length,
+          unknownCount,
+        );
+        const danglingRefs = consumedRanges.flatMap((spec) =>
+          danglingMessageRefs(state, input.messages, spec),
+        );
         const gateMessage =
           resolvableCount === 0 &&
           consumedRanges.length === 0 &&
           unknownCount > 0
-            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref failed with "does not exist in this session". Refs recorded before an earlier compress are stale: each successful compress renumbers the remaining refs. Run acp_status, then call the compress tool again using only the refs it reports.`
+            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref is unknown to this session. Refs are per-session snapshots, assigned once when a message is first rendered; no compress reassigns them, so unknown refs cannot come from an earlier compress in this session. They come from a different generation: a previous session instance (switching model or upstream mid-conversation starts a fresh session whose refs restart at m00001), the generation before a native-compaction rebase (which also resets refs to m00001), or a typo. ${diagnostics} Run acp_status, then call the compress tool again using only the refs it reports.`
             : consumedRanges.length > 0
-              ? `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — your refs are stale: a prior compress renumbered the remaining refs, so this range now falls inside an active block. Run acp_status, then call the compress tool again using only the CURRENT compressible ranges it reports.${liveHint}`
+              ? danglingRefs.length > 0
+                ? `Requested range(s) cannot be anchored (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — the refs exist in this session's ref map, but the messages they point to are no longer in the visible context and no active block covers them: the message content changed (or the message was filtered out of the view) and now carries a new ref, leaving your old refs dangling. ${diagnostics} Run acp_status, then call the compress tool again using only the refs it reports.`
+                : `Requested range(s) already compressed (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — those refs no longer point to directly compressible content: the range is covered by active block(s) or the block ref(s) are stale (distilled or consumed). ${diagnostics} Run acp_status, then call the compress tool again using only the CURRENT compressible ranges it reports.${liveHint}`
               : `Total compressible content too small (${totalRangeChars} chars across ${countedRanges} range(s), min ${input.config.compress.minCompressRange}). Combine more messages into your range(s) to meet the threshold.`;
         return {
           state: input.state,

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -426,7 +426,12 @@ test("consumed plus fresh-but-small range is not misreported as too small", () =
   assert.equal(retry.result.blocksCreated, 0);
   assert.equal(retry.result.errors.length, 1);
   assert.match(retry.result.errors[0]!, /already compressed/);
-  assert.match(retry.result.errors[0]!, /your refs are stale/);
+  assert.match(retry.result.errors[0]!, /covered by active block\(s\)/);
+  assert.match(
+    retry.result.errors[0]!,
+    /\[diagnostics: session highest ref=m00005, unknown ranges in request=0\/2, session history=1 compression\(s\), 1 block\(s\)\]/,
+  );
+  assert.doesNotMatch(retry.result.errors[0]!, /renumber/i);
   assert.match(retry.result.errors[0]!, /Run acp_status/);
   assert.doesNotMatch(retry.result.errors[0]!, /Combine more messages/);
 });
@@ -468,7 +473,16 @@ test("all-unknown batch reports stale refs instead of too-small (billion-context
     result.result.errors[0]!,
     /None of the 2 requested range\(s\) resolved/,
   );
-  assert.match(result.result.errors[0]!, /renumbers the remaining refs/);
+  assert.match(result.result.errors[0]!, /no compress reassigns them/);
+  assert.match(
+    result.result.errors[0]!,
+    /cannot come from an earlier compress in this session/,
+  );
+  assert.match(
+    result.result.errors[0]!,
+    /\[diagnostics: session highest ref=m00005, unknown ranges in request=2\/2, session history=0 compression\(s\), 0 block\(s\)\]/,
+  );
+  assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
   assert.match(result.result.errors[0]!, /Run acp_status/);
   assert.doesNotMatch(result.result.errors[0]!, /too small/);
   assert.match(result.result.errors[1]!, /does not exist in this session/);
@@ -524,6 +538,166 @@ test("consumed plus unknown ranges keep the already-compressed message", () => {
     retry.result.errors.find((e) => e.startsWith("range m00050..m00060")) ?? "",
     /does not exist in this session/,
   );
+});
+
+test("first compress of a fresh session with foreign refs reports a new generation, not a prior compress (billion-context#387)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00050", endRef: "m00060", summary: "foreign" }],
+    messages,
+    state,
+    config: config({
+      compress: {
+        minCompressRange: 5000,
+        maxSummaryLength: 0,
+        minSummaryLength: 0,
+      },
+    }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.equal(result.result.errors.length, 2);
+  assert.match(
+    result.result.errors[0]!,
+    /None of the 1 requested range\(s\) resolved/,
+  );
+  assert.match(
+    result.result.errors[0]!,
+    /cannot come from an earlier compress in this session/,
+  );
+  assert.match(result.result.errors[0]!, /switching model or upstream/);
+  assert.match(result.result.errors[0]!, /native-compaction rebase/);
+  assert.match(
+    result.result.errors[0]!,
+    /\[diagnostics: session highest ref=m00003, unknown ranges in request=1\/1, session history=0 compression\(s\), 0 block\(s\)\]/,
+  );
+  assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
+  assert.match(result.result.errors[1]!, /does not exist in this session/);
+});
+
+test("refs from before a native-compaction rebase report a new generation with zeroed history (billion-context#387)", () => {
+  const core = createCore();
+  const oldState = createInitialState();
+  const oldMessages = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+    msg("c", "gamma"),
+    msg("d", "delta"),
+  ];
+  oldState.messageRefs = assignRefs(oldMessages, {
+    existing: oldState.messageRefs,
+    nextIndex: 1,
+  }).map;
+  const { state: afterOne } = core.applyCompression({
+    ranges: [{ startRef: "m00002", endRef: "m00003", summary: "s1" }],
+    messages: oldMessages,
+    state: oldState,
+    config: config(),
+  });
+  const { state: afterTwo } = core.applyCompression({
+    ranges: [{ startRef: "m00004", endRef: "m00005", summary: "s2" }],
+    messages: oldMessages,
+    state: afterOne,
+    config: config(),
+  });
+  assert.equal(afterTwo.stats.compressionCount, 2);
+
+  const rebased = createInitialState();
+  const freshMessages = [msg("u2", "new task"), msg("e", "epsilon")];
+  rebased.messageRefs = assignRefs(freshMessages, {
+    existing: rebased.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00004", endRef: "m00005", summary: "old refs" }],
+    messages: freshMessages,
+    state: rebased,
+    config: config({
+      compress: {
+        minCompressRange: 5000,
+        maxSummaryLength: 0,
+        minSummaryLength: 0,
+      },
+    }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.match(
+    result.result.errors[0]!,
+    /None of the 1 requested range\(s\) resolved/,
+  );
+  assert.match(result.result.errors[0]!, /native-compaction rebase/);
+  assert.match(result.result.errors[0]!, /refs restart at m00001/);
+  assert.match(
+    result.result.errors[0]!,
+    /\[diagnostics: session highest ref=m00002, unknown ranges in request=1\/1, session history=0 compression\(s\), 0 block\(s\)\]/,
+  );
+  assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
+});
+
+test("drifted message content dangles the old ref — reported as unanchorable, not already-compressed (billion-context#387)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+    msg("c", "gamma"),
+    msg("d", "delta"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const drifted = [
+    msg("u", "the task"),
+    msg("a", "alpha"),
+    msg("b", "beta"),
+    msg("c", "gamma"),
+    msg("d2", "delta (edited)"),
+  ];
+  state.messageRefs = assignRefs(drifted, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00004", endRef: "m00005", summary: "c and d" }],
+    messages: drifted,
+    state,
+    config: config({
+      compress: {
+        minCompressRange: 5000,
+        maxSummaryLength: 0,
+        minSummaryLength: 0,
+      },
+    }),
+  });
+
+  assert.equal(result.result.blocksCreated, 0);
+  assert.match(result.result.errors[0]!, /cannot be anchored/);
+  assert.match(result.result.errors[0]!, /no active block covers them/);
+  assert.match(result.result.errors[0]!, /leaving your old refs dangling/);
+  assert.match(
+    result.result.errors[0]!,
+    /\[diagnostics: session highest ref=m00006, unknown ranges in request=0\/1, session history=0 compression\(s\), 0 block\(s\)\]/,
+  );
+  assert.doesNotMatch(result.result.errors[0]!, /already compressed/);
+  assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
 });
 
 test("fresh small content without consumed ranges keeps the too-small message", () => {


### PR DESCRIPTION
## What

Fixes the factually-wrong batch-gate error from ranxianglei/billion-context#387: `your refs are stale: a prior compress renumbered the remaining refs`. The kernel has **no ref-renumbering mechanism** — refs are additive per-session snapshots (`assignRefs` never deletes; `applyCompression`/`prune` only change the message view; `rebuildRefIndex` rebuilds the reverse map from the forward one). The fabricated history made models self-doubt on a session's **first** compress (0 blocks, 0 compression history).

## Changes (src/compress.ts only + tests)

- **All-unknown branch** (`compress.ts` gate, ex-line 274): now states refs are per-session snapshots, assigned once at first render, and that **no compress reassigns them** — so unknown refs cannot come from an earlier compress in this session. Names the real causes: a previous session instance (switching model/upstream mid-conversation starts a fresh session whose refs restart at m00001), the generation before a native-compaction rebase (also resets to m00001), or a typo.
- **Consumed branch** (ex-line 276): splits into two truthful sub-cases —
  - **dangling refs** (ref exists in the map but its message is gone from the view and no active block covers it — content drift / filtered message): `cannot be anchored … leaving your old refs dangling`
  - **covered by active block(s) / stale block ref**: `already compressed … covered by active block(s) or the block ref(s) are stale (distilled or consumed)` + existing liveHint
- **Diagnostics field** on both stale branches (per the issue's ask): `[diagnostics: session highest ref=mNNNNN|none, unknown ranges in request=U/R, session history=N compression(s), M block(s)]` — lets the model tell "fresh generation restart" (high requested refs, zero history) from "consumed by block" at a glance.
- `renumber` no longer appears in any user-visible text; verified 0 occurrences in the built `dist/index.js`.

## Tests

- Updated the 2 gate tests that asserted the old wording.
- Added 3 category tests (issue acceptance: one per true cause):
  1. **model switch** — fresh session (0 blocks / 0 compressions), foreign refs → new-generation wording + zero-history diagnostics, no "prior compress" claim
  2. **rebase** — state with 2 compressions replaced by `createInitialState`, old refs → same branch, diagnostics show zeroed history (current generation, not the past)
  3. **content drift** — message id changes, old ref dangles → `cannot be anchored`, asserted NOT "already compressed"
- All new/updated tests assert `doesNotMatch /renumber/i` on the gate message.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 552/552 pass (baseline 549 + 3 new)
- `npm run build` — success; `grep -c renumber dist/index.js` → 0

## Coordination notes

- **Overlapping in-flight kernel work**: other agent sessions have uncommitted work in the shared kernel clone touching the same gate area (`src/compress.ts` gate messages, `src/boundaries.ts` consumed-reason split, ref reclamation in `src/refs.ts`/`src/sync.ts` for the ghost-ref issue). This PR is based on clean master and is self-contained; if that work lands first, expect a small rebase on `compress.ts` lines ~270-290.
- **Ref-reclamation interaction**: if the dead-ref reclamation PR ships, the all-unknown branch gains a fourth cause (drifted message whose old ref was released) — a one-line wording follow-up, flagged here so it isn't lost.