### PR TITLE
fix: preserve images in wire codec round-trips (issue #187)

### DIFF
--- a/src/wire/bili-message.ts
+++ b/src/wire/bili-message.ts
@@ -55,8 +55,8 @@ export interface BiliMessage extends CoreMessage {
     /** The base64 data of an image (without the data: prefix). Lets the
      *  reverse conversion rebuild the full image payload. */
     imageBase64?: string;
-    /** OpenAI chat: ALL original image_url content parts (each a data: URL
-     *  part) for a user message carrying more than one image, in wire order.
+    /** OpenAI chat: ALL original image_url content parts (data: or remote
+     *  URL) for a user message carrying more than one image, in wire order.
      *  coreToOpenai re-emits these verbatim (after the text part). The
      *  singular `rawOpenaiContent` still covers the single-image case and
      *  legacy persisted state. Typed as unknown[] (not OpenAIContentPart) to

--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -64,6 +64,9 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                 break;
             }
             case "user": {
+                // Image-only messages keep text "" (NO "[image]" placeholder as
+                // in the responses/anthropic codecs): image-only msgs already
+                // had "" pre-#187, and switching would shift their derived ids.
                 const text = stringContent(m.content);
                 const imgs = allImageParts(m.content);
                 const firstImg = imgs[0];
@@ -75,8 +78,12 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                     role: "user",
                     contentType: "text",
                     text,
-                    ...(imgs.length === 1 && firstParsed
-                        ? { rawOpenaiContent: imgs[0], imageMediaType: firstParsed.mediaType, imageBase64: firstParsed.base64 }
+                    ...(imgs.length === 1
+                        ? {
+                            rawOpenaiContent: imgs[0],
+                            // data: URLs only — remote URLs ride rawOpenaiContent verbatim (issue #187)
+                            ...(firstParsed ? { imageMediaType: firstParsed.mediaType, imageBase64: firstParsed.base64 } : {}),
+                        }
                         : imgs.length > 1
                             ? { rawOpenaiContentParts: imgs }
                             : {}),
@@ -248,9 +255,10 @@ function stringContent(content: OpenAIMessage["content"]): string {
 
 type OpenAIImagePart = { type: "image_url"; image_url: { url: string } };
 
-/** Collect ALL data-URL image parts in a user content array, in wire order.
- *  (firstImagePart only kept the first, which silently dropped images 2..N
- *  on the coreToOpenai rebuild.) */
+/** Collect ALL image_url parts in a user content array, in wire order —
+ *  data: URLs and remote http(s) URLs alike. (firstImagePart only kept the
+ *  first, silently dropping images 2..N; the data-URL-only filter then
+ *  silently dropped every remote-URL image — issue #187.) */
 function allImageParts(content: OpenAIMessage["content"]): OpenAIImagePart[] {
     if (!Array.isArray(content)) return [];
     const out: OpenAIImagePart[] = [];
@@ -261,7 +269,7 @@ function allImageParts(content: OpenAIMessage["content"]): OpenAIImagePart[] {
         // narrow via a named const before reading the url.
         const imagePart = p as { image_url: { url?: unknown } };
         const url = imagePart.image_url.url;
-        if (typeof url === "string" && parseDataUrl(url)) out.push(p as OpenAIImagePart);
+        if (typeof url === "string") out.push(p as OpenAIImagePart);
     }
     return out;
 }

--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -106,6 +106,19 @@ function messageContent(content: string | ResponseContentPart[]): string {
     return typeof content === "string" ? content : content.map(partText).join("\n");
 }
 
+/** Kernel-side text responsesToCore assigns to a user item: its content
+ *  text, or the "[image]" placeholder when no text part exists (image-only
+ *  items — note ≥2 image parts join into a truthy "\n" that is not text).
+ *  coreToResponses re-emits the raw item verbatim exactly while the kernel
+ *  text still equals this form. MUST stay in lockstep with the displayText
+ *  computation in responsesToCore or the verbatim equality silently breaks. */
+function canonicalUserText(message: ResponseInputMessage): string {
+    const contentText = messageContent(message.content);
+    const hasImage = Array.isArray(message.content) && message.content.some((part) => part.type === "input_image");
+    const hasTextPart = typeof message.content !== "string" && message.content.some((part) => part.type === "input_text" || part.type === "output_text");
+    return !contentText || (hasImage && !hasTextPart) ? "[image]" : contentText;
+}
+
 /** Extract the reasoning text from a responses reasoning item. The host
  *  carries it in `content` (reasoning_text parts); the primeFold mirror
  *  carries it in `summary` (summary_text parts). Both must yield the same
@@ -203,8 +216,18 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                             effText = split.text;
                         }
                     }
-                    if (effText) {
-                        coreId = clusters.next(deriveMessageId(role, "text", effText));
+                    // Image-only user items have no text of their own (≥2 image
+                    // parts join to a truthy "\n" — not real text). Track them
+                    // with the "[image]" placeholder (anthropic codec precedent)
+                    // so they enter the compression space instead of vanishing
+                    // from the rebuilt input (issue #187). displayText derives
+                    // from effText (post-split); the placeholder applies only
+                    // when no real text part exists.
+                    const hasImage = Array.isArray(message.content) && message.content.some((part) => part.type === "input_image");
+                    const hasTextPart = typeof message.content !== "string" && message.content.some((part) => part.type === "input_text" || part.type === "output_text");
+                    if (effText || (role === "user" && hasImage)) {
+                        const displayText = !effText || (role === "user" && hasImage && !hasTextPart) ? "[image]" : effText;
+                        coreId = clusters.next(deriveMessageId(role, "text", displayText));
                         const imageUrl = Array.isArray(message.content)
                             ? message.content.find((part) => part.type === "input_image" && typeof part.image_url === "string")?.image_url
                             : undefined;
@@ -213,7 +236,7 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                             id: coreId,
                             role,
                             contentType: "text",
-                            text: effText,
+                            text: displayText,
                             rawResponsesItem: item,
                             ...(image ? { imageMediaType: image.mediaType, imageBase64: image.base64 } : {}),
                         });
@@ -385,7 +408,7 @@ export function coreToResponses(
         if (message.role === "system") {
             out.push({ type: "message", role: "developer", content: message.text ?? "" });
         } else if (message.role === "user") {
-            if (raw?.type === "message" && messageContent((raw as ResponseInputMessage).content) === (message.text ?? "")) out.push(raw);
+            if (raw?.type === "message" && canonicalUserText(raw as ResponseInputMessage) === (message.text ?? "")) out.push(raw);
             else out.push({ type: "message", role: "user", content: message.text ?? "" });
         } else if (message.role === "assistant") {
             if (message.contentType === "text") {

--- a/tests/wire-bili-message-roundtrip.test.ts
+++ b/tests/wire-bili-message-roundtrip.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { anthropicToCore, coreToAnthropic } from "../src/wire/anthropic.js";
 import { openaiToCore, coreToOpenai } from "../src/wire/openai.js";
-import { responsesToCore, coreToResponses } from "../src/wire/responses.js";
+import { responsesToCore, coreToResponses, patchResponsesInput } from "../src/wire/responses.js";
 import type { AnthropicBlock, AnthropicRequestBody } from "../src/wire/anthropic.js";
 import type { OpenAIRequestBody } from "../src/wire/openai.js";
 import type { ResponsesRequestBody } from "../src/wire/responses.js";
@@ -191,6 +191,86 @@ test("openai: user message with multiple image_url parts round-trips ALL images"
     assert.ok(typeof text?.text === "string" && text.text.startsWith("compare these?"), "text preserved");
 });
 
+// 5c. A single REMOTE (non-data) URL image gets no base64 sidecar, so it must
+//     ride rawOpenaiContent verbatim. Previously allImageParts filtered to
+//     data: URLs, so a lone remote-URL image produced NO sidecar at all and
+//     was silently dropped on the coreToOpenai rebuild (issue #187).
+test("openai: single remote-URL image_url round-trips via rawOpenaiContent", () => {
+    const REMOTE_URL = "https://example.com/a.png";
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "t" },
+                    { type: "image_url", image_url: { url: REMOTE_URL } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(msgs[0]?.rawOpenaiContent, "rawOpenaiContent sidecar stored for a single remote-URL image");
+    assert.equal(msgs[0]?.imageBase64, undefined, "no base64 split for non-data URLs");
+    assert.equal(msgs[0]?.imageMediaType, undefined, "no mediaType split for non-data URLs");
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    assert.ok(Array.isArray(u.content), "content rebuilt as array");
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    const img = parts.find((p) => p.type === "image_url") as unknown as { image_url: { url: string } };
+    assert.equal(img?.image_url.url, REMOTE_URL, "remote-URL image restored verbatim");
+    const text = parts.find((p) => p.type === "text");
+    assert.ok(typeof text?.text === "string" && text.text.startsWith("t"), "text preserved");
+});
+
+// 5d. Image-only user message (no text part) with a remote URL: the message
+//     text is empty, so survival depends entirely on the sidecar.
+test("openai: image-only remote-URL user message survives rebuild", () => {
+    const REMOTE_URL = "https://example.com/b.jpg";
+    const body: OpenAIRequestBody = {
+        messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: REMOTE_URL } }] }],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs[0]?.text, "");
+    assert.ok(msgs[0]?.rawOpenaiContent, "sidecar stored despite empty text");
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    assert.ok(Array.isArray(u.content), "content rebuilt as array (not an empty string)");
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    assert.equal(parts.length, 1, "exactly one part — no empty text part injected");
+    const img = parts[0] as unknown as { type: string; image_url: { url: string } };
+    assert.equal(img.type, "image_url");
+    assert.equal(img.image_url.url, REMOTE_URL);
+});
+
+// 5e. Mixed data-URL + remote-URL multi-image message: allImageParts used to
+//     keep only data-URL parts, so the remote one vanished from
+//     rawOpenaiContentParts (wider gap than the single-image case).
+test("openai: mixed data-URL + remote-URL multi-image message preserves ALL images in order", () => {
+    const REMOTE_URL = "https://example.com/c.webp";
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "both?" },
+                    { type: "image_url", image_url: { url: DATA_URL } },
+                    { type: "image_url", image_url: { url: REMOTE_URL } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(msgs[0]?.rawOpenaiContentParts, "multi-image sidecar stored");
+    assert.equal((msgs[0]?.rawOpenaiContentParts ?? []).length, 2, "BOTH images collected (remote included)");
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    const imgs = parts.filter((p) => p.type === "image_url");
+    assert.equal(imgs.length, 2, "all 2 image_url parts preserved");
+    const urls = imgs.map((p) => (p as unknown as { image_url: { url: string } }).image_url.url);
+    assert.deepEqual(urls, [DATA_URL, REMOTE_URL], "order preserved");
+});
+
 // 6. Responses API input_image round-trips (image was previously dropped).
 test("responses: user input_image is restored via rawResponsesItem", () => {
     const body: ResponsesRequestBody = {
@@ -219,6 +299,117 @@ test("responses: user input_image is restored via rawResponsesItem", () => {
     const img = parts.find((p) => p.type === "input_image");
     assert.ok(img, "input_image reconstructed");
     assert.equal(img?.image_url, DATA_URL, "image url restored");
+});
+
+// 6b. Image-ONLY user item (no input_text) previously produced NO core
+//     message at all (effText === ""), so coreToResponses never saw it and
+//     the item vanished from the rebuilt input (issue #187). It must be
+//     tracked with the "[image]" placeholder (anthropic codec precedent) and
+//     re-emitted verbatim via rawResponsesItem while unmodified.
+test("responses: image-only user item is tracked and round-trips verbatim", () => {
+    const body: ResponsesRequestBody = {
+        input: [{ type: "message", role: "user", content: [{ type: "input_image", image_url: DATA_URL }] }],
+    };
+    const { msgs } = responsesToCore(body);
+    assert.equal(msgs.length, 1, "image-only item produces exactly one core message");
+    assert.equal(msgs[0]?.text, "[image]", "placeholder text used for identity + display");
+    assert.ok(msgs[0]?.rawResponsesItem, "rawResponsesItem sidecar stored");
+    assert.equal(msgs[0]?.imageMediaType, "image/png", "data-URL sidecar fields still populated");
+    assert.equal(msgs[0]?.imageBase64, IMG_DATA);
+    const rebuilt = coreToResponses(msgs);
+    assert.equal(rebuilt.length, 1);
+    assert.deepEqual(rebuilt[0], body.input[0], "raw item re-emitted verbatim (images intact)");
+});
+
+// 6c. The tracked image-only item must survive patchResponsesInput (the
+//     host-rebuild path) AND disappear when its id leaves msgs[] — i.e. it
+//     participates in compression like any other message. Before the fix it
+//     was only kept by the layout fallback (untracked → invisible to the
+//     compression pipeline, accumulating unbounded).
+test("responses: image-only item survives patchResponsesInput and prunes with its turn", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "message", role: "user", content: [{ type: "input_image", image_url: DATA_URL }] },
+            { type: "message", role: "assistant", content: "got it" },
+        ],
+    };
+    const proj = responsesToCore(body);
+    assert.equal(proj.msgs.length, 2, "both items tracked");
+    const imgMsg = proj.msgs.find((m) => m.text === "[image]")!;
+    assert.ok(imgMsg, "image-only item has a tracked core id");
+    const kept = patchResponsesInput(proj, proj.msgs);
+    assert.ok(JSON.stringify(kept).includes(DATA_URL), "image survives the patch rebuild");
+    const pruned = patchResponsesInput(proj, proj.msgs.filter((m) => m.id !== imgMsg.id));
+    assert.ok(!JSON.stringify(pruned).includes(DATA_URL), "pruning the id removes the image from the rebuild");
+});
+
+// 6d. Two identical image-only items must get distinct but STABLE ids across
+//     turns (ClusterCounter disambiguation), so a later turn cannot collapse
+//     or misalign them.
+test("responses: image-only item ids are stable and distinct across turns", () => {
+    const first: ResponsesRequestBody = {
+        input: [
+            { type: "message", role: "user", content: [{ type: "input_image", image_url: DATA_URL }] },
+            { type: "message", role: "assistant", content: "ok" },
+        ],
+    };
+    const second: ResponsesRequestBody = {
+        input: [
+            ...first.input,
+            { type: "message", role: "user", content: [{ type: "input_image", image_url: DATA_URL }] },
+            { type: "message", role: "assistant", content: "ok again" },
+        ],
+    };
+    const a = responsesToCore(first);
+    const b = responsesToCore(second);
+    const idsA = a.msgs.map((m) => m.id);
+    const idsB = b.msgs.map((m) => m.id);
+    assert.deepEqual(idsA.slice(0, 2), idsB.slice(0, 2), "earlier ids unchanged by later turns");
+    const imgIds = b.msgs.filter((m) => m.text === "[image]").map((m) => m.id);
+    assert.equal(new Set(imgIds).size, 2, "identical image-only items get distinct ids");
+});
+
+// 6e. MULTI-part image-only item: joining N−1 empty part texts yields a
+//     truthy "\n", which is not real text — it must still take the "[image]"
+//     placeholder (and keep matching canonicalUserText verbatim).
+test("responses: multi-input_image user item takes the [image] placeholder", () => {
+    const DATA_URL2 = `data:image/png;base64,${IMG_DATA}AAAA`;
+    const body: ResponsesRequestBody = {
+        input: [{ type: "message", role: "user", content: [{ type: "input_image", image_url: DATA_URL }, { type: "input_image", image_url: DATA_URL2 }] }],
+    };
+    const { msgs } = responsesToCore(body);
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0]?.text, "[image]", "no-text multi-image item uses the placeholder (not the \"\\n\" join artifact)");
+    const rebuilt = coreToResponses(msgs);
+    assert.deepEqual(rebuilt[0], body.input[0], "raw item re-emitted verbatim");
+});
+
+// 6f. Whitespace-only text + image: the whitespace IS real text (a text part
+//     exists), so it must be kept as-is — both responsesToCore and
+//     canonicalUserText must agree on it for the verbatim round-trip to hold.
+test("responses: whitespace-only text plus image keeps its exact text", () => {
+    const body: ResponsesRequestBody = {
+        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "   " }, { type: "input_image", image_url: DATA_URL }] }],
+    };
+    const { msgs } = responsesToCore(body);
+    assert.equal(msgs.length, 1);
+    assert.notEqual(msgs[0]?.text, "[image]", "whitespace text counts as real text, not the placeholder");
+    assert.ok(msgs[0]?.text?.startsWith("   "), "exact whitespace text preserved (kernel joins non-text parts with \\n)");
+    const rebuilt = coreToResponses(msgs);
+    assert.deepEqual(rebuilt[0], body.input[0], "verbatim round-trip holds for truthy-blank text");
+});
+
+// 6g. Image part whose image_url is malformed (non-string): still tracked and
+//     re-emitted verbatim; no base64 sidecar fields.
+test("responses: input_image with non-string image_url is tracked without sidecar fields", () => {
+    const badPart = { type: "input_image", image_url: { not: "a string" } } as unknown as { type: string; [k: string]: unknown };
+    const body = { input: [{ type: "message", role: "user", content: [badPart] }] } as unknown as ResponsesRequestBody;
+    const { msgs } = responsesToCore(body);
+    assert.equal(msgs.length, 1, "tracked despite malformed url");
+    assert.equal(msgs[0]?.text, "[image]");
+    assert.equal(msgs[0]?.imageBase64, undefined, "no base64 split for non-string urls");
+    const rebuilt = coreToResponses(msgs);
+    assert.deepEqual(rebuilt[0], body.input[0], "malformed item re-emitted verbatim");
 });
 
 // 7. Responses reasoning is routed into the compression pipeline (NOT the


### PR DESCRIPTION
Fixes both silent image-loss gaps reported in ranxianglei/acp-kernel#187, plus a wider variant found during triage.

## Triage findings (verified on master v0.0.49)

**Gap 1 (openai)** — the report pointed at the `imgs.length === 1 && firstParsed` sidecar condition, but current code has an additional filter upstream: `allImageParts` only collected image parts whose url parses as a data URL (introduced by 626f933 to feed `rawOpenaiContentParts`). A single remote-URL image therefore never reached the sidecar logic at all (`imgs.length === 0`). Same end state as reported, but the fix must also remove that filter. Reproducing also showed the gap is **wider than reported**: due to the same filter, multi-image messages dropped *every* remote-URL part — `[data, remote]` round-tripped as `[data]`, not just the single-image case.

**Gap 2 (responses)** — reproduced exactly as described: an image-only user item produced zero core messages. One nuance: loss was path-dependent — `patchResponsesInput` kept such items via the layout fallback (slot without coreId → original item), while `coreToResponses` dropped them; and in either path the untracked item stayed invisible to the compression pipeline and would accumulate unbounded. Tracking fixes both paths.

## Changes

### openai codec (`src/wire/openai.ts`)
- `allImageParts` now collects every `image_url` part with a string url (data-URL filter removed).
- Single-image sidecar keeps the raw part verbatim for any URL shape; base64/mediaType fields are split out only for data URLs (the shape suggested in the issue):
  - 1 image → `{ rawOpenaiContent }` (+ base64 fields iff data URL)
  - >1 images → `{ rawOpenaiContentParts }` (field unchanged, now complete)
- `coreToOpenai` needed no change — its precedence chain already prefers verbatim raw over base64 rebuild.
- Image-only messages keep empty text (pre-existing behavior; switching to a placeholder would shift derived ids for already-working shapes).

### responses codec (`src/wire/responses.ts`)
- Image-only user items are now tracked: `"[image]"` placeholder text (anthropic codec precedent) + `rawResponsesItem` sidecar + data-URL base64 split as before, so they enter the compression space with stable ids.
- Multi-image-only items (≥2 `input_image`, no text) also get `"[image]"` — previously tracked with the `"\n"` join artifact, which is not real text. This is the **only id churn** introduced: those items' ids shift once (deterministically); every previously working shape keeps its exact id.
- `coreToResponses` re-emits the raw item verbatim while the kernel text still equals `canonicalUserText(raw)` (content text, or `"[image]"` when no text part exists); edited/summarized messages rebuild as plain text as before.
- Placeholder applies only to `role: "user"`; assistant/system/developer handling is unchanged.

## Known trade-offs / residual gaps (out of scope, reporting only)

- Literal user text `"[image]"` shares the base id with the placeholder; ClusterCounter disambiguates deterministically (documented message-id trade-off).
- The `"\n"` join artifact for non-text parts pre-dates this fix (e.g. `[text, image]` → `"t\n"`) and is unchanged; normalizing it would shift existing ids.
- Assistant-role image-only response items remain untracked (same class of gap, opposite direction) — needs owner decision.
- Mirror builders (`src/wire/mirror.ts`) cannot represent images at all (`MirrorBlock` has no image type) — pre-existing parity limitation, affects data-URL images too.
- Separate crash found during review, pre-existing, not touched here: `openaiToCore` throws `TypeError` on `{type:"image_url", image_url:null}` — filed as ranxianglei/acp-kernel#188.

## Evidence

- 9 new regression tests in `tests/wire-bili-message-roundtrip.test.ts` (5c–5e, 6b–6g): single/multi/mixed remote-URL OpenAI shapes, image-only responses tracking, verbatim round-trip, `patchResponsesInput` survival + prune-by-id, cross-turn id stability, whitespace-text edge, malformed `image_url`. All fail on master and pass with this change (verified against pristine HEAD copies).
- `npm run typecheck` ✓ · `npm test` 581/581 ✓ · `npm run build` ✓
- Reviewed by two independent agent reviews (correctness/id-stability angle + integration/consumer angle); consumer audit confirmed no other kernel module depends on the changed behavior.