### PR TITLE
release v0.0.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.53",
+    "version": "0.0.54",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Version-only release bump for **v0.0.54**.

## Changes since v0.0.53
- PR#203 (c1634b1): fix report tool accounting — attribute tool-results to their calling tool via toolCallId map (#386 follow-up); pct() floor removed; uncompressed ranges label true dominant tool; `isToolMessage` exported and reused; panel docstrings stop claiming chars/4. 5 new regression tests (580/580).

## Pre-flight
- typecheck ✓
- tests 580/580 ✓
- build ✓

Downstream: billion-context will pin 0.0.54 and switch its 3 `buildStatusReport` call sites to `defaultCountTokens` (closes billion-context#386).