### PR TITLE
fix: reclaim dead message refs, reuse exhausted capacity, classify boundary failures (billion-context#386)

### DIFF
--- a/src/boundaries.ts
+++ b/src/boundaries.ts
@@ -35,28 +35,37 @@ export function parseBoundary(ref: string): ParsedBoundary | null {
   return null;
 }
 
+export type BoundaryFailureReason =
+  "consumed" | "generation-replaced" | "edit-drift";
+
 /**
  * Thrown when a boundary ref parses but cannot be anchored in the visible
  * context. `kind` distinguishes a ref that never existed ("unknown", e.g. a
- * typo or a ref from another session) from one that was consumed by an
- * existing block ("consumed", messages hidden by prune). `endpoint` names the
- * failing side of the range so callers can attribute the error precisely.
+ * typo or a ref from another session) from one whose content is gone
+ * ("consumed"). `reason` classifies the consumed case: "consumed" (an active
+ * block covers it — retry with the block ref), "generation-replaced" (the
+ * covering block was itself distilled/consumed — content no longer
+ * available), "edit-drift" (the message was edited or removed, changing its
+ * content id). `endpoint` names the failing side of the range.
  */
 export class BoundaryNotFoundError extends Error {
   readonly code = "BOUNDARY_NOT_FOUND";
   readonly kind: "unknown" | "consumed";
   readonly endpoint: "start" | "end";
+  readonly reason: BoundaryFailureReason | null;
 
   constructor(
     kind: "unknown" | "consumed",
     endpoint: "start" | "end",
     message: string,
+    reason: BoundaryFailureReason | null = null,
   ) {
     super(message);
     this.name = "BoundaryNotFoundError";
     this.code = "BOUNDARY_NOT_FOUND";
     this.kind = kind;
     this.endpoint = endpoint;
+    this.reason = reason;
   }
 }
 
@@ -172,7 +181,7 @@ function resolveAnchorIndex(
       throw new BoundaryNotFoundError(
         "unknown",
         endpoint,
-        `${label}="${boundary.raw}" does not exist in this session (typo or wrong session) — run acp_status for current refs.`,
+        `${label}="${boundary.raw}" does not exist in this session (typo, wrong session, or the message was edited/removed and its ref released) — run acp_status for current refs.`,
       );
     }
     const index = indexByMessageId.get(rawId);
@@ -186,10 +195,33 @@ function resolveAnchorIndex(
         snapped: `${label}="${boundary.raw}" refers to a message already compressed into an active block — anchored to the active block covering it instead.`,
       };
     }
+    const coveringActive = state.blocks.filter(
+      (block) => block.active && block.effectiveMessageIds.includes(rawId),
+    );
+    if (coveringActive.length > 0) {
+      throw new BoundaryNotFoundError(
+        "consumed",
+        endpoint,
+        `${label}="${boundary.raw}" is already compressed into active block(s) ${coveringActive.map((block) => block.blockId).join(", ")} — retry with the block ref(s) instead of the message ref.`,
+        "consumed",
+      );
+    }
+    const generationReplaced = state.blocks.some(
+      (block) => !block.active && block.effectiveMessageIds.includes(rawId),
+    );
+    if (generationReplaced) {
+      throw new BoundaryNotFoundError(
+        "consumed",
+        endpoint,
+        `${label}="${boundary.raw}" was compressed into a block that has since been distilled or consumed — its content is no longer available in this session; run acp_status for current refs.`,
+        "generation-replaced",
+      );
+    }
     throw new BoundaryNotFoundError(
       "consumed",
       endpoint,
-      `${label}="${boundary.raw}" not found in visible context (likely consumed by an existing block).`,
+      `${label}="${boundary.raw}" no longer exists — the message was edited or removed (its content id changed); run acp_status for current refs.`,
+      "edit-drift",
     );
   }
 
