### PR TITLE
release v0.0.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.48",
+    "version": "0.0.49",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Changes since v0.0.48

- **feat: session handoff renderer** (#183) — new `renderHandoff({coreMessages, state, full, meta})`, `renderMessage(m)`, and `matchSession(sessions, selector, labelOf)` (+ `HandoffInput` / `HandoffMeta` types). Shared by the `billion-context` proxy and the `billion-context-pi` adapter to render the `/export` session-handoff markdown without duplicating the logic. Host differences are injected via `meta.extraBullets`.

## Verification

- `npm run typecheck` — clean
- `npm test` — 572 pass, 0 fail
- `npm run build` — success

## Downstream

Unblocks (both pin acp-kernel 0.0.49):
- billion-context-pi#272
- billion-context#434

After merge + publish, run `npm install` in each adapter to refresh the lockfile.