### PR TITLE
fix(sync): keep host-expanded blocks deactivated across syncBlocks

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -65,6 +65,14 @@ export function syncBlocks(
       block.active = false;
       continue;
     }
+    // Host-set `expanded` = the user explicitly decompressed this block, so its
+    // deactivated state is intentional. Re-activating it here would re-fold the
+    // already-restored messages next turn (double cost + lost originals). Keep
+    // it inactive; a fresh compress of the same range creates a NEW block.
+    if (block.expanded) {
+      block.active = false;
+      continue;
+    }
     block.active = true;
     // A block whose raw messages were replaced by its rendered summary
     // (pruned view) is still present — the summary IS the block's visible

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,12 @@ export interface CompressionBlock {
   survivedCount: number;
   generation: BlockGeneration;
   active: boolean;
+  /** Host-set: the user explicitly decompressed (expanded) this block, so its
+   *  deactivated state is intentional and must survive syncBlocks re-activation.
+   *  Absent/false for blocks deactivated by other means (orphan GC, tier
+   *  distillation, consumed-by-parent) — those keep the legacy resurrection
+   *  behavior. */
+  expanded?: boolean;
   durationMs?: number;
   compressCallId?: string;
   startRef?: string;

--- a/tests/sync-config.test.ts
+++ b/tests/sync-config.test.ts
@@ -50,6 +50,25 @@ test("syncBlocks leaves blocks intact when at least one message remains", () => 
   assert.equal(result.state.blocks[0]!.active, true);
 });
 
+test("syncBlocks keeps expanded (user-decompressed) blocks deactivated when present", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["a", "b"], active: false, expanded: true }),
+  );
+  const result = syncBlocks([msg("a"), msg("b")], state);
+  assert.equal(result.state.blocks[0]!.active, false, "expanded block must stay deactivated");
+  assert.deepEqual(result.deactivated, [], "expanded block is not reported as orphaned");
+});
+
+test("syncBlocks re-activates a deactivated (non-expanded) block when its messages return", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["a", "b"], active: false }),
+  );
+  const result = syncBlocks([msg("a"), msg("b")], state);
+  assert.equal(result.state.blocks[0]!.active, true, "legacy resurrection preserved for non-expanded blocks");
+});
+
 test("syncBlocks does not mutate input state", () => {
   const state = createInitialState();
   state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["x"] }));


### PR DESCRIPTION
## Problem

A block the host explicitly **decompressed** (`expanded`) was unconditionally re-activated by `syncBlocks` on the next turn: the client re-sends its full history, so the block's raw ids / summary id are present, and `syncBlocks` set `block.active = true` for every non-consumed block. This silently **re-folded the already-restored messages** — the model paid for the summary *and* the restored full text in the same round, and (with the host's content cache already deleted) a second `decompress` permanently degraded to the summary.

Root cause: the "user expanded this" intent had **no persistent trace** in the kernel — `deactivateBlock()` was wiped on the next `processTurn`.

## Fix

- `types.ts`: add `CompressionBlock.expanded?: boolean` — host-set, meaning "the user explicitly decompressed this block, so its deactivated state is intentional".
- `sync.ts`: in the activity pass, skip re-activation for `expanded` blocks (keep `active = false`). Blocks deactivated by other means (orphan GC, tier distillation, consumed-by-parent) keep the legacy resurrection behavior — the flag is the only thing that changes.
- `tests/sync-config.test.ts`: two cases — an expanded+deactivated block stays deactivated when its messages are present (and is not reported as orphaned); a non-expanded deactivated block is re-activated (legacy behavior preserved).

Back-compat: `expanded` is optional and defaults to absent/false, so existing persisted states are unaffected.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 568 pass, 0 fail
- `npm run build` — success

This is a content PR. A follow-up release PR (v0.0.49) will be cut from master once this lands, per the release workflow.