@@ -219,16 +251,26 @@ function resolveAnchorIndex(
     };
   }
   if (!block.active) {
+    const consumer = state.blocks.find(
+      (candidate) =>
+        candidate.active &&
+        candidate.directBlockIds.includes(block.blockId) &&
+        visibleBlockAnchor(candidate, indexByMessageId) !== null,
+    );
     throw new BoundaryNotFoundError(
       "consumed",
       endpoint,
-      `${label}="b${boundary.numericId}" not found in visible context (block distilled/consumed by a higher-tier block).`,
+      consumer
+        ? `${label}="b${boundary.numericId}" was consumed by ${consumer.blockId} (higher-tier block) — retry with ${consumer.blockId} instead.`
+        : `${label}="b${boundary.numericId}" is inactive (distilled or garbage-collected) and none of its content is visible in the current context — run acp_status for current refs.`,
+      "generation-replaced",
     );
   }
   throw new BoundaryNotFoundError(
     "consumed",
     endpoint,
-    `${label}="b${boundary.numericId}" is an active block but none of its content (raw messages or rendered summary) is visible in the current context — run acp_status to verify.`,
+    `${label}="b${boundary.numericId}" is an active block but none of its content (raw messages or rendered summary) is present in the current view — its messages were likely edited or removed (id drift); it will be deactivated on the next state sync. Run acp_status to verify.`,
+    "edit-drift",
   );
 }
 

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,4 +1,4 @@
-import { assignRefs, highestUsedIndex, indexToRef } from "./refs.js";
+import { assignRefs, highestUsedIndex, indexToRef, pruneDeadRefs } from "./refs.js";
 import { prune, isSummaryMessageId } from "./prune.js";
 import { syncBlocks } from "./sync.js";
 import { advanceSurvival, activeBlocks, blockById } from "./state.js";
