### PR TITLE
release v0.0.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.54",
+    "version": "0.0.55",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Changes since v0.0.54:
- #205 merge write-side quote fidelity into tuned compress prompts (verbatim user quotes require mNNNNN refs; task state labeled TASK AS OF THIS BLOCK history; no copying \uXXXX escapes from tool output; tier-2 KEEP guards against CURRENT TASK inheritance; read-side note re older blocks lacking refs)

Motivation: billion-context-pi#309 incident (fabricated user verbatim quote persisted as live CURRENT TASK → loop relapses).

bcp must pin ≥0.0.55 (0.0.54 lacks the prompt fix), then remove the adapter-level SUMMARY FIDELITY RULES section (bcp#310 coordination comment).