### PR TITLE
fix(wire): skip malformed image_url:null parts in openaiToCore (#188)

### DIFF
--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -259,8 +259,8 @@ function allImageParts(content: OpenAIMessage["content"]): OpenAIImagePart[] {
         if (!("type" in p) || p.type !== "image_url" || !("image_url" in p)) continue;
         // The union's index-signature member leaves image_url as `unknown`, so
         // narrow via a named const before reading the url.
-        const imagePart = p as { image_url: { url?: unknown } };
-        const url = imagePart.image_url.url;
+        const imagePart = p as { image_url?: { url?: unknown } | null };
+        const url = imagePart.image_url?.url;
         if (typeof url === "string" && parseDataUrl(url)) out.push(p as OpenAIImagePart);
     }
     return out;

--- a/tests/wire-bili-message-roundtrip.test.ts
+++ b/tests/wire-bili-message-roundtrip.test.ts
@@ -191,6 +191,21 @@ test("openai: user message with multiple image_url parts round-trips ALL images"
     assert.ok(typeof text?.text === "string" && text.text.startsWith("compare these?"), "text preserved");
 });
 
+// 5c. Malformed but JSON-valid image part (image_url:null) must degrade to a
+//     non-image part instead of throwing — previously raised TypeError reading
+//     null.url inside allImageParts, crashing the whole turn in proxy mode.
+test("openai: malformed image_url:null part is skipped without throwing", () => {
+    const body = {
+        messages: [
+            { role: "user", content: [{ type: "image_url", image_url: null }] },
+        ],
+    } as unknown as OpenAIRequestBody;
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0]?.imageMediaType, undefined, "null image_url degrades to non-image");
+    assert.equal(msgs[0]?.imageBase64, undefined);
+});
+
 // 6. Responses API input_image round-trips (image was previously dropped).
 test("responses: user input_image is restored via rawResponsesItem", () => {
     const body: ResponsesRequestBody = {


### PR DESCRIPTION
## Problem

`openaiToCore` throws an uncaught `TypeError` on an image part whose `image_url` is `null`:

```js
openaiToCore({ messages: [{ role: "user", content: [{ type: "image_url", image_url: null }] }] });
// TypeError: Cannot read properties of null (reading 'url')
```

Malformed but JSON-valid input. In billion-context proxy mode, any client request carrying such a part crashes the whole turn (or the proxy) instead of degrading gracefully.

**Pre-existing**, unrelated to #187 (that line is byte-identical at HEAD; #187's diff does not touch it). Found during independent review while working on #187.

## Root cause

`allImageParts` (src/wire/openai.ts) gates on `"image_url" in p`, which is `true` even when the value is `null`, then reads `imagePart.image_url.url` → `null.url` → TypeError. The gate checks key *presence*, not value validity.

## Fix

Widen the narrowing cast to allow null/absent `image_url` and optional-chain the read so such parts degrade to non-image parts (skipped):

```diff
-        const imagePart = p as { image_url: { url?: unknown } };
-        const url = imagePart.image_url.url;
+        const imagePart = p as { image_url?: { url?: unknown } | null };
+        const url = imagePart.image_url?.url;
         if (typeof url === "string" && parseDataUrl(url)) out.push(p as OpenAIImagePart);
```

The existing `typeof url === "string"` guard already skips non-string urls, so no other collection semantics change. This transitively protects `openai.ts:70` (`firstImg.image_url.url`) since `firstImg` now only ever comes from well-formed parts.

Sibling audit: `responses.ts` already guards `typeof part.image_url === "string"` (safe); no other vulnerable sites found.

## Verification

- Repro on v0.0.49 pre-fix: throws `TypeError: Cannot read properties of null (reading 'url')`.
- Post-fix: no throw; malformed part skipped, user message preserved (empty text, no image sidecar).
- Regression test added (`tests/wire-bili-message-roundtrip.test.ts`, case 5c) — confirmed to **fail on unfixed code**, pass post-fix.
- `npm run typecheck` clean; `npm test` → **573 pass / 0 fail**.

Fixes #188