### PR TITLE
fix: gate pressure-band nudges on a minimum benefit floor (#198)

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1069,6 +1069,22 @@ function resolveAdaptiveGrowth(
   );
 }
 
+/** Minimum reclaimable tokens for a pressure-band nudge to be worth injecting.
+ *  A sub-threshold rewrite (e.g. re-distilling a 232-token summary at near-
+ *  equal size) resets the nudge baselines on success, re-arming the still-hot
+ *  band next turn — a zero-yield loop (#198). Scales with the window so an
+ *  inflated host tokenCount can never make a tiny pending look actionable:
+ *  max(5000, round(limit × 0.01)); explicit 0 restores legacy any-pending. */
+function resolveMinPressureBenefit(
+  modelContextLimit: number,
+  nudge: NudgeConfig,
+): number {
+  return (
+    nudge.minPressureBenefitTokens ??
+    Math.max(5000, Math.round(modelContextLimit * 0.01))
+  );
+}
+
 /** Compressible amount for each tier. T1 = EFFECTIVE merged-range tokens —
  *  only ranges whose real char count >= minCompressRange count (avoids
  *  inflation from fragmentation; matches the apply-side gate, which counts
@@ -1115,6 +1131,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   const usage = limit > 0 ? tokenCount / limit : 0;
 
   const nudgeGrowthTokens = resolveAdaptiveGrowth(limit, config.nudge);
+  const minPressureBenefit = resolveMinPressureBenefit(limit, config.nudge);
 
   const overLimit = usage >= config.nudge.maxContextLimitPct;
   const emergencyOverride = usage >= config.nudge.emergencyThresholdPct;
@@ -1165,6 +1182,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
   );
   let injectedTier: CompressionTier | null = null;
   let injectedReason = "";
+  let bestPending = 0;
   const t1Eff = tiers[1]?.pending ?? 0;
   const t2Pen = tiers[2]?.pending ?? 0;
   const t3Pen = tiers[3]?.pending ?? 0;
@@ -1203,7 +1221,6 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       candidates.push(2, 3);
     }
     let best: CompressionTier | null = null;
-    let bestPending = 0;
     for (const t of candidates) {
       const p = tiers[t]?.pending ?? 0;
       if (p > bestPending) {
@@ -1211,7 +1228,10 @@ function decideNudge(input: NudgeInput): NudgeDecision {
         best = t;
       }
     }
-    if (best !== null && bestPending > 0) {
+    // Minimum-benefit gate (#198): a sub-threshold pending can never look
+    // actionable, no matter how hot the band is — otherwise every "success"
+    // resets the baselines and the same EMERGENCY nudge re-injects each turn.
+    if (best !== null && bestPending >= minPressureBenefit) {
       injectedTier = best;
       const label = emergencyOverride ? "EMERGENCY" : "OVER-LIMIT";
       injectedReason =
@@ -1266,7 +1286,10 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     reason = injectedReason;
   } else if (pressure) {
     const label = emergencyOverride ? "EMERGENCY" : "OVER-LIMIT";
-    reason = `${label}: usage ${Math.round(usage * 100)}% but no tier has effective compressible content (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}) — nudge suppressed to avoid offering ranges below minCompressRange`;
+    reason =
+      bestPending === 0
+        ? `${label}: usage ${Math.round(usage * 100)}% but no tier has effective compressible content (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}) — nudge suppressed to avoid offering ranges below minCompressRange`
+        : `${label}: usage ${Math.round(usage * 100)}% but max pending ${bestPending} < min benefit ${minPressureBenefit} tokens (T1 effective ${t1Eff}, T2 ${t2Pen}, T3 ${t3Pen}) — suppressed: rewriting below the benefit floor reclaims almost nothing while usage stays high; truncate.threshold remains the safety valve`;
    } else {
     const tiersList = [1, 2, 3] as const;
     const eligible = tiersList.filter((t) => config.tiers.enabled || t === 1);
@@ -1343,6 +1366,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
       hasPendingNudge: hasPendingNudge ? 1 : 0,
       overLimit: overLimit ? 1 : 0,
       emergencyOverride: emergencyOverride ? 1 : 0,
+      minPressureBenefit,
       pendingT1: tiers[1]!.pending,
       pendingT2: tiers[2]!.pending,
       pendingT3: tiers[3]!.pending,

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,13 @@ export function validateConfig(config: Config): string[] {
       "nudge.maxContextLimitPct must not exceed nudge.emergencyThresholdPct",
     );
   }
+  if (
+    config.nudge.minPressureBenefitTokens !== undefined &&
+    (!Number.isFinite(config.nudge.minPressureBenefitTokens) ||
+      config.nudge.minPressureBenefitTokens < 0)
+  ) {
+    errors.push("nudge.minPressureBenefitTokens must be finite and >= 0");
+  }
   if (config.promotionThreshold < 1) {
     errors.push("promotionThreshold must be >= 1");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,13 @@ export interface NudgeConfig {
    *  pending ≥ nudgeGrowthTokens × this multiplier AND T2 > T1 effective.
    *  Default 1.5. */
   tier2GrowthMultiplier: number;