@@ -165,7 +165,13 @@ export function createCore(ports: Ports = {}): CompressionCore {
   function applyCompression(
     input: ApplyCompressionInput,
   ): ApplyCompressionResult {
-    const state: CompressionState = cloneState(input.state);
+    // Sync against the caller's view before boundary resolution (a bare clone
+    // would keep stale state): deactivates drifted/orphaned blocks and prunes
+    // dead refs, so stale state can't hit "active block but none of its content visible".
+    const state: CompressionState = syncBlocks(
+      input.messages,
+      input.state,
+    ).state;
     const runId = allocateRunId(state);
     let blocksCreated = 0;
     let tokensCompressed = 0;
@@ -312,7 +318,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
           resolvableCount === 0 &&
           consumedRanges.length === 0 &&
           unknownCount > 0
-            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref is unknown to this session. Refs are per-session snapshots, assigned once when a message is first rendered; no compress reassigns them, so unknown refs cannot come from an earlier compress in this session. They come from a different generation: a previous session instance (switching model or upstream mid-conversation starts a fresh session whose refs restart at m00001), the generation before a native-compaction rebase (which also resets refs to m00001), or a typo. ${diagnostics} Run acp_status, then call the compress tool again using only the refs it reports.`
+            ? `None of the ${input.ranges.length} requested range(s) resolved — every ref is unknown to this session. Refs are per-session snapshots, assigned once when a message is first rendered; no compress reassigns them, so unknown refs cannot come from an earlier compress in this session. They come from a different generation: a previous session instance (switching model or upstream mid-conversation starts a fresh session whose refs restart at m00001), the generation before a native-compaction rebase (which also resets refs to m00001), a typo, or a message that was edited or removed (its old ref was released when the content id changed). ${diagnostics} Run acp_status, then call the compress tool again using only the refs it reports.`
             : consumedRanges.length > 0
               ? danglingRefs.length > 0
                 ? `Requested range(s) cannot be anchored (e.g. ${consumedRanges[0]!.startRef}..${consumedRanges[0]!.endRef}) — the refs exist in this session's ref map, but the messages they point to are no longer in the visible context and no active block covers them: the message content changed (or the message was filtered out of the view) and now carries a new ref, leaving your old refs dangling. ${diagnostics} Run acp_status, then call the compress tool again using only the refs it reports.`
@@ -504,9 +510,18 @@ const assignRefsNode: PipelineNode = {
     const protectedFn = hasProtection
       ? (m: CoreMessage) => isMessageProtected(m, ctx.config)
       : undefined;
+    // Prune before allocating: legacy state (pre-reclamation) or host-side
+    // drift can leave the map near MAX_INDEX — releasing dead slots first is
+    // what lets allocation reuse them instead of throwing capacity-exhausted.
+    const liveIds = new Set(io.messages.map((m) => m.id));
+    for (const block of io.state.blocks) {
+      if (!block.active) continue;
+      for (const id of block.effectiveMessageIds) liveIds.add(id);
+    }
+    const pruned = pruneDeadRefs(io.state.messageRefs, liveIds);
     const refResult = assignRefs(io.messages, {
-      existing: io.state.messageRefs,
-      nextIndex: highestUsedIndex(io.state.messageRefs) + 1,
+      existing: pruned.map,
+      nextIndex: highestUsedIndex(pruned.map) + 1,
       isProtected: protectedFn,
     });
     return { ...io, state: { ...io.state, messageRefs: refResult.map } };
@@ -1359,27 +1374,6 @@ function computeContextBreakdown(
     }
   }
   return { system, tool, summaries, code, text, total, growth };
-}
-
-function cloneState(state: CompressionState): CompressionState {
-  return {
-    blocks: state.blocks.map((block) => ({
-      ...block,
-      directMessageIds: [...block.directMessageIds],
-      effectiveMessageIds: [...block.effectiveMessageIds],
-      directBlockIds: [...block.directBlockIds],
-    })),
-    messageRefs: {
-      byRaw: { ...state.messageRefs.byRaw },
-      byRef: { ...state.messageRefs.byRef },
-    },
-    tokenSnapshot: { ...(state.tokenSnapshot ?? {}) },
-    nudge: { ...state.nudge, anchors: { ...state.nudge.anchors } },
-    stats: { ...state.stats },
-    absorbed: (state.absorbed ?? []).map((record) => ({ ...record })),
-    nextBlockId: state.nextBlockId,
-    nextRunId: state.nextRunId,
-  };
 }
 
 function scoreRelevance(block: CompressionBlock, terms: string[]): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   refToIndex,
   refForRaw,
   rawForRef,
+  pruneDeadRefs,
   BLOCKED_REF,
 } from "./refs.js";
 export {
@@ -43,6 +44,7 @@ export {
   visibleBlockAnchor,
   blockVisibleInRange,
 } from "./boundaries.js";
+export type { BoundaryFailureReason } from "./boundaries.js";
 export {
   defaultCountTokens,
   estimateTokensFast,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,6 +1,6 @@
 import { createCore } from "./compress.js";
 import { parseCompressArgs } from "./parse-compress-input.js";
-import { assignRefs, highestUsedIndex } from "./refs.js";
+import { assignRefs, highestUsedIndex, pruneDeadRefs } from "./refs.js";
 import { defaultCountTokens } from "./tokenize.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
@@ -30,9 +30,17 @@ export function rebuildCompressionState(
     ports: RebuildPorts = {},
 ): RebuildResult {
     const core = createCore({ countTokens: ports.countTokens ?? defaultCountTokens });
+    // Prune dead refs from the pre-fork state first: stale entries would pin
+    // the cursor (highestUsedIndex + 1) near MAX_INDEX.
+    const liveIds = new Set(messages.map((message) => message.id));
+    for (const block of state.blocks) {
+        if (!block.active) continue;
+        for (const id of block.effectiveMessageIds) liveIds.add(id);
+    }
+    const pruned = pruneDeadRefs(state.messageRefs, liveIds);
     const refResult = assignRefs(messages, {
-        existing: state.messageRefs,
-        nextIndex: highestUsedIndex(state.messageRefs) + 1,
+        existing: pruned.map,
+        nextIndex: highestUsedIndex(pruned.map) + 1,
     });
     let working: CompressionState = { ...state, messageRefs: refResult.map };
 

--- a/src/refs.ts
+++ b/src/refs.ts
@@ -87,17 +87,48 @@ function allocateFreeRef(
   map: MessageRefMap,
   start: number,
 ): { text: string; index: number } {
-  let candidate = Math.max(start, MIN_INDEX);
-  while (candidate <= MAX_INDEX) {
+  const from = Math.max(start, MIN_INDEX);
+  for (let candidate = from; candidate <= MAX_INDEX; candidate++) {
     const text = indexToRef(candidate);
     if (!map.byRef[text]) {
       return { text, index: candidate };
     }
-    candidate++;
+  }
+  // Forward scan exhausted — reclaim a freed low slot (pruneDeadRefs keeps
+  // the map bounded, so free slots appear only via reclamation).
+  for (let candidate = MIN_INDEX; candidate < from; candidate++) {
+    const text = indexToRef(candidate);
+    if (!map.byRef[text]) {
+      return { text, index: candidate };
+    }
   }
   throw new Error(
-    `ref capacity exhausted: cannot allocate beyond ${indexToRef(MAX_INDEX)}`,
+    `ref capacity exhausted: all ${MAX_INDEX} ref slots are occupied by live messages — nothing left to reclaim`,
   );
+}
+
+export interface PruneDeadRefsResult {
+  map: MessageRefMap;
+  pruned: number;
+}
+
+// Drop byRaw entries whose raw id is not in `liveIds`. Callers union the
+// current view with ids covered by ACTIVE blocks, so live block tombstones
+// survive while edit-drifted and distilled messages release their refs.
+export function pruneDeadRefs(
+  map: MessageRefMap,
+  liveIds: Set<string>,
+): PruneDeadRefsResult {
+  let pruned = 0;
+  const byRaw: Record<string, string> = {};
+  for (const [rawId, ref] of Object.entries(map.byRaw)) {
+    if (liveIds.has(rawId)) {
+      byRaw[rawId] = ref;
+      continue;
+    }
+    pruned++;
+  }
+  return { map: rebuildRefIndex({ byRaw, byRef: {} }), pruned };
 }
 
 export function rebuildRefIndex(map: MessageRefMap): MessageRefMap {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,3 +1,4 @@
+import { pruneDeadRefs } from "./refs.js";
 import { summaryMessageId } from "./prune.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
@@ -77,6 +78,18 @@ export function syncBlocks(
       deactivated.push(block.blockId);
     }
   }
+
+  // Reclaim dead refs AFTER the activity pass: live = current view ∪ ids
+  // covered by ACTIVE blocks only. Keeping tombstones of inactive (distilled
+  // or orphaned) blocks too would make the map grow with total session
+  // history instead of staying proportional to the live view.
+  const liveIds = new Set(presentIds);
+  for (const block of result.blocks) {
+    if (!block.active) continue;
+    for (const id of block.effectiveMessageIds) liveIds.add(id);
+  }
+  const prunedRefs = pruneDeadRefs(result.messageRefs, liveIds);
+  result.messageRefs = prunedRefs.map;
 
   return { state: result, deactivated };
 }

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -648,7 +648,7 @@ test("refs from before a native-compaction rebase report a new generation with z
   assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
 });
 
-test("drifted message content dangles the old ref — reported as unanchorable, not already-compressed (billion-context#387)", () => {
+test("drifted message content releases the old ref — reported as unknown (ref released), not already-compressed (billion-context#387)", () => {
   const core = createCore();
   const state = createInitialState();
   const messages = [
@@ -689,12 +689,13 @@ test("drifted message content dangles the old ref — reported as unanchorable, 
   });
 
   assert.equal(result.result.blocksCreated, 0);
-  assert.match(result.result.errors[0]!, /cannot be anchored/);
-  assert.match(result.result.errors[0]!, /no active block covers them/);
-  assert.match(result.result.errors[0]!, /leaving your old refs dangling/);
+  // #176: applyCompression syncs (prunes dead refs) before boundary resolution, so a
+  // drifted ref is released and reported as unknown — not the pre-#176 "dangling" branch.
+  assert.match(result.result.errors[0]!, /every ref is unknown to this session/);
+  assert.match(result.result.errors[0]!, /edited or removed/);
   assert.match(
     result.result.errors[0]!,
-    /\[diagnostics: session highest ref=m00006, unknown ranges in request=0\/1, session history=0 compression\(s\), 0 block\(s\)\]/,
+    /\[diagnostics: session highest ref=m00006, unknown ranges in request=1\/1, session history=0 compression\(s\), 0 block\(s\)\]/,
   );
   assert.doesNotMatch(result.result.errors[0]!, /already compressed/);
   assert.doesNotMatch(result.result.errors[0]!, /renumber/i);
@@ -1147,8 +1148,8 @@ test("gate error names the current active block span when anchors stay consumed"
       tier: 1,
       topic: "t",
       summary: "s2",
-      directMessageIds: ["a"],
-      effectiveMessageIds: ["a", "b"],
+      directMessageIds: ["gone1"],
+      effectiveMessageIds: ["gone1", "gone2"],
       directBlockIds: [],
       createdAt: 0,
       survivedCount: 0,

--- a/tests/ref-reclamation.test.ts
+++ b/tests/ref-reclamation.test.ts
@@ -1,0 +1,476 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import {
+  BLOCKED_REF,
+  assignRefs,
+  indexToRef,
+  pruneDeadRefs,
+  refToIndex,
+} from "../src/refs.js";
+import { syncBlocks } from "../src/sync.js";
+import { deactivateBlock } from "../src/decompress.js";
+import { BoundaryNotFoundError, resolveBoundaries } from "../src/boundaries.js";
+import type {
+  CompressionBlock,
+  CompressionState,
+  Config,
+  CoreMessage,
+  MessageRefMap,
+} from "../src/types.js";
+
+function msg(
+  id: string,
+  text: string,
+  role: CoreMessage["role"] = "user",
+): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    merge: { maxSummaryLength: 3000, minOldGenBlocks: 3 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+    ...overrides,
+  };
+}
+
+function block(
+  blockId: string,
+  summary: string,
+  overrides: Partial<CompressionBlock> = {},
+): CompressionBlock {
+  return {
+    blockId,
+    runId: "r1",
+    tier: 1,
+    summary,
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    compressedTokens: 100,
+    createdAt: 0,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+function boundaryError(
+  startRef: string,
+  endRef: string,
+  messages: CoreMessage[],
+  state: CompressionState,
+): BoundaryNotFoundError {
+  try {
+    resolveBoundaries({ startRef, endRef, messages, state });
+  } catch (error) {
+    if (error instanceof BoundaryNotFoundError) return error;
+    throw error;
+  }
+  throw new Error(`expected BoundaryNotFoundError for ${startRef}..${endRef}`);
+}
+
+test("pruneDeadRefs drops dead byRaw entries and rebuilds byRef", () => {
+  const map: MessageRefMap = {
+    byRaw: { a: "m00001", b: "m00002", c: "m00003" },
+    byRef: { m00001: "a", m00002: "b", m00003: "c" },
+  };
+  const { map: pruned, pruned: count } = pruneDeadRefs(
+    map,
+    new Set(["a", "c"]),
+  );
+  assert.deepEqual(pruned.byRaw, { a: "m00001", c: "m00003" });
+  assert.deepEqual(pruned.byRef, { m00001: "a", m00003: "c" });
+  assert.equal(count, 1);
+  assert.equal(map.byRaw.b, "m00002");
+});
+
+test("pruneDeadRefs drops dead BLOCKED entries (re-protected on reappear)", () => {
+  const map: MessageRefMap = {
+    byRaw: { p: BLOCKED_REF, q: "m00001" },
+    byRef: { m00001: "q" },
+  };
+  const { map: pruned, pruned: count } = pruneDeadRefs(map, new Set(["q"]));
+  assert.deepEqual(pruned.byRaw, { q: "m00001" });
+  assert.deepEqual(pruned.byRef, { m00001: "q" });
+  assert.equal(count, 1);
+});
+
+test("assignRefs reuses freed low slots when the cursor is past capacity", () => {
+  const existing: MessageRefMap = {
+    byRaw: { hi1: "m99998", hi2: "m99999" },
+    byRef: { m99998: "hi1", m99999: "hi2" },
+  };
+  const result = assignRefs([msg("new1", "x")], {
+    existing,
+    nextIndex: 100000,
+  });
+  assert.equal(result.map.byRaw.new1, "m00001");
+  assert.equal(result.newlyAssigned, 1);
+});
+
+test("assignRefs throws only when all 99999 slots are occupied", () => {
+  const byRaw: Record<string, string> = {};
+  const byRef: Record<string, string> = {};
+  for (let i = 1; i <= 99999; i++) {
+    const ref = indexToRef(i);
+    byRaw[`d${i}`] = ref;
+    byRef[ref] = `d${i}`;
+  }
+  assert.throws(
+    () =>
+      assignRefs([msg("x", "x")], {
+        existing: { byRaw, byRef },
+        nextIndex: 1,
+      }),
+    /ref capacity exhausted/,
+  );
+});
+
+test("syncBlocks releases refs of edit-drifted messages no block covers", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { old: "m00001", kept: "m00002", gone: "m00003" },
+    byRef: { m00001: "old", m00002: "kept", m00003: "gone" },
+  };
+  const view = [msg("edited", "old text v2"), msg("kept", "same")];
+  const { state: synced } = syncBlocks(view, state);
+  assert.deepEqual(synced.messageRefs.byRaw, { kept: "m00002" });
+  assert.deepEqual(synced.messageRefs.byRef, { m00002: "kept" });
+  assert.equal(state.messageRefs.byRaw.old, "m00001");
+});
+
+test("syncBlocks keeps refs of messages covered by ACTIVE blocks even when absent from view", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", y: "m00002", a: "m00003" },
+    byRef: { m00001: "x", m00002: "y", m00003: "a" },
+  };
+  state.blocks = [
+    block("b1", "s", {
+      directMessageIds: ["x", "y"],
+      effectiveMessageIds: ["x", "y"],
+    }),
+  ];
+  const { state: synced } = syncBlocks([msg("y", "y"), msg("a", "a")], state);
+  assert.equal(synced.blocks[0]!.active, true);
+  assert.deepEqual(synced.messageRefs.byRaw, {
+    x: "m00001",
+    y: "m00002",
+    a: "m00003",
+  });
+});
+
+test("syncBlocks deactivates orphaned active blocks and releases their refs", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", y: "m00002", a: "m00003" },
+    byRef: { m00001: "x", m00002: "y", m00003: "a" },
+  };
+  state.blocks = [
+    block("b1", "s", {
+      directMessageIds: ["x", "y"],
+      effectiveMessageIds: ["x", "y"],
+    }),
+  ];
+  const { state: synced, deactivated } = syncBlocks([msg("a", "a")], state);
+  assert.equal(synced.blocks[0]!.active, false);
+  assert.deepEqual(deactivated, ["b1"]);
+  assert.deepEqual(synced.messageRefs.byRaw, { a: "m00003" });
+});
+
+test("syncBlocks releases refs covered only by INACTIVE blocks (tombstones do not leak)", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", a: "m00002" },
+    byRef: { m00001: "x", m00002: "a" },
+  };
+  state.blocks = [
+    block("b1", "s", {
+      directMessageIds: ["x"],
+      effectiveMessageIds: ["x"],
+      active: false,
+    }),
+  ];
+  const { state: synced } = syncBlocks([msg("a", "a")], state);
+  assert.deepEqual(synced.messageRefs.byRaw, { a: "m00002" });
+});
+
+test("applyCompression deactivates orphaned active blocks before boundary resolution", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", y: "m00002", a: "m00003", b: "m00004" },
+    byRef: { m00001: "x", m00002: "y", m00003: "a", m00004: "b" },
+  };
+  state.blocks = [
+    block("b1", "old", {
+      directMessageIds: ["x", "y"],
+      effectiveMessageIds: ["x", "y"],
+    }),
+  ];
+  const view = [msg("a", "a"), msg("b", "b")];
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00003", endRef: "m00004", summary: "new" }],
+    messages: view,
+    state,
+    config: config(),
+  });
+  assert.deepEqual(result.result.errors, []);
+  assert.equal(result.result.blocksCreated, 1);
+  assert.equal(
+    result.state.blocks.find((b) => b.blockId === "b1")!.active,
+    false,
+  );
+  assert.equal(result.state.messageRefs.byRaw.x, undefined);
+  assert.equal(result.state.messageRefs.byRaw.y, undefined);
+});
+
+test("message ref into an orphaned block reports released ref, not 'active but invisible'", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", y: "m00002", a: "m00003" },
+    byRef: { m00001: "x", m00002: "y", m00003: "a" },
+  };
+  state.blocks = [
+    block("b1", "old", {
+      directMessageIds: ["x", "y"],
+      effectiveMessageIds: ["x", "y"],
+    }),
+  ];
+  const view = [msg("a", "a")];
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00002", summary: "retry" }],
+    messages: view,
+    state,
+    config: config(),
+  });
+  assert.equal(result.result.blocksCreated, 0);
+  assert.match(result.result.errors[0]!, /does not exist in this session/);
+  assert.doesNotMatch(
+    result.result.errors[0]!,
+    /active block but none of its content/,
+  );
+});
+
+test("block ref into an orphaned block reports consumed (inactive), not 'active but invisible'", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: { x: "m00001", y: "m00002", a: "m00003" },
+    byRef: { m00001: "x", m00002: "y", m00003: "a" },
+  };
+  state.blocks = [
+    block("b1", "old", {
+      directMessageIds: ["x", "y"],
+      effectiveMessageIds: ["x", "y"],
+    }),
+  ];
+  const view = [msg("a", "a")];
+  const { state: synced } = syncBlocks(view, state);
+  const error = boundaryError("b1", "m00003", view, synced);
+  assert.equal(error.kind, "consumed");
+  assert.equal(error.reason, "generation-replaced");
+  assert.match(error.message, /inactive \(distilled or garbage-collected\)/);
+});
+
+test("resolveBoundaries classifies consumed failures: consumed / generation-replaced / edit-drift", () => {
+  const state = createInitialState();
+  state.messageRefs = {
+    byRaw: {
+      a: "m00001",
+      covered: "m00002",
+      distilled: "m00003",
+      drifted: "m00004",
+    },
+    byRef: {
+      m00001: "a",
+      m00002: "covered",
+      m00003: "distilled",
+      m00004: "drifted",
+    },
+  };
+  state.blocks = [
+    block("b1", "s1", {
+      directMessageIds: ["covered"],
+      effectiveMessageIds: ["covered"],
+    }),
+    block("b2", "s2", {
+      directMessageIds: ["distilled"],
+      effectiveMessageIds: ["distilled"],
+      active: false,
+    }),
+  ];
+  const view = [msg("a", "a")];
+
+  const consumed = boundaryError("m00002", "m00001", view, state);
+  assert.equal(consumed.kind, "consumed");
+  assert.equal(consumed.reason, "consumed");
+  assert.match(
+    consumed.message,
+    /already compressed into active block\(s\) b1/,
+  );
+
+  const replaced = boundaryError("m00003", "m00001", view, state);
+  assert.equal(replaced.kind, "consumed");
+  assert.equal(replaced.reason, "generation-replaced");
+  assert.match(replaced.message, /distilled or consumed/);
+
+  const drifted = boundaryError("m00004", "m00001", view, state);
+  assert.equal(drifted.kind, "consumed");
+  assert.equal(drifted.reason, "edit-drift");
+  assert.match(drifted.message, /edited or removed/);
+
+  const unknown = boundaryError("m00099", "m00001", view, state);
+  assert.equal(unknown.kind, "unknown");
+  assert.equal(unknown.reason, null);
+  assert.match(unknown.message, /does not exist in this session/);
+});
+
+test("stress: 1200 mixed turns keep the ref map bounded (no monotonic leak)", () => {
+  const core = createCore();
+  let state = createInitialState();
+  const cfg = config();
+  const view: CoreMessage[] = [];
+  let seq = 0;
+  let maxByRaw = 0;
+
+  for (let turn = 1; turn <= 1200; turn++) {
+    if (view.length > 30) view.splice(0, 2);
+    if (turn % 3 === 0 && view.length > 4) {
+      const i = (turn * 7) % view.length;
+      const original = view[i]!;
+      view[i] = {
+        ...original,
+        id: `msg-${++seq}`,
+        text: `${original.text} edited`,
+      };
+    }
+    view.push({
+      id: `msg-${++seq}`,
+      role: "user",
+      contentType: "text",
+      text: `turn ${turn} ${"x".repeat(16 + (seq % 13))}`,
+    });
+
+    if (turn % 50 === 0 && view.length >= 8) {
+      const startRef = state.messageRefs.byRaw[view[0]!.id];
+      const endRef = state.messageRefs.byRaw[view[7]!.id];
+      if (startRef && endRef) {
+        const res = core.applyCompression({
+          ranges: [{ startRef, endRef, summary: `stress summary ${turn}` }],
+          messages: view,
+          state,
+          config: cfg,
+        });
+        state = res.state;
+      }
+    }
+
+    if (turn % 100 === 0) {
+      const active = state.blocks.filter((b) => b.active);
+      if (active.length > 0) {
+        const victim = active[0]!;
+        const victimIds = new Set(victim.effectiveMessageIds);
+        for (let i = view.length - 1; i >= 0; i--) {
+          if (victimIds.has(view[i]!.id)) view.splice(i, 1);
+        }
+        state = deactivateBlock(state, [victim.blockId]);
+      }
+    }
+
+    const result = core.processTurn({
+      messages: view,
+      state,
+      config: cfg,
+      tokenCount: 1000,
+      renderTags: "none",
+    });
+    state = result.state;
+
+    const activeIds = new Set<string>();
+    for (const b of state.blocks) {
+      if (b.active) for (const id of b.effectiveMessageIds) activeIds.add(id);
+    }
+    const bound = view.length + activeIds.size;
+    const byRawSize = Object.keys(state.messageRefs.byRaw).length;
+    assert.ok(
+      byRawSize <= bound,
+      `turn ${turn}: byRaw ${byRawSize} exceeds bound ${bound}`,
+    );
+    maxByRaw = Math.max(maxByRaw, byRawSize);
+  }
+
+  assert.ok(seq > 1500, `workload should churn many ids, created ${seq}`);
+  assert.ok(
+    maxByRaw <= 150,
+    `ref map should stay proportional to the live view, saw max ${maxByRaw}`,
+  );
+});
+
+test("near-capacity legacy state: dead refs reclaimed, refs reused, compression works", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const byRaw: Record<string, string> = {};
+  const byRef: Record<string, string> = {};
+  for (let i = 1; i <= 99999; i++) {
+    const ref = indexToRef(i);
+    byRaw[`dead-${i}`] = ref;
+    byRef[ref] = `dead-${i}`;
+  }
+  state.messageRefs = { byRaw, byRef };
+  const view = [
+    msg("live-1", "one"),
+    msg("live-2", "two"),
+    msg("live-3", "three"),
+  ];
+
+  const result = core.processTurn({
+    messages: view,
+    state,
+    config: config(),
+    tokenCount: 100,
+    renderTags: "none",
+  });
+  assert.equal(Object.keys(result.state.messageRefs.byRaw).length, 3);
+  for (const m of view) {
+    const ref = result.state.messageRefs.byRaw[m.id]!;
+    assert.ok(
+      (refToIndex(ref) ?? 0) <= 100,
+      `expected a low reused ref, got ${ref}`,
+    );
+  }
+
+  const refs = view.map((m) => result.state.messageRefs.byRaw[m.id]!);
+  const compressed = core.applyCompression({
+    ranges: [{ startRef: refs[0]!, endRef: refs[2]!, summary: "s" }],
+    messages: view,
+    state: result.state,
+    config: config(),
+  });
+  assert.deepEqual(compressed.result.errors, []);
+  assert.equal(compressed.result.blocksCreated, 1);
+});


