### PR TITLE
fix(search): wire core.search to the searchBlocks engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const { state: compressed, result } = core.applyCompression({
 });
 
 core.decompress("b3", compressed);            // look up a block
-core.search("auth token", compressed);        // relevance-ranked block search
+core.search("auth token", compressed);        // relevance-ranked search over active blocks (+ optional visible messages)
 core.status(compressed, tokenCount, config);  // context-usage report
 ```
 

--- a/src/compress-tools.ts
+++ b/src/compress-tools.ts
@@ -252,7 +252,7 @@ Since host tools cannot coexist with a declared tools field, ALL ACP tools use t
    ${ACP_STATUS_OPEN}${ACP_STATUS_CLOSE}
    No payload needed. Use this FIRST when unsure about context state.
 
-2. search_context — search compressed block summaries by keyword:
+2. search_context — search compressed block summaries and visible messages by keyword:
    ${ACP_SEARCH_OPEN}{"query":"auth token refresh"}${ACP_SEARCH_CLOSE}
    Use when you need details that may have been compressed away.
 
@@ -301,7 +301,7 @@ ACP TOOLS (FUNCTION CALLS)
 The proxy also provides these as real function tools you can call directly (they appear in your tool list). Call them like any other function; the proxy executes them and returns the result, then you continue.
 
 - acp_status — view context usage, compression state, and compressible ranges. No arguments. Use this FIRST when unsure about context state.
-- search_context — search compressed block summaries by keyword. Arguments: {"query":"...","limit":5}.
+- search_context — search compressed block summaries and visible messages by keyword. Arguments: {"query":"...","limit":5}.
 - decompress — restore compressed content for exact details. Arguments: {"blockId":"b5"} (optional "toFile":"/tmp/x.txt", "full":true).
 
 Note: compress is ONLY available via the text marker above (it needs batch ranges + an immediate stop), NOT as a function tool.`;
