### PR TITLE
release v0.0.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.46",
+    "version": "0.0.50",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.46",
+            "version": "0.0.50",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.49",
+    "version": "0.0.50",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Version bump only (0.0.49 → 0.0.50).

## Ships since v0.0.49

- **Revert of PR #176** (ref reclamation + capacity reuse) via #191 — ref numbers are never recycled again; closes the silent decompress-misattribution risk. Reopens the #386 monotonic-growth leak by design (to be solved by REF_WIDTH widening).
- (#192 docs pending separately.)

Needed by downstream: billion-context-pi currently pins 0.0.48 (contains the reverted reclamation) and must move to this release.