### PR DESCRIPTION
## Root cause

`assignRefs` (refs.ts) allocates `highestUsedIndex(map)+1` forward and `allocateFreeRef` skips occupied slots, but **no path ever removed dead entries**: after a message is edited/truncated/deduplicated (content-hash id drift, `wire/message-id.ts`), its raw id stays in `byRaw`/`byRef` forever (`rebuildRefIndex` only rebuilds the reverse table). Consequences:

1. Refs grow monotonically toward the 99999 cap; past it `allocateFreeRef` throws `ref capacity exhausted`, which the host (bili `prepareAnthropic`) catches and forwards unchanged — **compression silently stalls for that request**, and the stall gets closer with every ghost entry.
2. `orphan-gc`/`deactivateBlock` deactivates blocks but their `effectiveMessageIds` mappings are kept → `boundaries.ts` "is an active block but none of its content is visible" — an unsolvable error for the model.

## Fix

- **`refs.ts`**
  - New exported `pruneDeadRefs(map, liveIds)` — pure; drops `byRaw` entries whose raw id is not live (incl. dead `BLOCKED_REF` entries, re-protected on reappear) and rebuilds `byRef`.
  - `allocateFreeRef`: when the forward scan from the cursor exhausts MAX_INDEX, fall back to scanning from MIN_INDEX (reclaim freed low slots). Throws only when **all 99999 slots are occupied by live messages** (impossible for a bounded view), with a message that says so.