+  /** Minimum tokens the pressure band (usage ≥ maxContextLimitPct /
+   *  emergencyThresholdPct) must be able to reclaim before injecting. Below
+   *  this, the rewrite reclaims almost nothing while high usage keeps the
+   *  band hot — each "success" resets the baselines and re-injects next turn
+   *  (zero-yield loop, #198). Default: max(5000, round(modelContextLimit ×
+   *  0.01)). Set 0 to restore the legacy any-pending behavior. */
+  minPressureBenefitTokens?: number;
 }
 
 export interface TruncateConfig {

--- a/tests/nudge-pressure-benefit.test.ts
+++ b/tests/nudge-pressure-benefit.test.ts
@@ -1,0 +1,274 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import type { Config, CompressionBlock, CoreMessage } from "../src/types.js";
+
+// #198: the pressure band (usage >= maxContextLimitPct / emergencyThresholdPct)
+// used to inject an EMERGENCY nudge for ANY bestPending > 0. Micro pending
+// (232 / 120 tokens in production) triggered rewrites that reclaimed ~nothing;
+// each success reset the nudge baselines and the still-hot band re-injected
+// next turn — a continuous zero-yield compression loop. These tests pin the
+// minimum-benefit gate: default max(5000, round(limit * 0.01)), overridable via
+// nudge.minPressureBenefitTokens, 0 = legacy any-pending behavior.
+
+function buildConfig(overrides: Partial<Config> = {}): Config {
+  const base = {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.9,
+      minContextLimitPct: 0.45,
+      frequency: 1,
+      iterationThreshold: 15,
+      force: "soft" as const,
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    merge: { maxSummaryLength: 3000, minOldGenBlocks: 3 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+  };
+  return { ...base, ...overrides };
+}
+
+function textMessage(
+  role: CoreMessage["role"],
+  id: string,
+  text: string,
+): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function makeMessages(count: number): CoreMessage[] {
+  return Array.from({ length: count }, (_, i) =>
+    textMessage(
+      i % 2 === 0 ? "user" : "assistant",
+      `m${i}`,
+      `message ${i} `.repeat(2000),
+    ),
+  );
+}
+
+// T1 block whose effective ids cover EVERY message → no compressible raw range
+// remains (T1 effective = 0); its summary is the only pending mass (T2).
+function coverAllBlock(
+  messages: CoreMessage[],
+  summaryChars: number,
+): CompressionBlock {
+  const ids = messages.map((m) => m.id);
+  return {
+    blockId: "b1",
+    runId: "r1",
+    tier: 1,
+    summary: "x".repeat(summaryChars),
+    directMessageIds: ids,
+    effectiveMessageIds: ids,
+    directBlockIds: [],
+    compressedTokens: summaryChars,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+  };
+}
+
+test("pressure: EMERGENCY with only micro T2 pending (232 tokens) is suppressed (#198)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 10000,
+  }).state;
+  // Mirrors production: "EMERGENCY T2 distill: max pending 232 (T1 effective 0,
+  // T2 232, T3 0)" — 928-char summary → 232 tokens at chars/4.
+  state = { ...state, blocks: [coverAllBlock(messages, 928)] };
+
+  let turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(
+    turn.nudge.breakdown.emergencyOverride,
+    1,
+    "usage 99% >= 98% → emergency band active",
+  );
+  assert.equal(
+    turn.nudge.shouldInject,
+    false,
+    "232 < default floor 5000 → no injection",
+  );
+  assert.equal(
+    turn.nudge.breakdown.minPressureBenefit,
+    5000,
+    "default = max(5000, round(1e5*0.01))",
+  );
+  assert.match(turn.nudge.reason, /EMERGENCY/);
+  assert.match(turn.nudge.reason, /232/);
+  assert.match(turn.nudge.reason, /suppressed/i);
+
+  // The loop: next turn must stay suppressed with nothing stamped.
+  turn = core.processTurn({
+    messages,
+    state: turn.state,
+    config,
+    tokenCount: 99500,
+  });
+  assert.equal(
+    turn.nudge.shouldInject,
+    false,
+    "suppression persists — no re-arm loop",
+  );
+  assert.equal(
+    turn.state.nudge.lastNudgeShownTokens,
+    0,
+    "no shown stamp on suppression",
+  );
+});
+
+test("pressure: EMERGENCY with only micro T3 pending (120 tokens) is suppressed (#198)", () => {
+  const core = createCore();
+  const config = buildConfig({ preserveRecentMessages: 10 });
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 10000,
+  }).state;
+  // Tier-2 block (→ T3 pending) with a 480-char summary → 120 tokens, mirroring
+  // production "EMERGENCY T3 condense: max pending 120". preserveRecentMessages
+  // zeroes T1 effective; fake directBlockIds keep any tier-1 sources alive.
+  state = {
+    ...state,
+    blocks: [
+      {
+        blockId: "t2-1",
+        runId: "r2",
+        tier: 2 as const,
+        summary: "x".repeat(480),
+        directMessageIds: [],
+        effectiveMessageIds: messages.map((m) => m.id),
+        directBlockIds: ["t2-src-1"],
+        compressedTokens: 480,
+        createdAt: Date.now(),
+        survivedCount: 0,
+        generation: "young" as const,
+        active: true,
+      },
+    ],
+  };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(turn.nudge.breakdown.emergencyOverride, 1);
+  assert.equal(turn.nudge.shouldInject, false, "120 < 5000 → suppressed");
+  assert.match(turn.nudge.reason, /EMERGENCY/);
+  assert.match(turn.nudge.reason, /120/);
+});
+
+test("pressure: pending exactly at the benefit floor still injects (boundary inclusive)", () => {
+  const core = createCore();
+  const config = buildConfig();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 10000,
+  }).state;
+  // 20000-char summary → 5000 tokens = exactly the default floor.
+  state = { ...state, blocks: [coverAllBlock(messages, 20000)] };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(turn.nudge.shouldInject, true, "5000 >= 5000 → injects");
+  assert.equal(turn.nudge.tier, 2, "argmax routes to T2");
+  assert.match(turn.nudge.reason, /EMERGENCY T2 distill: max pending 5000/);
+});
+
+test("pressure: window scaling — 1M limit raises the floor to 10000", () => {
+  const core = createCore();
+  const config = buildConfig({ modelContextLimit: 1000000 });
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 100000,
+  }).state;
+  // 24000-char summary → 6000 tokens < round(1e6 * 0.01) = 10000 → suppressed.
+  state = { ...state, blocks: [coverAllBlock(messages, 24000)] };
+  let turn = core.processTurn({ messages, state, config, tokenCount: 990000 });
+  assert.equal(
+    turn.nudge.shouldInject,
+    false,
+    "6000 < 10000 (1% of 1M window) → suppressed",
+  );
+  assert.equal(turn.nudge.breakdown.minPressureBenefit, 10000);
+
+  // 40000-char summary → 10000 tokens = floor → injects again.
+  state = { ...turn.state, blocks: [coverAllBlock(messages, 40000)] };
+  turn = core.processTurn({ messages, state, config, tokenCount: 990000 });
+  assert.equal(turn.nudge.shouldInject, true, "10000 >= 10000 → injects");
+  assert.equal(turn.nudge.tier, 2);
+});
+
+test("pressure: explicit minPressureBenefitTokens lowers the gate", () => {
+  const core = createCore();
+  const config = buildConfig({
+    nudge: { ...buildConfig().nudge, minPressureBenefitTokens: 100 },
+  });
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 10000,
+  }).state;
+  state = { ...state, blocks: [coverAllBlock(messages, 928)] };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(
+    turn.nudge.breakdown.minPressureBenefit,
+    100,
+    "override honored",
+  );
+  assert.equal(
+    turn.nudge.shouldInject,
+    true,
+    "232 >= 100 → injects despite micro pending",
+  );
+  assert.equal(turn.nudge.tier, 2);
+});
+
+test("pressure: minPressureBenefitTokens 0 restores legacy any-pending behavior", () => {
+  const core = createCore();
+  const config = buildConfig({
+    nudge: { ...buildConfig().nudge, minPressureBenefitTokens: 0 },
+  });
+  const messages = makeMessages(10);
+  let state = createInitialState();
+  state = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 10000,
+  }).state;
+  state = { ...state, blocks: [coverAllBlock(messages, 928)] };
+  const turn = core.processTurn({ messages, state, config, tokenCount: 99000 });
+  assert.equal(
+    turn.nudge.shouldInject,
+    true,
+    "legacy: any pending > 0 under pressure",
+  );
+  assert.equal(turn.nudge.tier, 2);
+});

