### PR TITLE
feat: StateStore.loadAll({ maxParseBytes }) — stat-only parse budget for sub-linear startup

### DIFF
--- a/src/persist/index.ts
+++ b/src/persist/index.ts
@@ -14,5 +14,5 @@
  * - the store never deletes files; cleanup is a downstream decision
  */
 export { StateStore, flatFileNameFor } from "./store.js";
-export type { PersistedEnvelope, PersistLogger, StateStoreOptions } from "./store.js";
+export type { LoadAllOptions, PersistedEnvelope, PersistLogger, StateStoreOptions } from "./store.js";
 export { mergeCompressionState } from "./state-merge.js";

--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -88,6 +88,26 @@ export interface StateStoreOptions<T> {
     retryMaxMs?: number;
 }
 
+/** Options for {@link StateStore.loadAll}. */
+export interface LoadAllOptions {
+    /**
+     * Cap on the total bytes of record files loadAll will read and parse.
+     * When set, loadAll does a stat-only pass first (readdir + stat, no
+     * content reads), groups each canonical file with its `.fb.json` spill
+     * variant (same id ⇒ all-or-nothing, so the pair's freshest-wins
+     * reconciliation always sees both sides), then includes groups
+     * newest-mtime-first while the running total stays within the budget.
+     * Excluded groups are left on disk untouched (the store never deletes)
+     * and stay individually reachable via loadSync(id, hint). If no group
+     * fits, the result is an empty map (a warning is logged) — the budget
+     * is a hard cap, so one oversized record can never blow past it. Group
+     * freshness uses file mtime as a stat-level proxy for the in-envelope
+     * savedAt; ordering among parsed records still comes from savedAt
+     * reconciliation. Omitted ⇒ parse every record (default, unchanged).
+     */
+    maxParseBytes?: number;
+}
+
 /**
  * Crash-safe, debounce-coalescing JSON state store. Mechanism only — lifted
  * from billion-context's proxy SessionStore and generalized:
@@ -288,11 +308,18 @@ export class StateStore<T> {
     /** Load every record under dir. Populates the discovery map (enables
      *  loadSync for namespaced relPaths). Skips corrupt files, `.tmp-*`
      *  orphans, and records whose filename does not match their id — one
-     *  bad file never blocks boot. Never throws. */
-    async loadAll(): Promise<Map<string, PersistedEnvelope<T>>> {
+     *  bad file never blocks boot. Never throws.
+     *
+     * With `options.maxParseBytes`, parsing is budget-limited via a stat-only
+     * preselection pass (see {@link LoadAllOptions.maxParseBytes}); skipped
+     * records are not deleted and remain loadable via loadSync(id, hint). */
+    async loadAll(options?: LoadAllOptions): Promise<Map<string, PersistedEnvelope<T>>> {
         const out = new Map<string, PersistedEnvelope<T>>();
         if (!this.enabled) return out;
-        const files = await this.walkJsonFiles(this.dir);
+        const files =
+            options?.maxParseBytes == null
+                ? await this.walkJsonFiles(this.dir)
+                : await this.selectWithinBudget(options.maxParseBytes);
         for (const file of files) {
             const envelope = this.readEnvelope(file);
             if (!envelope) continue;
@@ -572,6 +599,63 @@ export class StateStore<T> {
             }
         }
         return out;
+    }
+
+    /** Stat-only preselection for budgeted loadAll: pairs each canonical
+     *  file with its `.fb.json` spill under a dir+stem key (identical stems
+     *  in different directories are different records), sums group sizes,
+     *  and fills the budget newest-mtime-first. Never reads file content. */
+    private async selectWithinBudget(budget: number): Promise<string[]> {
+        if (!Number.isFinite(budget) || budget < 0) {
+            throw new TypeError(
+                `maxParseBytes must be a finite non-negative number, got ${String(budget)}`,
+            );
+        }
+        const entries = await Promise.all(
+            (await this.walkJsonFiles(this.dir)).map(async (file) => {
+                try {
+                    const st = await fsp.stat(file);
+                    return { file, size: st.size, mtimeMs: st.mtimeMs };
+                } catch {
+                    return null; // vanished or unreadable between walk and stat
+                }
+            }),
+        );
+        const groups = new Map<string, { key: string; files: string[]; size: number; mtimeMs: number }>();
+        for (const e of entries) {
+            if (!e) continue;
+            const base = path.basename(e.file);
+            const stem = base.endsWith(".fb.json")
+                ? base.slice(0, -".fb.json".length)
+                : base.slice(0, -".json".length);
+            const key = `${path.dirname(e.file)}\u0000${stem}`;
+            const g = groups.get(key) ?? { key, files: [], size: 0, mtimeMs: 0 };
+            g.files.push(e.file);
+            g.size += e.size;
+            g.mtimeMs = Math.max(g.mtimeMs, e.mtimeMs);
+            groups.set(key, g);
+        }
+        const ordered = [...groups.values()].sort(
+            (a, b) => b.mtimeMs - a.mtimeMs || b.size - a.size || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0),
+        );
+        const selected: string[] = [];
+        let used = 0;
+        let skipped = 0;
+        for (const g of ordered) {
+            if (used + g.size > budget) {
+                skipped++;
+                continue;
+            }
+            selected.push(...g.files);
+            used += g.size;
+        }
+        if (skipped > 0) {
+            this.log(
+                "warn",
+                `[persist] loadAll budget ${budget} bytes: parsed ${ordered.length - skipped}/${ordered.length} record groups (skipped ${skipped})`,
+            );
+        }
+        return selected;
     }
 }
 

