### PR TITLE
release v0.0.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.47",
+    "version": "0.0.48",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.48 — includes:
- #175 stale-ref gate messages report true causes with diagnostics
- #176 reclaim dead message refs, reuse exhausted capacity, classify boundary failures (rebased onto #175)