### PR TITLE
fix #194: bypass growth floor to drain big-ingest ready mass (first-sight + post-compress re-arm)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1173,12 +1173,14 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   // (stateless full-history ingest / restored state) shows growthSinceReference
   // ≈ 0 and waits for a full floor of NEW tokens before its first compress —
   // #351 sat 934K-ready for 18 idle minutes and died ~4 min short of the floor.
-  // The floor paces REPEATED nudges; it must not gate the first one. Bypass it
-  // only while the session has never been nudged (baseline AND shown unstamped)
-  // and only inside the normal nudge band (usage >= minContextLimitPct — a
-  // fresh small session below the band still waits, as before) and only when
-  // the effective ready mass already clears the normal threshold, so the tier
-  // branches below apply unchanged.
+  // The floor paces WITHIN a backlog; it must not gate draining one. The bypass
+  // re-arms after every SUCCESSFUL compression (which clears the baseline):
+  // still-in-band with ready mass over threshold keeps nudging the backlog
+  // down, one compress per re-fire — no growth debt between compressions.
+  // Guardrails: while the model IGNORES a nudge the shown stamp stays set, so
+  // this never re-fires on an unresponsive session; a fresh session below the
+  // usage band still waits, as before; and the tier branches below apply
+  // unchanged.
   const firstSightMassReady =
     state.nudge.lastNudgeShownTokens === 0 &&
     baseline === 0 &&

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1165,10 +1165,27 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   );
   let injectedTier: CompressionTier | null = null;
   let injectedReason = "";
-  const growthReady = growthSinceReference >= growthFloor;
   const t1Eff = tiers[1]?.pending ?? 0;
   const t2Pen = tiers[2]?.pending ?? 0;
   const t3Pen = tiers[3]?.pending ?? 0;
+  // First-sight mass bypass (#194): growthReference seeds to tokenCount when
+  // no baseline exists, so a session that ARRIVES with a huge ready mass
+  // (stateless full-history ingest / restored state) shows growthSinceReference
+  // ≈ 0 and waits for a full floor of NEW tokens before its first compress —
+  // #351 sat 934K-ready for 18 idle minutes and died ~4 min short of the floor.
+  // The floor paces REPEATED nudges; it must not gate the first one. Bypass it
+  // only while the session has never been nudged (baseline AND shown unstamped)
+  // and only inside the normal nudge band (usage >= minContextLimitPct — a
+  // fresh small session below the band still waits, as before) and only when
+  // the effective ready mass already clears the normal threshold, so the tier
+  // branches below apply unchanged.
+  const firstSightMassReady =
+    state.nudge.lastNudgeShownTokens === 0 &&
+    baseline === 0 &&
+    usage >= config.nudge.minContextLimitPct &&
+    Math.max(t1Eff, t2Pen, t3Pen) >= nudgeGrowthTokens;
+  const growthReady =
+    firstSightMassReady || growthSinceReference >= growthFloor;
   const t2Count = tiers[2]?.targetBlocks.length ?? 0;
   const t3Count = tiers[3]?.targetBlocks.length ?? 0;
 
@@ -1238,6 +1255,9 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   }
 
   const shouldInject = injectedTier !== null;
+  if (shouldInject && firstSightMassReady) {
+    injectedReason += " [first-sight mass]";
+  }
 
   let reason: string;
   if (injectedTier !== null) {

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -780,3 +780,67 @@ test("nudge: first-sight bypass paces normally after the first nudge (#194)", ()
     "post-nudge growth 4000 < floor 10000 → paced again, no bypass",
   );
 });
+
+// #194 regression: the bypass must keep draining a backlog across compressions.
+// The reviewer on PR #196 caught that the one-shot wording hid this path:
+// applyCompression success clears the shown stamp and baseline, so a session
+// still in band with ready mass over the threshold nudges AGAIN without
+// waiting for a fresh growth floor of new tokens. This is the load-bearing
+// behavior for #351 (934K backlog needs several compressions to drain).
+test("nudge: first-sight bypass re-arms after a successful compression while still in band (#194)", () => {
+  const core = createCore();
+  const config = buildConfig({
+    nudge: {
+      ...buildConfig().nudge,
+      minGrowthFloor: 10000,
+      minGrowthRatio: 0.9,
+    },
+  });
+  const messages = makeMessages(20);
+  let state = createInitialState();
+
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 47000 });
+  assert.equal(turn1.nudge.shouldInject, true, "big ingest in band fires");
+  assert.match(turn1.nudge.reason, /\[first-sight mass\]/);
+
+  // Model executes the compress → success clears baseline + shown stamps.
+  state = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00005", summary: "drained a slice of the backlog" }],
+    messages,
+    state: turn1.state,
+    config,
+  }).state;
+  assert.equal(state.nudge.lastNudgeShownTokens, 0, "shown cleared by the compression");
+
+  // Still in band (48%) with growth 0 post-compress: the backlog is not yet
+  // drained, so the bypass must fire again — NOT wait for 10000 new tokens.
+  const turn2 = core.processTurn({ messages, state, config, tokenCount: 48000 });
+  assert.equal(
+    turn2.nudge.shouldInject,
+    true,
+    "post-compress, still in band + ready mass → nudge again (drain semantics)",
+  );
+  assert.match(turn2.nudge.reason, /\[first-sight mass\]/);
+});
+
+// Companion: once the drain gets usage below the band, the bypass goes quiet
+// even though growth is still 0 — it must not become an always-on compressor.
+test("nudge: first-sight bypass falls silent once usage drops below the band (#194)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(20);
+  let state = createInitialState();
+
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 55000 });
+  assert.equal(turn1.nudge.shouldInject, true);
+
+  state = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00005", summary: "drained most of the backlog" }],
+    messages,
+    state: turn1.state,
+    config,
+  }).state;
+
+  const turn2 = core.processTurn({ messages, state, config, tokenCount: 20000 });
+  assert.equal(turn2.nudge.shouldInject, false, "20% < 45% band → drain complete, pacing resumes");
+});

