### PR TITLE
feat: salvage single-quoted JSON compress args in the kernel (#211)

### DIFF
--- a/src/parse-compress-input.ts
+++ b/src/parse-compress-input.ts
@@ -8,6 +8,8 @@
 //   - raw newlines inside string values (line-wrapped summaries)
 //   - the whole arguments object stringified by the gateway (vLLM,
 //     billion-context#176)
+//   - single-quoted JSON: {'content': [...]} (weak local models,
+//     billion-context#603 / omp#121)
 //   - the stream cut off mid-arguments, leaving a truncated JSON prefix
 //
 // Hosts parse this on their own today: rebuild.ts (strict, silent skip),
@@ -37,6 +39,8 @@ export interface CompressParseDiagnostics {
     ok: boolean;
     /** Why the input parsed the way it did. */
     kind: CompressParseKind;
+    /** True when the winning parse came from single→double quote repair. */
+    quoteSalvage?: boolean;
     /** First 800 chars of the raw string input (string inputs only). */
     rawPrefix?: string;
     /** Raw string input length (string inputs only). */
@@ -87,6 +91,29 @@ function parseStringInput(raw: string, callId: string | undefined, diag: Compres
     diag.rawPrefix = raw.slice(0, 800);
     diag.length = raw.length;
     const cleaned = stripFence(raw.trim());
+    const first = parseStringCore(cleaned, callId, diag);
+    // Weak local models emit single-quoted args ({'content': [...]}). The
+    // salvage regex only recognizes double-quoted "content", so a truncated
+    // single-quoted prefix recovers nothing on the first pass. Retry once
+    // with the quotes normalized; the retry wins only if it recovers strictly
+    // more ranges, so valid input is never rewritten.
+    if (first.ranges.length === 0 || first.diagnostics.invalidItems > 0) {
+        const normalized = normalizeSingleQuotes(cleaned);
+        if (normalized !== undefined) {
+            const retryDiag: CompressParseDiagnostics = { ok: false, kind: "ok", invalidItems: 0 };
+            retryDiag.rawPrefix = diag.rawPrefix;
+            retryDiag.length = diag.length;
+            const retry = parseStringCore(normalized, callId, retryDiag);
+            if (retry.ranges.length > first.ranges.length) {
+                retryDiag.quoteSalvage = true;
+                return retry;
+            }
+        }
+    }
+    return first;
+}
+
+function parseStringCore(cleaned: string, callId: string | undefined, diag: CompressParseDiagnostics): ParsedCompressInput {
     if (cleaned === "") {
         diag.kind = "empty-input";
         return finish([], diag);
@@ -144,6 +171,7 @@ function parseObjectValue(value: Record<string, unknown>, callId: string | undef
         }
         entries = parsed.entries;
         salvaged = parsed.salvaged;
+        if (parsed.quoteRepaired) diag.quoteSalvage = true;
     } else {
         diag.kind = "content-not-array";
         return finish([], diag);
@@ -168,9 +196,22 @@ function parseObjectValue(value: Record<string, unknown>, callId: string | undef
     return finish(ranges, diag);
 }
 
-function parseContentArray(s: string): { entries: unknown[]; salvaged: boolean } | null {
+function parseContentArray(s: string): { entries: unknown[]; salvaged: boolean; quoteRepaired?: boolean } | null {
     const cleaned = stripFence(s.trim());
-    let value: unknown = cleaned === "" ? undefined : tryParseLenient(cleaned);
+    const direct = parseContentArrayCore(cleaned);
+    if (direct !== null && direct.entries.length > 0) return direct;
+    // Single-quoted array (weak local models): normalize once and re-run;
+    // the retry is adopted only if it recovers strictly more entries.
+    const normalized = normalizeSingleQuotes(cleaned);
+    if (normalized !== undefined) {
+        const retry = parseContentArrayCore(normalized);
+        if (retry !== null && retry.entries.length > 0) return { ...retry, quoteRepaired: true };
+    }
+    return direct;
+}
+
+function parseContentArrayCore(s: string): { entries: unknown[]; salvaged: boolean } | null {
+    let value: unknown = s === "" ? undefined : tryParseLenient(s);
     if (typeof value === "string") {
         value = tryParseLenient(stripFence(value));
     }
@@ -179,7 +220,7 @@ function parseContentArray(s: string): { entries: unknown[]; salvaged: boolean }
     }
     if (value === undefined) {
         // Unparseable (usually truncated): recover the complete entries.
-        const entries = salvageContentEntries('{"content": ' + cleaned);
+        const entries = salvageContentEntries('{"content": ' + s);
         return { entries, salvaged: entries.length > 0 };
     }
     return null;
@@ -267,6 +308,79 @@ function tryParseLenient(s: string): unknown {
         }
     }
     return undefined;
+}
+
+// State machine that converts single-quoted strings to double-quoted ones.
+// Apostrophes inside double-quoted strings are data and are copied verbatim;
+// control characters inside single-quoted regions become JSON escapes.
+// Returns undefined when nothing was converted (input unchanged).
+// Ported from billion-context compress-tool.ts (#603/#610): pure text repair —
+// it never invents structure, so anything it cannot make into valid JSON
+// simply stays unrecovered.
+function normalizeSingleQuotes(raw: string): string | undefined {
+    if (!raw.includes("'") || (!raw.includes("{") && !raw.includes("["))) return undefined;
+    let out = "";
+    let changed = false;
+    let inDouble = false;
+    let inSingle = false;
+    for (let i = 0; i < raw.length; i++) {
+        const ch = raw.charAt(i);
+        if (inDouble) {
+            out += ch;
+            if (ch === "\\" && i + 1 < raw.length) {
+                out += raw.charAt(i + 1);
+                i++;
+            } else if (ch === '"') {
+                inDouble = false;
+            }
+            continue;
+        }
+        if (inSingle) {
+            if (ch === "\\" && i + 1 < raw.length) {
+                const next = raw.charAt(i + 1);
+                out += next === "'" ? "'" : "\\" + next;
+                i++;
+                continue;
+            }
+            if (ch === "'") {
+                out += '"';
+                inSingle = false;
+                changed = true;
+                continue;
+            }
+            if (ch === '"') {
+                out += '\\"';
+                continue;
+            }
+            if (ch === "\n") {
+                out += "\\n";
+                continue;
+            }
+            if (ch === "\r") {
+                out += "\\r";
+                continue;
+            }
+            if (ch === "\t") {
+                out += "\\t";
+                continue;
+            }
+            out += ch;
+            continue;
+        }
+        if (ch === '"') {
+            inDouble = true;
+            out += ch;
+            continue;
+        }
+        if (ch === "'") {
+            inSingle = true;
+            out += '"';
+            changed = true;
+            continue;
+        }
+        out += ch;
+    }
+    return changed ? out : undefined;
 }
 
 function stripFence(s: string): string {

--- a/tests/parse-compress-input.test.ts
+++ b/tests/parse-compress-input.test.ts
@@ -122,6 +122,96 @@ test("parseCompressArgs preserves escaped quotes in salvaged entries", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Single-quoted JSON salvage (#603 / omp#121: weak local models)
+// ---------------------------------------------------------------------------
+
+test("parseCompressArgs salvages single-quoted JSON args (#603)", () => {
+    const input = `{'content':[{'startId':'m00010','endId':'m00020','summary':'first'},{'startId':'m00030','endId':'m00040','summary':'second','topic':'mid'}],'topic':'intro'}`;
+    const { ranges, diagnostics } = parseCompressArgs(input, { callId: "call-q" });
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.quoteSalvage, true);
+    assert.equal(ranges.length, 2);
+    assert.equal(ranges[0]?.startRef, "m00010");
+    assert.equal(ranges[0]?.endRef, "m00020");
+    assert.equal(ranges[0]?.summary, "first");
+    assert.equal(ranges[0]?.topic, "intro");
+    assert.equal(ranges[0]?.compressCallId, "call-q");
+    assert.equal(ranges[1]?.startRef, "m00030");
+    assert.equal(ranges[1]?.topic, "mid");
+});
+
+test("parseCompressArgs salvages mixed single/double quotes, keeps apostrophes in data (#603)", () => {
+    const input = `{'content': [{'startId': "m00001", 'endId': "m00009", 'summary': "it's done, really"}]}`;
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.quoteSalvage, true);
+    assert.equal(ranges.length, 1);
+    assert.equal(ranges[0]?.startRef, "m00001");
+    assert.equal(ranges[0]?.endRef, "m00009");
+    assert.equal(ranges[0]?.summary, "it's done, really");
+});
+
+test("parseCompressArgs salvages truncated single-quoted content array (#603)", () => {
+    const input = `{'content':[{'startId':'m00010','endId':'m00020','summary':'first'},{'startId':'m00030','endId':'m00040','summary':'secon`;
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "truncated");
+    assert.equal(diagnostics.ok, true);
+    assert.equal(diagnostics.quoteSalvage, true);
+    assert.equal(ranges.length, 1);
+    assert.equal(ranges[0]?.startRef, "m00010");
+    assert.equal(ranges[0]?.endRef, "m00020");
+    assert.equal(ranges[0]?.summary, "first");
+});
+
+test("parseCompressArgs salvages object input whose content string is single-quoted (#603)", () => {
+    const input = { content: `[{'startId':'m00005','endId':'m00006','summary':'ok'}]` };
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.quoteSalvage, true);
+    assert.equal(ranges.length, 1);
+    assert.equal(ranges[0]?.startRef, "m00005");
+    assert.equal(ranges[0]?.endRef, "m00006");
+    assert.equal(ranges[0]?.summary, "ok");
+});
+
+test("parseCompressArgs still rejects prose with apostrophes unchanged (#603)", () => {
+    const { ranges, diagnostics } = parseCompressArgs("I couldn't believe {that} would 'work'");
+    assert.deepEqual(ranges, []);
+    assert.equal(diagnostics.ok, false);
+    assert.equal(diagnostics.kind, "malformed-json");
+    assert.equal(diagnostics.quoteSalvage, undefined);
+});
+
+test("parseCompressArgs leaves valid double-quoted args untouched by salvage (#603)", () => {
+    const input = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "don't panic" }] });
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.quoteSalvage, undefined);
+    assert.equal(ranges.length, 1);
+    assert.equal(ranges[0]?.summary, "don't panic");
+});
+
+test("parseCompressArgs repairs single quotes combined with trailing commas and raw newlines", () => {
+    const input = `{'content':[{'startId':'m00001','endId':'m00002','summary':'line1\nline2',}]}`;
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(diagnostics.kind, "ok");
+    assert.equal(diagnostics.quoteSalvage, true);
+    assert.equal(ranges.length, 1);
+    assert.equal(ranges[0]?.summary, "line1\nline2");
+});
+
+test("parseCompressArgs does not fabricate fields for a single-quoted entry missing bounds", () => {
+    // Quote repair makes the entry parseable, but validation still applies:
+    // no endId/summary means no range — reported, not invented. The retry
+    // wins only on strictly more ranges, so first-pass diagnostics stand.
+    const input = `{'content':[{'startId':'m00010'}]}`;
+    const { ranges, diagnostics } = parseCompressArgs(input);
+    assert.equal(ranges.length, 0);
+    assert.equal(diagnostics.ok, false);
+    assert.equal(diagnostics.quoteSalvage, undefined);
+});
+
+// ---------------------------------------------------------------------------
 // Truncation salvage
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Folds the single→double quote-repair state machine from billion-context#610 into `parseCompressArgs`, so all hosts (billion-context proxy, omp, pi) converge on one parser. After this release ships, the host-side fallback in billion-context#610 can be dropped.

