### PR TITLE
release v0.0.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.51",
+            "version": "0.0.52",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## Changes since v0.0.51

- **#198 fix** (PR #199): pressure-band nudges in `decideNudge` are now gated on a minimum benefit floor — default `max(5000, round(modelContextLimit × 0.01))` (5K floor up to 500K windows, then 1% of window: 2K @ 200K, 10K @ 1M). A micro pending (the production incident fired EMERGENCY on 232/120-token pendings at usage 128%) can no longer masquerade as an actionable emergency: each zero-yield rewrite used to reset the nudge baselines and re-arm the still-hot band every turn — a continuous compression loop. New optional knob `nudge.minPressureBenefitTokens` (explicit `0` restores legacy any-pending behavior; validated finite ≥ 0 in `validateConfig`); suppressed reason states the shortfall; `NudgeBreakdown` exposes `minPressureBenefit`. Count-triggered T2/T3 paths and the #194 first-sight mass bypass are untouched.

## Pre-flight

- typecheck ✅
- tests 571/571 ✅
- build ✅

Commit is version-bump-only (`package.json` + `package-lock.json`).