### PR TITLE
fix(recommend): segment compressible ranges by array adjacency, not refNum continuity

### DIFF
--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -28,11 +28,6 @@ import {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function refNum(ref: string): number {
-  const n = parseInt(ref.slice(1), 10);
-  return Number.isNaN(n) ? -1 : n;
-}
-
 /** Default token estimate (chars/4) used when the caller doesn't inject a
  *  countTokens — preserves the historical behavior for backwards compat. */
 function estimateTextTokens(text: string): number {
@@ -152,131 +147,147 @@ export function buildCompressibleRanges(
   countTokens: (text: string) => number = estimateTextTokens,
 ): ContextRanges {
   const compressibleMsgs: {
-    ref: string;
-    refNum: number;
-    tokens: number;
-    chars: number;
-    isTool: boolean;
-    isUser: boolean;
-  }[] = [];
+  ref: string;
+  gapBefore: boolean;
+  tokens: number;
+  chars: number;
+  isTool: boolean;
+  isUser: boolean;
+}[] = [];
   const protectedMsgs: {
-    ref: string;
-    refNum: number;
-    tokens: number;
-    tools: string[];
-  }[] = [];
+  ref: string;
+  gapBefore: boolean;
+  tokens: number;
+  tools: string[];
+}[] = [];
 
   // Pairing: a tool-result may carry only toolCallId (no toolName). Collect the
   // callIds of protected tool-calls first, then protect matching results too.
   const protectedCallIds = collectProtectedToolCallIds(messages, config);
 
+  // Continuity follows the message ARRAY, not ref arithmetic: a host that
+  // replaces its surface feeds the kernel the current surface only — shadowed
+  // messages leave the array (ref-map holes) and freshly written summary nodes
+  // join mid-array with fresh HIGH refs, so ref numbers no longer track
+  // message order. What still splits a range is a message SKIPPED between two
+  // entries: protected, synthetic, or in the protected zone.
+  let pendingGapC = false;
+  let pendingGapP = false;
+
   for (const msg of messages) {
-    if (isSyntheticOrPruned(msg, state)) continue;
-    const ref = state.messageRefs.byRaw[msg.id];
-    if (!ref || ref === "BLOCKED") continue;
+  const ref = state.messageRefs.byRaw[msg.id];
+  if (isSyntheticOrPruned(msg, state)) {
+  if (ref && ref !== "BLOCKED") {
+  pendingGapC = true;
+  pendingGapP = true;
+  }
+  continue;
+  }
+  if (!ref || ref === "BLOCKED") continue;
 
-    const rn = refNum(ref);
-
-    if (isMessageProtectedWithPairing(msg, config, protectedCallIds)) {
-      protectedMsgs.push({
-        ref,
-        refNum: rn,
-        tokens: countTokens(msg.text ?? ""),
-        tools: msg.toolName ? [msg.toolName] : [],
-      });
-      continue;
-    }
-
-    if (protectedZoneRefs?.has(ref)) {
-      continue;
-    }
-
-    compressibleMsgs.push({
-      ref,
-      refNum: rn,
-      tokens: countTokens(msg.text ?? ""),
-      chars: (msg.text ?? "").length,
-      isTool: isToolMessage(msg),
-      isUser: msg.role === "user",
-    });
+  if (isMessageProtectedWithPairing(msg, config, protectedCallIds)) {
+  protectedMsgs.push({
+  ref,
+  gapBefore: pendingGapP,
+  tokens: countTokens(msg.text ?? ""),
+  tools: msg.toolName ? [msg.toolName] : [],
+  });
+  pendingGapC = true;
+  pendingGapP = false;
+  continue;
   }
 
-  // Build compressible groups (contiguous, split at ref gaps and at user
-  // messages once a group has >= 3 messages). Splitting at user boundaries
-  // keeps each compressible range aligned to roughly one user turn, instead
-  // of producing one giant range spanning many turns (or, conversely, a
-  // fragment per message when ref gaps appear). Mirrors opencode-acp's
-  // buildCompressibleRanges condition.
+  if (protectedZoneRefs?.has(ref)) {
+  pendingGapC = true;
+  pendingGapP = true;
+  continue;
+  }
+
+  compressibleMsgs.push({
+  ref,
+  gapBefore: pendingGapC,
+  tokens: countTokens(msg.text ?? ""),
+  chars: (msg.text ?? "").length,
+  isTool: isToolMessage(msg),
+  isUser: msg.role === "user",
+  });
+  pendingGapC = false;
+  pendingGapP = true;
+}
+
+  // Build compressible groups (contiguous in the array; split at skipped-
+  // message boundaries and at user messages once a group has >= 3 messages).
+  // Splitting at user boundaries keeps each compressible range aligned to
+  // roughly one user turn, instead of producing one giant range spanning many
+  // turns. Array adjacency — not ref arithmetic — is the continuity ground
+  // truth: append-only hosts see exactly the ranges ref continuity used to
+  // derive, while replace-style hosts group the surface they actually show.
   const compressible: CompressibleRange[] = [];
   let cur: CompressibleRange | null = null;
-  let prevRefNum = -2;
 
   for (const info of compressibleMsgs) {
-    const hasGap = info.refNum > prevRefNum + 1;
-    if (cur && ((info.isUser && cur.count >= 3) || hasGap)) {
-      compressible.push(cur);
-      cur = null;
-    }
-    prevRefNum = info.refNum;
-    if (!cur) {
-      cur = {
-        startRef: info.ref,
-        endRef: info.ref,
-        count: 1,
-        tokens: info.tokens,
-        chars: info.chars,
-        toolPct: info.isTool ? 100 : 0,
-        textPct: info.isTool ? 0 : 100,
-      };
-    } else {
-      cur.endRef = info.ref;
-      cur.count++;
-      cur.tokens += info.tokens;
-      cur.chars = (cur.chars ?? 0) + info.chars;
-      if (info.isTool) {
-        cur.toolPct = Math.round((cur.toolPct * (cur.count - 1) + 100) / cur.count);
-      } else {
-        cur.toolPct = Math.round((cur.toolPct * (cur.count - 1)) / cur.count);
-      }
-      cur.textPct = 100 - cur.toolPct;
-    }
+  const hasGap = info.gapBefore;
+  if (cur && ((info.isUser && cur.count >= 3) || hasGap)) {
+  compressible.push(cur);
+  cur = null;
   }
+  if (!cur) {
+  cur = {
+  startRef: info.ref,
+  endRef: info.ref,
+  count: 1,
+  tokens: info.tokens,
+  chars: info.chars,
+  toolPct: info.isTool ? 100 : 0,
+  textPct: info.isTool ? 0 : 100,
+  };
+  } else {
+  cur.endRef = info.ref;
+  cur.count++;
+  cur.tokens += info.tokens;
+  cur.chars = (cur.chars ?? 0) + info.chars;
+  if (info.isTool) {
+  cur.toolPct = Math.round((cur.toolPct * (cur.count - 1) + 100) / cur.count);
+  } else {
+  cur.toolPct = Math.round((cur.toolPct * (cur.count - 1)) / cur.count);
+  }
+  cur.textPct = 100 - cur.toolPct;
+  }
+}
   if (cur) compressible.push(cur);
 
-  // Build protected groups (contiguous)
+  // Build protected groups (contiguous in the array)
   const protectedRanges: ProtectedRange[] = [];
   let pcur: ProtectedRange | null = null;
-  let pPrevRefNum = -2;
 
   for (const info of protectedMsgs) {
-    const hasGap = info.refNum > pPrevRefNum + 1;
-    if (pcur && hasGap) {
-      protectedRanges.push(pcur);
-      pcur = null;
-    }
-    pPrevRefNum = info.refNum;
-    if (!pcur) {
-      pcur = {
-        startRef: info.ref,
-        endRef: info.ref,
-        count: 1,
-        tokens: info.tokens,
-        tools: [...info.tools],
-      };
-    } else {
-      pcur.endRef = info.ref;
-      pcur.count++;
-      pcur.tokens += info.tokens;
-      for (const t of info.tools) {
-        if (!pcur!.tools.includes(t)) pcur!.tools.push(t);
-      }
-    }
+  const hasGap = info.gapBefore;
+  if (pcur && hasGap) {
+  protectedRanges.push(pcur);
+  pcur = null;
   }
+  if (!pcur) {
+  pcur = {
+  startRef: info.ref,
+  endRef: info.ref,
+  count: 1,
+  tokens: info.tokens,
+  tools: [...info.tools],
+  };
+  } else {
+  pcur.endRef = info.ref;
+  pcur.count++;
+  pcur.tokens += info.tokens;
+  for (const t of info.tools) {
+  if (!pcur!.tools.includes(t)) pcur!.tools.push(t);
+  }
+  }
+}
   if (pcur) protectedRanges.push(pcur);
 
   return {
-    compressible: compressible.filter((g) => g.tokens > 0),
-    protected: protectedRanges,
+  compressible: compressible.filter((g) => g.tokens > 0),
+  protected: protectedRanges,
   };
 }
 

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -245,6 +245,98 @@ test("buildCompressibleRanges: does NOT split before a group reaches 3 messages"
   assert.equal(ranges.compressible[0]!.count, 3);
 });
 