--- a/tests/regression-bugfixes.test.ts
+++ b/tests/regression-bugfixes.test.ts
@@ -135,7 +135,8 @@ test("compressibleRanges use real assigned refs, not array-index arithmetic", ()
   const result = core.processTurn({
     messages,
     state,
-    config: config({ protectedTools: ["skill"], preserveRecentMessages: 2, nudge: { ...config().nudge, growthRatio: 0 } }),
+    // minPressureBenefitTokens: 0 = legacy any-pending pressure injection; this test exercises ref assignment, not the #198 benefit gate.
+    config: config({ protectedTools: ["skill"], preserveRecentMessages: 2, nudge: { ...config().nudge, growthRatio: 0, minPressureBenefitTokens: 0 } }),
     tokenCount: 99000,
   });
 
@@ -167,10 +168,11 @@ test("processTurn does not mutate the caller's input state.nudge", () => {
   assert.equal(baselineBefore, 0);
   assert.equal(shownBefore, 0);
 
+  // minPressureBenefitTokens: 0 = legacy any-pending pressure injection; this test exercises input-state immutability, not the #198 benefit gate.
   const result = core.processTurn({
     messages,
     state,
-    config: config({ nudge: { ...config().nudge, growthRatio: 0 } }),
+    config: config({ nudge: { ...config().nudge, growthRatio: 0, minPressureBenefitTokens: 0 } }),
     tokenCount: 99000,
   });
 
@@ -273,7 +275,8 @@ test("composable pipeline excluding sync-blocks must not leak nudge mutations to
   const core = createCore();
   const state = createInitialState();
   const messages = [msg("a", "hello"), msg("b", "world")];
-  const cfg = config({ nudge: { ...config().nudge, growthRatio: 0 } });
+  // minPressureBenefitTokens: 0 = legacy any-pending pressure injection; this test exercises pipeline composition, not the #198 benefit gate.
+  const cfg = config({ nudge: { ...config().nudge, growthRatio: 0, minPressureBenefitTokens: 0 } });
 
   const nodes = core
     .defaultNodes()

--- a/tests/sync-config.test.ts
+++ b/tests/sync-config.test.ts
@@ -90,6 +90,19 @@ test("validateConfig flags min > max nudge thresholds", () => {
   assert.ok(validateConfig(base).some((e) => e.includes("minContextLimitPct")));
 });
 
+test("validateConfig flags negative or non-finite minPressureBenefitTokens", () => {
+  const base = defaultConfig(200000);
+  base.nudge.minPressureBenefitTokens = -1;
+  assert.ok(validateConfig(base).some((e) => e.includes("minPressureBenefitTokens")));
+  base.nudge.minPressureBenefitTokens = Number.NaN;
+  assert.ok(validateConfig(base).some((e) => e.includes("minPressureBenefitTokens")));
+});
+
+test("validateConfig accepts explicit minPressureBenefitTokens override", () => {
+  const cfg = defaultConfig(200000, { nudge: { minPressureBenefitTokens: 0 } });
+  assert.deepEqual(validateConfig(cfg), []);
+});
+
 test("validateConfig passes for default config", () => {
   assert.deepEqual(validateConfig(defaultConfig(200000)), []);
 });


### PR DESCRIPTION
Fixes #198.

## Problem
The pressure band in `decideNudge` (usage >= maxContextLimitPct / emergencyThresholdPct) picked the argmax tier and injected whenever `bestPending > 0`. In production (v0.0.48) this fired `EMERGENCY T2 distill: max pending 232 ... usage 128%` and `EMERGENCY T3 condense: max pending 120 ...` repeatedly: each rewrite reclaimed ~0 tokens, each success reset the nudge baselines, and the still-hot band re-injected the same EMERGENCY nudge every turn - a continuous zero-yield compression loop.

## Fix
- Pressure band now injects only when `bestPending >= minPressureBenefit`, default **`max(5000, round(modelContextLimit * 0.01))`** (5K floor up to 500K windows, then 1% of window: 2K @ 200K, 10K @ 1M). A tiny pending can no longer masquerade as an actionable emergency regardless of how accurate the host tokenCount is.
- New optional config knob `nudge.minPressureBenefitTokens` for hosts that need to tune it; explicit `0` restores the legacy any-pending behavior. Validated in `validateConfig` (finite, >= 0).
- When suppressed, the reason states why: usage high but max pending below the benefit floor - instead of offering a sub-threshold rewrite. The zero-pending reason is unchanged; `truncate.threshold` remains the independent last resort.
- `NudgeBreakdown` now exposes `minPressureBenefit` for adapters/debugging.

## Scope
Pressure band only. The count-triggered T2/T3 paths (`tier2Trigger`/`tier3Trigger`) deliberately fire on block count regardless of summary token mass (LSM-style compaction) and are untouched, as is the #194 first-sight mass bypass.

## Tests
`tests/nudge-pressure-benefit.test.ts` (new) mirrors the production pendings at exact values:
- EMERGENCY + only 232-token T2 pending -> suppressed, reason explains the shortfall, second turn stays suppressed with nothing stamped (loop cannot re-arm)
- EMERGENCY + only 120-token T3 pending -> suppressed
- pending exactly at the floor (5000) -> still injects (boundary inclusive)
- 1M window -> floor scales to 10000 (6000 pending suppressed; 10000 injects)
- override 100 honored (232 injects); override 0 restores legacy behavior

All three suppression tests failed against unmodified master (captured before implementing); after the fix: **571/571 tests pass**, `tsc --noEmit` clean, build clean.

Three pre-existing regression tests (`tests/regression-bugfixes.test.ts`) used pressure injection with micro pending purely as scaffolding for unrelated assertions (ref assignment, input-state immutability, pipeline composition). They opt out via the documented `minPressureBenefitTokens: 0` escape hatch, keeping them testing what they always tested.