### PR TITLE
release v0.0.53

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.52",
+    "version": "0.0.53",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## What

Version bump only — ships PR #201 (`fix: retry whole write cycle on transient ENOENT/ENOTDIR (CI Windows temp sweep)`).

## Why it matters

GitHub Windows runners (and real-world AV software) periodically sweep `%TEMP%`, deleting freshly-created files between `writeFile(tmp)` and `rename`. The old retry set (EPERM/EBUSY/EACCES) rethrew ENOENT immediately → data-at-risk logs on bili CI and dropped session persists. #201 retries the whole write cycle (mkdir + fresh tmp + write + rename) on transient ENOENT/ENOTDIR, and retries the spill write too.

## Pre-flight

- typecheck ✓
- 575/575 tests ✓
- build ✓

## Downstream

billion-context PR #559 (test polling, already merged) is the test-side companion; after this publishes, bili will bump its `acp-kernel` pin to 0.0.53 and release v0.1.86.