### PR TITLE
fix: waive growth gate for inherited ready T1 mass on fresh/rebuilt states (#194)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -658,6 +658,7 @@ const nudgeNode: PipelineNode = {
 
     if (nudge.shouldInject) {
       stamped.lastNudgeShownTokens = ctx.tokenCount;
+      stamped.everInjected = true;
       // Record the injected tier's own cadence baseline. Shared baseline
       // (lastNudgeShownTokens) suppresses lower-priority tiers within this
       // turn; the per-tier entry throttles re-firing of the SAME tier.
@@ -1187,6 +1188,16 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   const t2Count = tiers[2]?.targetBlocks.length ?? 0;
   const t3Count = tiers[3]?.targetBlocks.length ?? 0;
 
+  // Inherited ready-mass waiver (#194): on a fresh/rebuilt state the growth
+  // reference seeds at the CURRENT tokenCount, so history ingested before the
+  // first seed can never count toward growth — the first nudge used to stall
+  // until a full growthFloor of NEW tokens arrived while ready T1 sat idle.
+  // Ready T1 mass at least one full interval large is compressible now; waive
+  // the growth gate for the first injection only. everInjected + !hasPendingNudge
+  // keep this from re-arming after a shown (even ignored) nudge or post-compress.
+  const inheritedReady =
+    !state.nudge.everInjected && !hasPendingNudge && t1Eff >= nudgeGrowthTokens;
+
   if (pressure) {
     // High pressure: pick the tier with the MAX pending so pressure can route
     // to distillation when that reclaims the most tokens. Gated on effective
@@ -1215,10 +1226,11 @@ function decideNudge(input: NudgeInput): NudgeDecision {
           ? `${label} T1: max effective pending ${bestPending}, usage ${Math.round(usage * 100)}%`
           : `${label} T${best} distill: max pending ${bestPending} (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}), usage ${Math.round(usage * 100)}%`;
     }
-  } else if (growthReady) {
+  } else if (growthReady || inheritedReady) {
     if (t1Eff >= nudgeGrowthTokens) {
       injectedTier = 1;
-      injectedReason = `T1 effective ${t1Eff} >= ${nudgeGrowthTokens}, growth ${growthSinceReference}, usage ${Math.round(usage * 100)}%`;
+      const waived = !growthReady;
+      injectedReason = `T1 effective ${t1Eff} >= ${nudgeGrowthTokens}, growth ${growthSinceReference}, usage ${Math.round(usage * 100)}%${waived ? " (growth gate waived: inherited ready mass)" : ""}`;
     } else if (
       config.tiers.enabled &&
       (t2Count >= config.tiers.tier2Trigger ||
@@ -1336,6 +1348,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       hasPendingNudge: hasPendingNudge ? 1 : 0,
       overLimit: overLimit ? 1 : 0,
       emergencyOverride: emergencyOverride ? 1 : 0,
+      inheritedReady: inheritedReady ? 1 : 0,
       pendingT1: tiers[1]!.pending,
       pendingT2: tiers[2]!.pending,
       pendingT3: tiers[3]!.pending,

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ export function createInitialState(): CompressionState {
       baselineTokens: 0,
       anchors: {},
       lastShownByTier: {},
+      everInjected: false,
     },
     stats: { tokensCompressed: 0, compressionCount: 0, absorbedTokens: 0 },
     absorbed: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,12 @@ export interface NudgeState {
    *  tiers. Using a record (not N named fields) so adding tier 4+ needs no
    *  schema change. */
   lastShownByTier: Record<number, number>;
+  /** Lifetime flag: true once ANY nudge has been injected in this state's
+   *  history. Deliberately NOT reset by applyCompression or shrink re-anchor —
+   *  the inherited-ready-mass waiver (first nudge on a fresh/rebuilt state
+   *  sitting on large ready T1) must not re-arm after a nudge was already
+   *  shown, which would defeat post-compress spacing cadence. */
+  everInjected: boolean;
 }
 
 export interface CompressionStats {

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createCore } from "../src/compress.js";
 import { createInitialState } from "../src/state.js";
-import type { Config, CoreMessage } from "../src/types.js";
+import type { Config, CoreMessage, NudgeState } from "../src/types.js";
 
 function buildConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -47,16 +47,74 @@ function makeMessages(count: number): CoreMessage[] {
 // effectiveThreshold (no pending) = 6000
 // effectiveThreshold (pending) = 3000
 
-test("nudge: baseline stamped on first turn, no nudge below threshold", () => {
+// #194: a fresh/rebuilt state ingesting large history sits on ready T1 mass
+// that the growth reference (seeded at current tokenCount) can never count.
+// Pre-fix, the first nudge stalled until a full growthFloor of NEW tokens
+// arrived. The inherited-ready waiver fires the first T1 nudge immediately.
+test("nudge: inherited ready T1 mass waives the growth gate on a fresh state (#194)", () => {
   const core = createCore();
   const config = buildConfig();
   const messages = makeMessages(10);
   const state = createInitialState();
 
+  // ~50K tokens of ready T1, growth since unseeded reference = 0, usage 10%.
   const turn1 = core.processTurn({ messages, state, config, tokenCount: 10000 });
-  assert.equal(turn1.nudge.shouldInject, false);
+  assert.equal(turn1.nudge.shouldInject, true, "inherited ready mass → first nudge fires immediately");
+  assert.equal(turn1.nudge.tier, 1);
+  assert.ok(turn1.nudge.reason.includes("waived"), `reason marks the waiver: ${turn1.nudge.reason}`);
   assert.equal(turn1.state.nudge.lastPerMessageNudgeTokens, 10000, "baseline stamped");
-  assert.equal(turn1.state.nudge.lastNudgeShownTokens, 0, "no nudge shown");
+  assert.equal(turn1.state.nudge.lastNudgeShownTokens, 10000, "shown stamped");
+  assert.equal(turn1.state.nudge.everInjected, true, "lifetime flag armed");
+});
+
+test("nudge: small fresh session below threshold stays quiet", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = Array.from({ length: 10 }, (_, i) =>
+    textMessage(i % 2 === 0 ? "user" : "assistant", `m${i}`, `msg ${i} `.repeat(10)),
+  );
+  const state = createInitialState();
+
+  // ~175 tokens total << 6000 interval → nothing worth offering yet.
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 10000 });
+  assert.equal(turn1.nudge.shouldInject, false, "pending below interval → no nudge");
+  assert.equal(turn1.state.nudge.lastPerMessageNudgeTokens, 10000, "baseline stamped");
+  assert.equal(turn1.state.nudge.everInjected, false);
+});
+
+test("nudge: stall shape — ready mass reaches interval before floor of NEW growth arrives (#194)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const small = Array.from({ length: 4 }, (_, i) =>
+    textMessage(i % 2 === 0 ? "user" : "assistant", `m${i}`, `s${i} `.repeat(10)),
+  );
+  let state = core.processTurn({ messages: small, state: createInitialState(), config, tokenCount: 10000 }).state;
+  assert.equal(state.nudge.everInjected, false, "turn 1 too small to inject");
+
+  // Reconnect-style ingest: ~50K ready T1 arrives but only +3000 new tokens
+  // since baseline (< floor 5000). Pre-fix this was the 18-minute idle.
+  const turn2 = core.processTurn({ messages: makeMessages(10), state, config, tokenCount: 13000 });
+  assert.equal(turn2.nudge.shouldInject, true, "ready mass >= interval → waiver despite growth 3000 < floor 5000");
+  assert.equal(turn2.nudge.tier, 1);
+  assert.ok(turn2.nudge.reason.includes("waived"));
+});
+
+test("nudge: legacy snapshot without everInjected and a shown-but-uncompressed nudge does not re-fire (#194 guard)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+
+  state = core.processTurn({ messages, state, config, tokenCount: 10000 }).state;
+  state = core.processTurn({ messages, state, config, tokenCount: 55000 }).state;
+  assert.equal(state.nudge.lastNudgeShownTokens, 55000, "nudge shown, model has not compressed");
+
+  const legacyNudge: NudgeState = { ...state.nudge };
+  delete (legacyNudge as Record<string, unknown>).everInjected;
+  const legacy = { ...state, nudge: legacyNudge };
+
+  const next = core.processTurn({ messages, state: legacy, config, tokenCount: 55000 });
+  assert.equal(next.nudge.shouldInject, false, "!hasPendingNudge guard blocks the waiver on old snapshots");
 });
 
 test("nudge: fires when growth exceeds threshold AND usage over min limit", () => {


### PR DESCRIPTION
Fixes #194.

## Problem
On a fresh/rebuilt state (`lastNudgeShownTokens = 0`, baseline `0`), `growthReference` falls back to the current `tokenCount` in `decideNudge` (src/compress.ts), so history ingested before the first seed can never count toward growth. The first nudge stalled until a full `growthFloor` of NEW tokens accumulated while large ready pendingT1 sat idle — the bili session from #194 idled 18 min with `pendingT1=934141/50000` and died ~4800 tokens short of the floor.

## Fix — ready-mass bypass (issue direction 1), scoped to T1
- `decideNudge`: when no nudge has ever been injected in this state's lifetime, nothing is currently pending, and effective T1 pending >= `nudgeGrowthTokens`, the growth gate is waived and the first T1 nudge injects immediately. Reason string marks it `(growth gate waived: inherited ready mass)`; also exposed as `breakdown.inheritedReady`.
- New lifetime flag `NudgeState.everInjected`: stamped when any nudge injects, deliberately NOT reset by `applyCompression` or shrink re-anchor. This keeps post-compress spacing cadence (the §5.7 anti-feedback-loop invariant) and shown-but-ignored nudges under normal growth gating. Old persisted snapshots without the field shallow-merge to `false` (src/persist/state-merge.ts) — desired semantics for inherited sessions; the extra `!hasPendingNudge` guard prevents per-turn re-firing on legacy snapshots that carried an unsatisfied shown stamp.

Why not direction 2 (seed `growthReference` at `tokenCount - readyPending`): seeding the reference below the current token count would make every subsequent turn over-count the inherited mass as "growth", permanently skewing the cadence of ALL later nudges (T1/T2/T3 share the reference). The waiver touches only the first injection and leaves steady-state accounting untouched.

Pressure/emergency paths are unchanged (they already bypass the growth gate).

## Tests (tests/nudge.test.ts)
- fresh state + ~50K ready T1 → first nudge fires immediately, tier 1, waiver marked, `everInjected` armed (replaces the old "no nudge below threshold" assertion which codified the bug)
- small fresh session below the interval stays quiet
- stall shape: turn 1 small, reconnect-style ingest reaches the interval with only +3000 new tokens (< floor 5000) → waives (pre-fix: the 18-minute idle)
- legacy snapshot (field absent) with a shown-but-uncompressed nudge → does NOT re-fire (guard regression)
- existing post-compress / T2-cadence / repeat-suppression tests unchanged and green: typecheck ✅ 575/575 tests ✅ build ✅