- **`sync.ts` `syncBlocks`**: after the block-activity pass, prune refs to `liveIds = current view ∪ effectiveMessageIds of ACTIVE blocks`. Active-block ids are tombstones (their summary text may still reference them); inactive-block ids are released — so the map stays proportional to *view + active-block refs*, matching the issue's acceptance criterion, instead of total session history.
- **`compress.ts`**
  - `applyCompression` now starts from `syncBlocks(input.messages, input.state).state` instead of a bare clone (clone deleted). Drifted/orphaned blocks are deactivated and dead refs pruned **before** boundary resolution, so the "active block but none of its content is visible" error is unreachable in the normal flow — such blocks become inactive and the range is reported as consumed (skip + warning) instead of a hard error.
  - `assignRefsNode` prunes before allocating: a legacy near-full state (pre-reclamation persisted state) releases its dead slots first, so allocation reuses them instead of throwing capacity-exhausted.
- **`rebuild.ts` `rebuildCompressionState`**: same pre-allocation prune so pre-fork stale entries can't pin the cursor near MAX_INDEX.
- **`boundaries.ts`**: `BoundaryNotFoundError` gains `reason: "consumed" | "generation-replaced" | "edit-drift" | null` (additive; `kind` unchanged for API compat). The message-branch failures now classify into the three real causes: covered by an active block ("retry with the block ref"), covered only by inactive blocks (distilled/consumed), or no block (message edited/removed, ref released). The unknown-ref message mentions ref release. The active-block-invisible branch is rewritten as id-drift wording (next sync deactivates the block).
- **`index.ts`**: exports `pruneDeadRefs` and `BoundaryFailureReason`.