@@ -339,7 +339,7 @@ export const SEARCH_CONTEXT_TOOL_OPENAI = {
   function: {
     name: SEARCH_CONTEXT_TOOL_NAME,
     description:
-      "Search through compressed block summaries by keyword. Use BEFORE decompressing to find the right block.",
+      "Search through compressed block summaries and visible messages by keyword (BM25 + fuzzy, CJK-aware). Use BEFORE decompressing to find the right block or message.",
     parameters: {
       type: "object",
       properties: {

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -31,6 +31,8 @@ import {
   type PipelineNode,
   type NodeIO,
 } from "./pipeline.js";
+import { blockDocs, messageDocs, searchBlocks } from "./search/index.js";
+import type { MessageInput, SearchDoc, SearchResult } from "./search/types.js";
 import type {
   ApplyCompressionResult,
   CompressionBlock,
@@ -58,7 +60,11 @@ export interface CompressionCore {
     blockId: string,
     state: CompressionState,
   ): CompressionBlock | undefined;
-  search(query: string, state: CompressionState): CompressionBlock[];
+  search(
+    query: string,
+    state: CompressionState,
+    messages?: CoreMessage[],
+  ): SearchResult[];
   status(
     state: CompressionState,
     tokenCount: number,
@@ -381,17 +387,33 @@ export function createCore(ports: Ports = {}): CompressionCore {
     return blockById(state, blockId);
   }
 
-  function search(query: string, state: CompressionState): CompressionBlock[] {
-    const terms = query
-      .toLowerCase()
-      .split(/\s+/)
-      .filter((term) => term.length > 0);
-    if (terms.length === 0) return [];
-    const scored = activeBlocks(state)
-      .map((block) => ({ block, score: scoreRelevance(block, terms) }))
-      .filter((entry) => entry.score > 0.1)
-      .sort((left, right) => right.score - left.score);
-    return scored.map((entry) => entry.block);
+  function search(
+    query: string,
+    state: CompressionState,
+    messages?: CoreMessage[],
+  ): SearchResult[] {
+    // Active blocks only: content folded into a parent tier is reachable
+    // through the parent's summary — scoring both would double-count it.
+    const activeIds = new Set(activeBlocks(state).map((b) => b.blockId));
+    const docs: SearchDoc[] = blockDocs(state).filter((d) =>
+      activeIds.has(d.ref),
+    );
+    if (messages) {
+      const inputs: MessageInput[] = [];
+      for (const m of messages) {
+        const ref = state.messageRefs.byRaw[m.id];
+        const text = m.text ?? "";
+        if (!ref || !text) continue;
+        inputs.push({
+          ref,
+          role: m.role === "system" ? "assistant" : m.role,
+          text,
+          tokens: state.tokenSnapshot[ref],
+        });
+      }
+      docs.push(...messageDocs(inputs));
+    }
+    return searchBlocks(docs, query);
   }
 
   function status(
@@ -1337,30 +1359,6 @@ function cloneState(state: CompressionState): CompressionState {
     nextBlockId: state.nextBlockId,
     nextRunId: state.nextRunId,
   };
-}
-
-function scoreRelevance(block: CompressionBlock, terms: string[]): number {
-  const topic = (block.topic ?? "").toLowerCase();
-  const summary = block.summary.toLowerCase();
-  let score = 0;
-  for (const term of terms) {
-    const topicHits = countOccurrences(topic, term);
-    if (topicHits > 0) score += Math.min(topicHits * 0.15, 0.45);
-    const summaryHits = countOccurrences(summary, term);
-    if (summaryHits > 0) score += Math.min(summaryHits * 0.04, 0.2);
-  }
-  return Math.min(score, 1);
-}
-
-function countOccurrences(haystack: string, needle: string): number {
-  if (!haystack || !needle) return 0;
-  let count = 0;
-  let position = 0;
-  while ((position = haystack.indexOf(needle, position)) !== -1) {
-    count++;
-    position += needle.length;
-  }
-  return count;
 }
 
 export { createInitialState };

--- a/tests/compress.test.ts
+++ b/tests/compress.test.ts
@@ -231,8 +231,132 @@ test("search returns active blocks matching the query, ranked", () => {
   );
 
   const hits = core.search("auth token", state);
-  assert.equal(hits.length, 1);
+  assert.ok(hits.length >= 1);
   assert.equal(hits[0]!.blockId, "b1");
+});
+
+test("search: 0-block session with visible messages returns message hits", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "the auth token refresh flow uses jwt rotation"),
+    msg("b", "docker compose deployment notes"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const hits = core.search("auth token", state, messages);
+  assert.ok(hits.length >= 1, "visible messages must be searchable");
+  assert.equal(hits[0]!.kind, "message");
+  assert.equal(hits[0]!.ref, "m00001");
+});
+
+test("search: CJK query hits CJK block summary", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.blocks.push({
+    blockId: "b1",
+    runId: "r1",
+    tier: 1,
+    topic: "认证系统",
+    summary: "实现了登录和身份验证流程,使用 jwt 签发令牌",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    createdAt: 0,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+  });
+
+  const hits = core.search("身份验证", state);
+  assert.ok(hits.length >= 1, "CJK query must hit CJK summary");
+  assert.equal(hits[0]!.kind, "block");
+  assert.equal(hits[0]!.blockId, "b1");
+});
+
+test("search: CJK query hits CJK visible message", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "请帮我修复登录页面的身份验证错误"),
+    msg("b", "docker compose deployment notes"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const hits = core.search("身份验证", state, messages);
+  assert.ok(hits.length >= 1, "CJK query must hit CJK message");
+  assert.equal(hits[0]!.kind, "message");
+  assert.equal(hits[0]!.ref, "m00001");
+});
+
+test("search: a term appearing once in a summary passes the threshold", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.blocks.push({
+    blockId: "b1",
+    runId: "r1",
+    tier: 1,
+    topic: "deployment",
+    summary: "configured the postgres connection pool",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    createdAt: 0,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+  });
+
+  const hits = core.search("postgres", state);
+  assert.ok(hits.length >= 1, "single-occurrence term must pass");
+  assert.equal(hits[0]!.blockId, "b1");
+});
+
+test("search: inactive (folded) blocks are excluded from the corpus", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.blocks.push(
+    {
+      blockId: "b1",
+      runId: "r1",
+      tier: 1,
+      topic: "deployment",
+      summary: "docker compose",
+      directMessageIds: [],
+      effectiveMessageIds: [],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+    },
+    {
+      blockId: "b2",
+      runId: "r1",
+      tier: 1,
+      topic: "auth legacy",
+      summary: "auth token rotation",
+      directMessageIds: [],
+      effectiveMessageIds: [],
+      directBlockIds: [],
+      createdAt: 0,
+      survivedCount: 0,
+      generation: "young",
+      active: false,
+    },
+  );
+
+  const hits = core.search("auth token", state);
+  assert.ok(
+    hits.every((h) => h.blockId !== "b2"),
+    "inactive block must not be searchable",
+  );
 });
 
 test("GC is fully removed: createCore() exposes no gc method", () => {


### PR DESCRIPTION
## Fixes #178

`core.search` was disconnected from the published `src/search/` engine — it scored only active blocks with a naive substring scorer whose 0.1 filter line was unreachable for single-occurrence summary hits, had no CJK support, and never searched visible messages.

### Changes

- **Corpus**: active `blockDocs(state)` (inactive/folded blocks excluded — their content is reachable through the parent tier's summary) + optional `messageDocs(messages)`. `search(query, state, messages?)` — the 2-arg call stays backwards compatible.
- **Scoring**: hybrid BM25+fuzzy (the published default) with `minScore 0.01`. Real hits land ≈0.7–1.0; weak fuzzy recall ≈0.1–0.3. The old `scoreRelevance`/`countOccurrences` are deleted.
- **CJK**: works via the tokenizer (Intl.Segmenter + bigram fallback) — Chinese queries now hit Chinese summaries and messages.
- **Tool descriptions**: compress-tools.ts tool schema + text/hybrid system prompts now say "block summaries and visible messages", matching the implementation.

### API note

Return type changes from `CompressionBlock[]` to `SearchResult[]` (`{kind, ref, blockId?, tier, score, title, preview, role?, tokens?}`). In-process hosts (billion-context-pi, pai-acp) need a small adaptation — the block id is still available as `result.blockId` for `decompress`.

### Tests

5 new tests in tests/compress.test.ts:
- 0-block session with visible messages → message hit (acceptance: no more silent empty results)
- CJK query → CJK block summary hit
- CJK query → CJK visible message hit
- single-occurrence term in a summary passes the threshold
- inactive (folded) blocks excluded from the corpus

The one pre-existing search test's assertion was relaxed from `hits.length === 1` to a top-hit check: under hybrid scoring, weak fuzzy bigram overlap (e.g. "deployment docker compose" vs "auth token" via shared bigrams) legitimately surfaces at ≈0.1 ≥ minScore 0.01 — that is the engine's designed recall channel, same behavior as the proxy-side PR ranxianglei/billion-context#415.

### Checks

- `npm run typecheck` ✅
- `npm test` — 554 pass, 0 fail ✅
- `npm run build` ✅