+// ─── Replace-host shapes: ref-map holes, mid-array summary nodes ───────────
+
+test("buildCompressibleRanges: ref-map holes from a replaced surface do NOT fragment ranges", () => {
+  // Regression guard for the replace-host contract: a durable-surface host
+  // passes the CURRENT surface only. Messages shadowed by an earlier
+  // compression leave the array while their refs stay assigned — the map
+  // grows holes. Nothing was SKIPPED between m2 and m7 on the surface, so
+  // the four messages form one contiguous range.
+  const history = [
+  msg("m1", "x".repeat(2000), "assistant"),
+  msg("m2", "y".repeat(2000), "assistant"),
+  msg("m3", "z".repeat(2000), "assistant"),
+  msg("m4", "w".repeat(2000), "assistant"),
+  msg("m5", "v".repeat(2000), "assistant"),
+  msg("m6", "u".repeat(2000), "assistant"),
+  msg("m7", "t".repeat(2000), "assistant"),
+  msg("m8", "s".repeat(2000), "assistant"),
+  ];
+  const state = assignAll(history);
+  const surface = [
+  msg("m1", "x".repeat(2000), "assistant"),
+  msg("m2", "y".repeat(2000), "assistant"),
+  msg("m7", "t".repeat(2000), "assistant"),
+  msg("m8", "s".repeat(2000), "assistant"),
+  ];
+  const ranges = buildCompressibleRanges(surface, state, config());
+  assert.equal(ranges.compressible.length, 1, "holes in the ref map are not interruptions");
+  assert.equal(ranges.compressible[0]!.startRef, "m00001");
+  assert.equal(ranges.compressible[0]!.endRef, "m00008");
+  assert.equal(ranges.compressible[0]!.count, 4);
+});
+
+test("buildCompressibleRanges: a mid-array summary node extends the range instead of flushing it", () => {
+  // The replace host writes the model's summary node at the position of the
+  // replaced span — mid-array — while assignRefs gives it a FRESH HIGH ref
+  // (m00007 here). Ref arithmetic saw the jump as a gap: it flushed the live
+  // head and emitted a descending pair that hid the messages behind the
+  // summary. Array adjacency says the summary is simply the next compressible
+  // message.
+  const history = [
+  msg("m1", "x".repeat(2000), "assistant"),
+  msg("m2", "y".repeat(2000), "assistant"),
+  msg("m3", "z".repeat(2000), "assistant"),
+  msg("m4", "w".repeat(2000), "assistant"),
+  msg("m5", "v".repeat(2000), "assistant"),
+  msg("m6", "u".repeat(2000), "assistant"),
+  ];
+  const state = assignAll(history);
+  const summary = msg("s1", "summary of the replaced span", "assistant");
+  // m3..m4 were replaced by the summary on the host surface; re-assigning refs
+  // for the surface keeps the first-wins map and allocates m00007 for the
+  // summary node.
+  const surface = [
+  msg("m1", "x".repeat(2000), "assistant"),
+  msg("m2", "y".repeat(2000), "assistant"),
+  summary,
+  msg("m5", "v".repeat(2000), "assistant"),
+  msg("m6", "u".repeat(2000), "assistant"),
+  ];
+  const state2 = assignAll(surface, state);
+  const ranges = buildCompressibleRanges(surface, state2, config());
+  assert.equal(ranges.compressible.length, 1, "no spurious split at the summary node");
+  assert.equal(ranges.compressible[0]!.startRef, "m00001");
+  assert.equal(ranges.compressible[0]!.endRef, "m00006");
+  assert.equal(ranges.compressible[0]!.count, 5);
+});
+
+test("buildCompressibleRanges: a range starting at a mid-array summary node is an ordered anchor pair", () => {
+  // Same shape with the replaced span at the HEAD: the group starts at the
+  // summary's fresh HIGH ref and ends at a lower one. The pair is ARRAY-ORDERED
+  // (start = array head, end = array tail); apply-side boundaries resolve
+  // anchors by message index (boundaries.ts), so the span still applies
+  // correctly — consumers must read the pair as anchors, never as a numeric
+  // interval.
+  const history = [
+  msg("m1", "x".repeat(2000), "assistant"),
+  msg("m2", "y".repeat(2000), "assistant"),
+  msg("m3", "z".repeat(2000), "assistant"),
+  msg("m4", "w".repeat(2000), "assistant"),
+  msg("m5", "v".repeat(2000), "assistant"),
+  ];
+  const state = assignAll(history);
+  const summary = msg("s1", "summary of the replaced head", "assistant");
+  const surface = [summary, msg("m4", "w".repeat(2000), "assistant"), msg("m5", "v".repeat(2000), "assistant")];
+  const state2 = assignAll(surface, state);
+  const ranges = buildCompressibleRanges(surface, state2, config());
+  assert.equal(ranges.compressible.length, 1);
+  assert.equal(ranges.compressible[0]!.startRef, "m00006", "the summary keeps its fresh high ref as the array head");
+  assert.equal(ranges.compressible[0]!.endRef, "m00005");
+  assert.equal(ranges.compressible[0]!.count, 3, "the descending pair still covers the whole array span");
+});
+
 // ─── Integration: 19-token bug fix ─────────────────────────────────────────────
 
 test("integration: tiny ranges are suppressed — fixes the 19-token compression bug", () => {


### PR DESCRIPTION
Fixes #207

<!-- ework-agent-pr -->

## Problem

On a host that compresses by durably REPLACING its message surface (billion-context-dsh / DeepSeek Harness), after a handful of compressions the nudge range table shows ranges whose endRef is numerically smaller than startRef (real example: `m00110295..m00106762`), large tool results drop out of the recommended ranges, and the benefit floor starves nudges (observed: a ~28-token table at ~20 % occupancy). Tracking line: Tyan66666/billion-context-dsh#38.

## Cause

`buildCompressibleRanges` segmented ranges with `hasGap = info.refNum > prevRefNum + 1`. That assumes refNum order equals message-array order — true only for append-only hosts. A replace-style host breaks it two ways: (a) compressed messages leave the array while their refs stay assigned (map holes → false gaps → every range fragments), and (b) the summary node is inserted mid-array with a fresh high ref (→ the live head flushes and a descending pair is emitted).

## Fix

Segment by array adjacency instead of ref arithmetic. Each list entry carries a `gapBefore` flag, set when a numbered-ref message was SKIPPED between two entries of the list (protected tool, synthetic/covered, protected zone) or routed to the other list; the grouping loop splits on the flag. User-turn-boundary splitting is unchanged. The `refNum` helper and the `prevRefNum` arithmetic are removed.

- No ref is recycled, rewritten, or pruned — the "never reuse" invariant recorded by the #176 revert stands untouched.
- The apply side already resolves anchors by message index (`boundaries.ts` `indexByMessageId`), so a descending anchor pair still applies to the correct span; a new test pins the pair as an ORDERED ANCHOR (array head..tail), never a numeric interval.

## Verification

- Existing suite: 580/580 green with ZERO edits to existing tests (append-only hosts see byte-identical ranges: a numbered message is skipped between two entries iff a refNum gap exists).
- 3 new regression tests in tests/recommend.test.ts; the first two FAIL on the old code (verified by stashing the fix: 18/20 → 20/20), the third documents the anchor-pair contract.
- Full suite 583/583; `npm run typecheck` and `npm run build` clean.

Downstream: billion-context-dsh keeps a labeled workaround (`buildCompressibleSeqRanges`, rule-11 stopgap) whose removal gate is this fix shipping — it deletes the self-computation on the next kernel bump that includes this PR.
