### PR TITLE
release v0.0.51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.50",
+    "version": "0.0.51",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.50",
+            "version": "0.0.51",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.50",
+    "version": "0.0.51",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Changes since v0.0.50

- **#194 fix** (PR #196): first-sight mass bypass in `decideNudge` — a session that arrives with a huge ready mass (stateless full-history ingest / restored state) no longer waits a full growth floor of NEW tokens before its first compress. Semantics per review: drain-until-under-band — a successful compression clears the baseline/shown stamp, so the bypass re-arms and keeps draining an in-band backlog, one nudge per successful compression; an ignored nudge keeps the stamp (no feedback loop); below-band stays quiet; no `NudgeState` schema change. Fixes the kernel half of the #351/#499 family (934K-ready session idle 18 min, died 4 min short of the floor).

## Pre-flight

- typecheck ✅
- tests 563/563 ✅
- build ✅

Commit is version-bump-only (`package.json` + `package-lock.json`).