## Changes (`src/parse-compress-input.ts`)

- **Ported `normalizeSingleQuotes`** (~60-line state machine, verbatim semantics): apostrophes inside double-quoted strings are data and copied verbatim; control chars inside single-quoted regions become JSON escapes; returns `undefined` when nothing was converted. Pure text repair — never invents structure.
- **String input**: `parseStringInput` split into core + wrapper. When the first pass recovers zero ranges or reports invalid items, retry once through the normalized text (mirrors the proven #610 fallback).
- **Object input with stringified content**: same retry inside `parseContentArray` (split into core + retry), so the `{"content": "[{...single...]"}` shape is covered too.
- **Adoption rule unchanged from #610**: the retry wins only if it recovers *strictly more* ranges/entries → valid input is never rewritten; tied retries keep first-pass diagnostics.
- **New diagnostic field** `CompressParseDiagnostics.quoteSalvage?: boolean` — true iff the winning parse came from quote normalization (gives hosts observability parity with the proxy's warn log).

## Verification

- Both issue repros now recover: full single-quoted object → 2 ranges, kind=ok, quoteSalvage=true; stringified single-quoted content → recovered.
- Test matrix ported from billion-context tests/basic.test.ts (#603 cases): full single-quoted object w/ topic+callId stamping, mixed quotes w/ apostrophe in double-quoted data preserved verbatim, truncated single-quoted array (1 complete entry), object input w/ single-quoted content string, prose-with-apostrophes still rejected (malformed-json), valid double-quoted input untouched (quoteSalvage stays undefined), plus single quotes combined with trailing commas + raw newlines, and no-fabrication check for entries missing bounds.
- `npm run typecheck` clean · `npm test` 588/588 pass · `npm run build` OK.

Note: `format:check` reports pre-existing violations across 94 files (both touched files were already non-compliant at HEAD); edits follow existing file style, no reformatting bundled.

Closes #211. Related: ranxianglei/billion-context#603, ranxianglei/billion-context#610, ranxianglei/billion-context-omp#121.

<!-- ework-agent-pr -->