### PR TITLE
feat: add session handoff renderer (renderHandoff/renderMessage/matchSession)

### DIFF
--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -1,0 +1,83 @@
+import { prune } from "./prune.js";
+import type { CompressionState, CoreMessage } from "./types.js";
+
+export interface HandoffMeta {
+  title?: string;
+  label?: string;
+  sessionId: string;
+  contextTokens?: number;
+  extraBullets?: string[];
+}
+
+export interface HandoffInput {
+  coreMessages: CoreMessage[];
+  state: CompressionState;
+  full: boolean;
+  meta: HandoffMeta;
+}
+
+export function renderMessage(m: CoreMessage): string {
+  const parts: string[] = [];
+  switch (m.contentType) {
+    case "text":
+      parts.push(m.text ?? "");
+      break;
+    case "tool-call":
+      parts.push(`\`${m.toolName ?? "?"}(${m.toolCallId ?? ""})\` args: ${m.text ?? ""}`);
+      break;
+    case "tool-result":
+      parts.push(`\`${m.toolName ?? "?"}(${m.toolCallId ?? ""})\` → ${m.text ?? ""}`);
+      break;
+    case "reasoning":
+      parts.push(`_reasoning_: ${m.text ?? ""}`);
+      break;
+  }
+  const body = parts.join("\n").trim();
+  return body === "" ? "_(empty)_" : body + "\n";
+}
+
+export function renderHandoff(input: HandoffInput): string {
+  const { coreMessages, state, full, meta } = input;
+  const lines: string[] = [];
+  lines.push("# billion-context session handoff");
+  lines.push("");
+  lines.push(`- title: ${meta.title ?? "(untitled)"}`);
+  if (meta.label) lines.push(`- label: ${meta.label}`);
+  lines.push(`- session id: ${meta.sessionId}`);
+  for (const bullet of meta.extraBullets ?? []) lines.push(bullet);
+  if (meta.contextTokens) lines.push(`- last context tokens: ~${meta.contextTokens}`);
+  lines.push(`- compression blocks: ${state.blocks.length} (active ${state.blocks.filter((b) => b.active).length})`);
+  lines.push("");
+  const view = full ? coreMessages : prune(coreMessages, state);
+  lines.push(full
+    ? `## Full conversation (${coreMessages.length} messages)`
+    : `## Conversation (folded view as the model saw it, ${coreMessages.length} client messages)`);
+  lines.push("");
+  if (view.length === 0) {
+    lines.push("No conversation messages to export.");
+    lines.push("");
+  }
+  let lastRole = "";
+  for (const m of view) {
+    if (m.role !== lastRole) {
+      lines.push(`### ${m.role}`);
+      lines.push("");
+      lastRole = m.role;
+    }
+    lines.push(renderMessage(m));
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function matchSession<T extends { id: string }>(
+  sessions: T[],
+  selector: string,
+  labelOf: (s: T) => string | undefined,
+): T[] {
+  const exact = sessions.filter((s) => s.id === selector);
+  if (exact.length > 0) return exact;
+  const byLabel = sessions.filter((s) => labelOf(s) === selector);
+  if (byLabel.length > 0) return byLabel;
+  return sessions.filter((s) => s.id.startsWith(selector) || (labelOf(s) ?? "").startsWith(selector));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,8 @@ export type {
 } from "./decompress.js";
 export { buildStatusReport, buildRecap } from "./report.js";
 export type { StatusReportOptions } from "./report.js";
+export { renderHandoff, renderMessage, matchSession } from "./handoff.js";
+export type { HandoffInput, HandoffMeta } from "./handoff.js";
 export { hideConsumedCompressCalls } from "./hide-consumed.js";
 export type { HideConsumedResult } from "./hide-consumed.js";
 export {

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createInitialState } from "../src/state.js";
+import { renderHandoff, renderMessage, matchSession } from "../src/handoff.js";
+import type { CompressionBlock, CompressionState, CoreMessage } from "../src/types.js";
+
+function msg(id: string, role: CoreMessage["role"] = "user", text: string = id): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function makeBlock(overrides: Partial<CompressionBlock> & { blockId: string }): CompressionBlock {
+  return {
+    runId: "r1",
+    tier: 1,
+    summary: "summary",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    createdAt: 0,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+test("renderMessage renders each content type", () => {
+  assert.equal(renderMessage({ id: "a", role: "user", contentType: "text", text: "hello" }), "hello\n");
+  assert.equal(
+    renderMessage({ id: "b", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "t1", text: "ls" }),
+    "`bash(t1)` args: ls\n",
+  );
+  assert.equal(
+    renderMessage({ id: "c", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "t1", text: "ok" }),
+    "`bash(t1)` → ok\n",
+  );
+  assert.equal(
+    renderMessage({ id: "d", role: "assistant", contentType: "reasoning", text: "thinking" }),
+    "_reasoning_: thinking\n",
+  );
+  assert.equal(renderMessage({ id: "e", role: "user", contentType: "text", text: "" }), "_(empty)_");
+});
+
+test("renderHandoff full view shows every original message", () => {
+  const messages = [msg("m1", "user", "hello"), msg("m2", "assistant", "world")];
+  const state = createInitialState();
+  const out = renderHandoff({ coreMessages: messages, state, full: true, meta: { sessionId: "s1", title: "T" } });
+  assert.match(out, /## Full conversation \(2 messages\)/);
+  assert.match(out, /### user/);
+  assert.match(out, /hello/);
+  assert.match(out, /### assistant/);
+  assert.match(out, /world/);
+});
+
+test("renderHandoff folded view injects the block summary and drops the covered message", () => {
+  const messages = [msg("m1", "user", "hello"), msg("m2", "user", "secret-covered"), msg("m3", "assistant", "hi")];
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", summary: "COVERED SUMMARY", effectiveMessageIds: ["m2"] }));
+  const folded = renderHandoff({ coreMessages: messages, state, full: false, meta: { sessionId: "s1" } });
+  assert.match(folded, /## Conversation \(folded view as the model saw it, 3 client messages\)/);
+  assert.match(folded, /COVERED SUMMARY/);
+  assert.doesNotMatch(folded, /secret-covered/);
+  assert.match(folded, /hello/);
+  assert.match(folded, /hi/);
+  const full = renderHandoff({ coreMessages: messages, state, full: true, meta: { sessionId: "s1" } });
+  assert.match(full, /secret-covered/);
+});
+
+test("renderHandoff renders metadata bullets in order and omits optionals", () => {
+  const messages = [msg("m1", "user", "hi")];
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", summary: "s", effectiveMessageIds: [] }));
+  state.blocks.push(makeBlock({ blockId: "b2", summary: "s", effectiveMessageIds: [], active: false }));
+  const out = renderHandoff({
+    coreMessages: messages,
+    state,
+    full: true,
+    meta: { sessionId: "abc", title: "My Title", label: "my-label", contextTokens: 1234, extraBullets: ["- requests: 7"] },
+  });
+  assert.match(out, /- title: My Title/);
+  assert.match(out, /- label: my-label/);
+  assert.match(out, /- session id: abc/);
+  assert.match(out, /- requests: 7/);
+  assert.match(out, /- last context tokens: ~1234/);
+  assert.match(out, /- compression blocks: 2 \(active 1\)/);
+  const idxTitle = out.indexOf("- title:");
+  const idxLabel = out.indexOf("- label:");
+  const idxId = out.indexOf("- session id:");
+  const idxReq = out.indexOf("- requests:");
+  const idxTok = out.indexOf("- last context tokens:");
+  const idxBlocks = out.indexOf("- compression blocks:");
+  assert.ok(idxTitle < idxLabel && idxLabel < idxId && idxId < idxReq && idxReq < idxTok && idxTok < idxBlocks);
+  const noOptional = renderHandoff({ coreMessages: messages, state, full: true, meta: { sessionId: "abc" } });
+  assert.doesNotMatch(noOptional, /- label:/);
+  assert.doesNotMatch(noOptional, /- last context tokens:/);
+  assert.match(noOptional, /- title: \(untitled\)/);
+});
+
+test("renderHandoff empty conversation shows a placeholder", () => {
+  const out = renderHandoff({ coreMessages: [], state: createInitialState(), full: true, meta: { sessionId: "s" } });
+  assert.match(out, /No conversation messages to export\./);
+});
+
+test("matchSession matches by exact id, label, and prefix", () => {
+  const sessions = [
+    { id: "sess-aaa-111", label: "alpha" },
+    { id: "sess-bbb-222", label: "beta" },
+  ];
+  const labelOf = (s: { id: string; label?: string }) => s.label;
+  assert.deepEqual(matchSession(sessions, "sess-aaa-111", labelOf).map((s) => s.id), ["sess-aaa-111"]);
+  assert.deepEqual(matchSession(sessions, "beta", labelOf).map((s) => s.id), ["sess-bbb-222"]);
+  assert.deepEqual(matchSession(sessions, "sess-aaa", labelOf).map((s) => s.id), ["sess-aaa-111"]);
+  assert.deepEqual(matchSession(sessions, "alpha", labelOf).map((s) => s.id), ["sess-aaa-111"]);
+  assert.deepEqual(matchSession(sessions, "sess", labelOf).map((s) => s.id), ["sess-aaa-111", "sess-bbb-222"]);
+  assert.deepEqual(matchSession(sessions, "nope", labelOf), []);
+});

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createInitialState } from "../src/state.js";
 import { renderHandoff, renderMessage, matchSession } from "../src/handoff.js";
-import type { CompressionBlock, CompressionState, CoreMessage } from "../src/types.js";
+import type { CompressionBlock, CoreMessage } from "../src/types.js";
 
 function msg(id: string, role: CoreMessage["role"] = "user", text: string = id): CoreMessage {
   return { id, role, contentType: "text", text };
@@ -16,6 +16,7 @@ function makeBlock(overrides: Partial<CompressionBlock> & { blockId: string }): 
     directMessageIds: [],
     effectiveMessageIds: [],
     directBlockIds: [],
+    compressedTokens: 0,
     createdAt: 0,
     survivedCount: 0,
     generation: "young",
@@ -39,6 +40,8 @@ test("renderMessage renders each content type", () => {
     "_reasoning_: thinking\n",
   );
   assert.equal(renderMessage({ id: "e", role: "user", contentType: "text", text: "" }), "_(empty)_");
+  assert.equal(renderMessage({ id: "f", role: "assistant", contentType: "tool-call" }), "`?()` args:\n");
+  assert.equal(renderMessage({ id: "g", role: "tool", contentType: "tool-result", toolName: "bash" }), "`bash()` →\n");
 });
 
 test("renderHandoff full view shows every original message", () => {
@@ -94,6 +97,8 @@ test("renderHandoff renders metadata bullets in order and omits optionals", () =
   assert.doesNotMatch(noOptional, /- label:/);
   assert.doesNotMatch(noOptional, /- last context tokens:/);
   assert.match(noOptional, /- title: \(untitled\)/);
+  const zeroTokens = renderHandoff({ coreMessages: messages, state, full: true, meta: { sessionId: "abc", contextTokens: 0 } });
+  assert.doesNotMatch(zeroTokens, /- last context tokens:/);
 });
 
 test("renderHandoff empty conversation shows a placeholder", () => {
@@ -111,6 +116,7 @@ test("matchSession matches by exact id, label, and prefix", () => {
   assert.deepEqual(matchSession(sessions, "beta", labelOf).map((s) => s.id), ["sess-bbb-222"]);
   assert.deepEqual(matchSession(sessions, "sess-aaa", labelOf).map((s) => s.id), ["sess-aaa-111"]);
   assert.deepEqual(matchSession(sessions, "alpha", labelOf).map((s) => s.id), ["sess-aaa-111"]);
+  assert.deepEqual(matchSession(sessions, "alp", labelOf).map((s) => s.id), ["sess-aaa-111"]);
   assert.deepEqual(matchSession(sessions, "sess", labelOf).map((s) => s.id), ["sess-aaa-111", "sess-bbb-222"]);
   assert.deepEqual(matchSession(sessions, "nope", labelOf), []);
 });


### PR DESCRIPTION
## What
Extracts the session-handoff markdown rendering shared by the `billion-context` proxy and the `billion-context-pi` adapter into the kernel, so both adapters can delegate instead of duplicating the logic (requested in ranxianglei/billion-context-pi#271).

## Changes
- **New** `src/handoff.ts`:
  - `renderHandoff({ coreMessages, state, full, meta })` — metadata header + folded (`prune`) or full conversation grouped by role. Host-specific bullets (protocol / upstream / requests / messages) are injected via `meta.extraBullets`; the folded-view header reports the original client-message count.
  - `renderMessage` — per-message formatting (text / tool-call / tool-result / reasoning), byte-compatible with the existing proxy + Pi renderers.
  - `matchSession(sessions, selector, labelOf)` — exact id, then label, then prefix.
- `src/index.ts` — re-export the three functions + `HandoffInput` / `HandoffMeta` types.
- **New** `tests/handoff.test.ts` — 6 tests (renderMessage types, full vs folded, metadata order, empty view, matchSession).

## Verification
- `npm run typecheck` — clean
- `npm test` — 572 pass, 0 fail (6 new)
- `npm run build` — success; new exports present in `dist/index.d.ts`

## Notes
- No version bump (release-branch-only per AGENTS.md). Downstream adapters will pin the next release (`0.0.49`) and are validated locally against this branch's build.
- The proxy keeps its v2 fallback (block summaries + `blockContents`) — only the `lastMessages` path delegates to the kernel.