### PR TITLE
release v0.0.56

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.55",
+    "version": "0.0.56",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Ships #182 (panel label fixes: never-shrinks wording, cumulative tokensCompressed).

Contents since v0.0.55:
- #182 — panel.ts/sync.ts/types.ts: label accuracy fixes only, no behavior change

After merge, release.yml publishes 0.0.56 to npm automatically. Then billion-context-pi #268 (already rebased onto v0.1.58, CI green) can merge; a follow-up bcp PR will bump the kernel dep to 0.0.56.