--- a/tests/nudge.test.ts
+++ b/tests/nudge.test.ts
@@ -721,3 +721,62 @@ test("arbitration: tiers disabled -> count trigger cannot fire T2", () => {
   assert.equal(turn.nudge.tier, null);
   assert.doesNotMatch(turn.nudge.reason ?? "", /tier2Trigger/);
 });
+
+// #194 first-sight mass bypass: a session that ARRIVES with a huge ready mass
+// (stateless full-history ingest) must not wait a full growth floor of NEW
+// tokens for its first compress. #351: growthReference seeded to the ingest
+// tokenCount → growth stayed 0 → 934K-ready sat idle until the session died.
+test("nudge: first-sight mass bypass fires on big ingest despite growth 0 (#194)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  const state = createInitialState();
+
+  // One-shot ingest: usage 47% (inside the 45% band), growth 0 from the
+  // tokenCount-seeded reference, T1 effective ~55K >= 6000 ready.
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 47000 });
+  assert.equal(
+    turn1.nudge.shouldInject,
+    true,
+    "first sight with ready mass >= threshold and usage in band nudges immediately",
+  );
+  assert.match(turn1.nudge.reason, /\[first-sight mass\]/);
+});
+
+test("nudge: first-sight bypass stays off below the min usage band (#194)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  const state = createInitialState();
+
+  // 44% < 45% minContextLimitPct: a fresh session below the band still waits
+  // (the bypass must not turn first-turn compression on for small sessions).
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 44000 });
+  assert.equal(turn1.nudge.shouldInject, false, "below min band → no bypass");
+});
+
+test("nudge: first-sight bypass paces normally after the first nudge (#194)", () => {
+  const config = buildConfig({
+    nudge: {
+      ...buildConfig().nudge,
+      minGrowthFloor: 10000,
+      minGrowthRatio: 0.9,
+    },
+  });
+  // growthFloor = max(10000, 0.9*6000) = 10000
+  const core = createCore();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+
+  const turn1 = core.processTurn({ messages, state, config, tokenCount: 46000 });
+  assert.equal(turn1.nudge.shouldInject, true, "bypass fires in band (growth 0)");
+  assert.match(turn1.nudge.reason, /\[first-sight mass\]/);
+
+  state = turn1.state;
+  const turn2 = core.processTurn({ messages, state, config, tokenCount: 50000 });
+  assert.equal(
+    turn2.nudge.shouldInject,
+    false,
+    "post-nudge growth 4000 < floor 10000 → paced again, no bypass",
+  );
+});


### PR DESCRIPTION
Fixes #194.

## Problem

A session that arrives with a huge ready mass (stateless full-history ingest, restored state) seeds `growthReference` to its own `tokenCount`, so `growthSinceReference` stays ≈ 0 and the first compress waits for a full `growthFloor` of **NEW** tokens. #351 sat 934K-ready for 18 idle minutes and died ~4 min short of the floor.

## Fix — first-sight mass bypass in `decideNudge`

```ts
const firstSightMassReady =
    state.nudge.lastNudgeShownTokens === 0 &&   // no nudge pending/shown
    baseline === 0 &&                            // no baseline (= arrived with mass)
    usage >= config.nudge.minContextLimitPct &&  // inside the normal band
    Math.max(t1Eff, t2Pen, t3Pen) >= nudgeGrowthTokens;  // ready mass clears the normal threshold
const growthReady = firstSightMassReady || growthSinceReference >= growthFloor;
```

**Semantics (corrected per review, commit fd8c832):** the floor paces nudges *within* a backlog; it must not gate *draining* one. A successful `applyCompression` clears the baseline and shown stamp, so the bypass re-arms: as long as usage stays in band and ready mass clears the threshold, it keeps nudging the backlog down — one nudge per **successful** compression, no growth debt between compressions. This drain-until-under-band behavior is exactly what #351 (934K backlog needing several compressions) requires.

**Guardrails:**
- While the model IGNORES a nudge, the shown stamp stays set → no re-fire on an unresponsive session (no feedback loop).
- A fresh small session below `minContextLimitPct` still waits, as before.
- Tier branches unchanged; the bypass only replaces the growth-floor gate. Reason tag ` [first-sight mass]` for log forensics.
- No `NudgeState` schema change (important for bili: inline bundle + exact pin).

## Tests

563/563 pass on latest master base. New cases:
- fires on big ingest despite growth 0
- stays off below the min usage band
- paces normally while a nudge is pending (stamp set, no compression)
- **re-arms after a successful compression while still in band (drain regression)**
- **falls silent once usage drops below the band**

Supersedes #195 (its `everInjected` strict one-shot leaves the cross-compression starvation that killed #351).