--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -97,7 +97,10 @@ export interface LoadAllOptions {
      * variant (same id ⇒ all-or-nothing, so the pair's freshest-wins
      * reconciliation always sees both sides), then includes groups
      * newest-mtime-first while the running total stays within the budget.
-     * Excluded groups are left on disk untouched (the store never deletes)
+     * A group that does not fit is skipped individually and selection
+     * continues with older groups — the byte cap is hard even when the
+     * newest group alone exceeds it; only if NO group fits is the result
+     * empty. Excluded groups are left on disk untouched (the store never deletes)
      * and stay individually reachable via loadSync(id, hint). If no group
      * fits, the result is an empty map (a warning is logged) — the budget
      * is a hard cap, so one oversized record can never blow past it. Group
@@ -308,11 +311,13 @@ export class StateStore<T> {
     /** Load every record under dir. Populates the discovery map (enables
      *  loadSync for namespaced relPaths). Skips corrupt files, `.tmp-*`
      *  orphans, and records whose filename does not match their id — one
-     *  bad file never blocks boot. Never throws.
+     *  bad file never blocks boot; filesystem and record problems never
+     *  throw. An invalid `maxParseBytes` (non-finite or negative) throws
+     *  TypeError fail-fast instead.
      *
      * With `options.maxParseBytes`, parsing is budget-limited via a stat-only
-     * preselection pass (see {@link LoadAllOptions.maxParseBytes}); skipped
-     * records are not deleted and remain loadable via loadSync(id, hint). */
+     *  preselection pass (see {@link LoadAllOptions.maxParseBytes}); skipped
+     *  records are not deleted and remain loadable via loadSync(id, hint). */
     async loadAll(options?: LoadAllOptions): Promise<Map<string, PersistedEnvelope<T>>> {
         const out = new Map<string, PersistedEnvelope<T>>();
         if (!this.enabled) return out;

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -653,6 +653,102 @@ test("flushSync retries use a fresh temp name per attempt (no tombstoned reuse)"
         assert.ok(written.some((p) => p.endsWith(".fb.json")), "spill file written");
     } finally {
         t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function writeRawRecord(dir: string, id: string, opts: { name?: string; savedAt?: number; mtimeSec?: number; pad?: number } = {}): string {
+    const file = path.join(dir, opts.name ?? flatFileNameFor(id));
+    mkdirSync(path.dirname(file), { recursive: true });
+    const payload: Record<string, unknown> = { label: id, count: 0 };
+    if (opts.pad !== undefined) payload.pad = "x".repeat(opts.pad);
+    writeFileSync(file, JSON.stringify({ version: 1, savedAt: opts.savedAt ?? 1_000_000, id, payload }), "utf8");
+    if (opts.mtimeSec !== undefined) fs.utimesSync(file, opts.mtimeSec, opts.mtimeSec);
+    return file;
+}
+
+test("loadAll maxParseBytes parses only the newest records within the budget", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        ["old-1", "mid-1", "mid-2", "new-1"].forEach((id, i) =>
+            writeRawRecord(dir, id, { pad: 1000, mtimeSec: 1000 + i * 100 }),
+        );
+        const size = fs.statSync(path.join(dir, flatFileNameFor("old-1"))).size;
+        const out = await s.loadAll({ maxParseBytes: 2 * size + 1 });
+        assert.deepEqual([...out.keys()].sort(), ["mid-2", "new-1"]);
+        // Without a budget the behavior is unchanged: everything parses.
+        assert.equal((await s.loadAll()).size, 4);
+        // Skipped records are not deleted and stay directly loadable.
+        assert.ok(existsSync(path.join(dir, flatFileNameFor("old-1"))), "skipped file stays on disk");
+        assert.equal(s.loadSync("old-1")?.payload.label, "old-1");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll budget treats a canonical file and its spill as one all-or-nothing unit", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        writeRawRecord(dir, "dup-id", { savedAt: 100, mtimeSec: 3000, pad: 500 });
+        writeRawRecord(dir, "dup-id", { name: spillNameFor("dup-id"), savedAt: 200, mtimeSec: 3001, pad: 500 });
+        writeRawRecord(dir, "fresh-id", { mtimeSec: 4000, pad: 100 });
+        const dupSize = fs.statSync(path.join(dir, flatFileNameFor("dup-id"))).size;
+        const freshSize = fs.statSync(path.join(dir, flatFileNameFor("fresh-id"))).size;
+        // Room for the fresh record plus only one half of the pair → the pair is skipped whole.
+        const tight = await s.loadAll({ maxParseBytes: freshSize + dupSize });
+        assert.deepEqual([...tight.keys()], ["fresh-id"]);
+        // Room for the whole pair → both halves parse and reconcile by savedAt.
+        const roomy = await s.loadAll({ maxParseBytes: freshSize + 2 * dupSize });
+        assert.equal(roomy.get("dup-id")?.savedAt, 200);
+        assert.equal(roomy.get("dup-id")?.payload.label, "dup-id");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll budget smaller than every record parses nothing and warns", async () => {
+    const dir = tmpDir();
+    try {
+        const logs: { level: string; msg: string }[] = [];
+        const s = store(dir, { log: (level, msg) => logs.push({ level, msg }) });
+        writeRawRecord(dir, "a-1", { mtimeSec: 1000 });
+        writeRawRecord(dir, "b-1", { mtimeSec: 2000 });
+        const out = await s.loadAll({ maxParseBytes: 1 });
+        assert.equal(out.size, 0);
+        assert.ok(existsSync(path.join(dir, flatFileNameFor("a-1"))), "files remain on disk");
+        assert.ok(existsSync(path.join(dir, flatFileNameFor("b-1"))), "files remain on disk");
+        assert.ok(logs.some((l) => l.level === "warn" && l.msg.includes("budget")), "warn logged");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll rejects invalid budgets fail-fast", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        await assert.rejects(s.loadAll({ maxParseBytes: -1 }), TypeError);
+        await assert.rejects(s.loadAll({ maxParseBytes: Number.NaN }), TypeError);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("loadAll budget pairs canonical and spill within a directory only", async () => {
+    const dir = tmpDir();
+    try {
+        const relPath = (id: string): string =>
+            id === "p" ? "n1/same.json" : id === "q" ? "n2/same.json" : flatFileNameFor(id);
+        const s = store(dir, { relPath });
+        writeRawRecord(dir, "p", { name: "n1/same.json", mtimeSec: 3000, pad: 500 });
+        writeRawRecord(dir, "q", { name: "n2/same.json", mtimeSec: 4000, pad: 500 });
+        const size = fs.statSync(path.join(dir, "n1/same.json")).size;
+        // Equal-sized same-stem files in different dirs must NOT merge into one oversized group.
+        const out = await s.loadAll({ maxParseBytes: size + 1 });
+        assert.deepEqual([...out.keys()], ["q"]);
+    } finally {
         rmSync(dir, { recursive: true, force: true });
     }
 });

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -687,6 +687,21 @@ test("loadAll maxParseBytes parses only the newest records within the budget", a
     }
 });
 
+test("loadAll budget skips an oversized newest group and fills from older groups", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir);
+        writeRawRecord(dir, "huge-new", { pad: 50_000, mtimeSec: 4000 });
+        writeRawRecord(dir, "old-a", { pad: 100, mtimeSec: 1000 });
+        writeRawRecord(dir, "old-b", { pad: 100, mtimeSec: 2000 });
+        const small = fs.statSync(path.join(dir, flatFileNameFor("old-a"))).size;
+        const out = await s.loadAll({ maxParseBytes: 2 * small + 1 });
+        assert.deepEqual([...out.keys()].sort(), ["old-a", "old-b"]);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
 test("loadAll budget treats a canonical file and its spill as one all-or-nothing unit", async () => {
     const dir = tmpDir();
     try {


### PR DESCRIPTION
Closes #185.

## Motivation

Startup cost of `loadAll` grows linearly with corpus size: every boot does `readFileSync` + `JSON.parse` over **all** surviving records, even after startup GC caps the corpus (billion-context#478). At GB-scale corpora that is 100ms~seconds of synchronous parsing per boot, and it keeps growing with session count.

billion-context cannot work around this in-repo: selective loading would require replicating the kernel's canonical/spill (`<name>.fb.json`) savedAt reconciliation ("freshest wins") — a fragile copy of kernel internals.

## What this PR does

Implements suggestion **1** from the issue (purely additive, default behavior unchanged):

```ts
export interface LoadAllOptions {
    maxParseBytes?: number;
}
async loadAll(options?: LoadAllOptions): Promise<Map<string, PersistedEnvelope<T>>>
```

Suggestion 2 (`statAll()`) was rejected: flat filenames are one-way hashes (`sha256(id)[:24].json`) and the id lives inside the envelope, so id-keyed metadata would require reading content anyway; a path-keyed variant would push canonical/spill pairing and freshest-wins onto the consumer — exactly the fragile duplication the issue rejects.

### Semantics

1. No options ⇒ byte-for-byte identical to current behavior.
2. With `maxParseBytes`: pass 1 is readdir + stat only (no content reads). Each canonical `<stem>.json` is paired with its `<stem>.fb.json` spill under a **dir+stem** key (same stem in different dirs = different records). Group size = sum of member sizes; group freshness = max mtimeMs. Groups are filled newest-first while the running total stays within budget (skip-and-continue).
3. Hard cap: if even the newest group alone exceeds the budget, nothing is parsed — empty `Map` plus a warn log `[persist] loadAll budget <N> bytes: parsed K/M record groups (skipped ...)`. Skipped files are never deleted and remain loadable via `loadSync(id, hint)`.
4. mtime is the stat-level proxy for savedAt (savedAt is unknowable without parsing); ordering among parsed records still goes through the unchanged savedAt reconciliation.
5. Non-finite or negative `maxParseBytes` throws `TypeError` fail-fast.

The hard constraint from the issue is honored: a record's canonical and spill variants are selected together or not at all, so freshest-wins semantics can't break on a half-parsed pair.

## Tests (tests/persist.test.ts, +5)

- Budget selects exactly the newest records within the cap; default `loadAll()` still parses everything; skipped files stay on disk and remain `loadSync`-able (skip ≠ delete).
- Canonical+spill all-or-nothing: tight budget skips the whole pair; roomy budget parses both and reconciles by savedAt (spill wins).
- Budget smaller than every record → empty map, files untouched, warn logged.
- `-1` / `NaN` → `TypeError`.
- Same-stem files in different directories are NOT merged into one oversized group (dir-scoped pairing).

## Verification

- `npm run typecheck` ✅
- `npm test` — 577 pass / 0 fail ✅
- `npm run build` ✅

No version bump (feature branch; release workflow handles that separately).

## Release ordering (cross-repo rule)

This must land and publish to npm first; billion-context then bumps its exact-version dependency on `acp-kernel` and consumes `loadAll({ maxParseBytes })` from `SessionStore.boot()` to turn `BILI_MAX_SESSIONS` into a true load budget.

Per AGENTS.md §6: requires review by at least 2 separate agents before merge.