## Scope note

The stale-ref gate wording at `compress.ts:274/276` ("renumbers the remaining refs") is **deliberately untouched here** — it is owned by the sibling issue #387 PR (branch `2026-08-31_stale-ref-gate-truth`). Both PRs land independently; the billion-context dep bump should happen after both merge.

## Tests (14 new, tests/ref-reclamation.test.ts)

- `pruneDeadRefs`: dead byRaw/byRef both directions, BLOCKED entries, input not mutated
- `assignRefs`: reuse of freed low slots when cursor > MAX_INDEX; throw only with all-99999 occupied
- `syncBlocks`: edit-drift release; active-block tombstones kept when absent from view; orphaned active block deactivated + refs released; inactive-block-only refs released; input state not mutated
- `applyCompression`: orphaned active block deactivated before resolution (no "active but invisible"); message ref into it → "ref released" wording; block ref into it → consumed/generation-replaced
- `resolveBoundaries`: 3-way classification (consumed / generation-replaced / edit-drift) + unknown
- **Stress (acceptance #1)**: 1200 `processTurn` turns mixing appends + edits (id drift) + truncation + periodic `applyCompression` + periodic orphan-gc-style deactivation — per-turn invariant `byRaw size ≤ view + Σ active-block refs`, `maxByRaw ≤ 150` with >1500 distinct ids churned
- **Near-capacity (acceptance #2)**: 99999 dead entries + 3-message view → `processTurn` succeeds with no throw, refs reused at low indices, and a subsequent `applyCompression` on the range succeeds (no stall)

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 563/563 pass (549 existing + 14 new)
- `npm run build` — success

Per AGENTS.md, source changes require review by at least 2 separate agents before merge.