### PR TITLE
fix: backfill toolName onto wire-projected tool results (#213)

### DIFF
--- a/src/wire/anthropic.ts
+++ b/src/wire/anthropic.ts
@@ -63,6 +63,11 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
     const msgs: BiliMessage[] = [];
     const cacheControls = new Map<string, unknown>();
     const clusters = new ClusterCounter();
+    // Backfill toolName onto tool-results from their paired tool_use: the wire
+    // format only carries the call id on results, but kernel guards
+    // (excludeTools / protectedTools / isNeverPreserveRecent) are name-based.
+    // Not part of the result identity seed — ids must stay stable across versions.
+    const toolNames = new Map<string, string>();
     for (const m of body.messages) {
         const blocks = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
         for (const b of blocks) {
@@ -88,6 +93,7 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
                         toolCallId: b.id,
                         text: safeStringify(b.input),
                     });
+                    toolNames.set(b.id, b.name);
                     if (b.cache_control) cacheControls.set(id, b.cache_control);
                     break;
                 }
@@ -95,12 +101,14 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
                     const text = typeof b.content === "string" ? b.content : b.content.map((c) => c.text).join("\n");
                     const base = deriveMessageId("tool", "tool-result", text, { toolCallId: b.tool_use_id });
                     const id = clusters.next(base);
+                    const name = toolNames.get(b.tool_use_id);
                     msgs.push({
                         id,
                         role: "tool",
                         contentType: "tool-result",
                         toolCallId: b.tool_use_id,
                         text,
+                        ...(name ? { toolName: name } : {}),
                         ...(b.is_error === true ? { toolIsError: true } : {}),
                     });
                     if (b.cache_control) cacheControls.set(id, b.cache_control);

--- a/src/wire/openai.ts
+++ b/src/wire/openai.ts
@@ -51,6 +51,9 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
     const msgs: BiliMessage[] = [];
     const systemParts: string[] = [];
     const clusters = new ClusterCounter();
+    // Backfill toolName onto role:"tool" results from their paired tool_call —
+    // kernel guards are name-based. Not part of the identity seed (id stability).
+    const toolNames = new Map<string, string>();
     for (const m of body.messages) {
         switch (m.role) {
             case "system":
@@ -129,6 +132,7 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                             toolCallId: tc.id,
                             text: tc.function.arguments ?? "",
                         });
+                        toolNames.set(tc.id, tc.function.name);
                     }
                 }
                 break;
@@ -137,12 +141,14 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                 const base = deriveMessageId("tool", "tool-result", stringContent(m.content), {
                     toolCallId: m.tool_call_id ?? "",
                 });
+                const name = m.name || toolNames.get(m.tool_call_id ?? "");
                 msgs.push({
                     id: clusters.next(base),
                     role: "tool",
                     contentType: "tool-result",
                     toolCallId: m.tool_call_id ?? "",
                     text: stringContent(m.content),
+                    ...(name ? { toolName: name } : {}),
                 });
                 break;
             }

--- a/src/wire/responses.ts
+++ b/src/wire/responses.ts
@@ -135,6 +135,9 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
     const layout: ResponseLayoutSlot[] = [];
     let droppedReasoning = 0;
     const clusters = new ClusterCounter();
+    // Backfill toolName onto call outputs from their paired calls — kernel
+    // guards are name-based. Not part of the identity seed (id stability).
+    const toolNames = new Map<string, string>();
     let idx = 0;
     if (typeof body.instructions === "string" && body.instructions.trim()) systemParts.push(body.instructions);
     if (typeof body.input === "string") {
@@ -236,13 +239,15 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                     text: call.arguments ?? "",
                     rawResponsesItem: item,
                 });
+                toolNames.set(call.call_id, call.name);
                 break;
             }
             case "function_call_output": {
                 const output = item as ResponseFunctionCallOutput;
                 const text = typeof output.output === "string" ? output.output : JSON.stringify(output.output);
                 coreId = clusters.next(deriveMessageId("tool", "tool-result", text, { toolCallId: output.call_id }));
-                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: output.call_id, text, rawResponsesItem: item });
+                const name = toolNames.get(output.call_id);
+                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: output.call_id, text, ...(name ? { toolName: name } : {}), rawResponsesItem: item });
                 break;
             }
             case "computer_call":
@@ -267,6 +272,7 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                 const argText = ctc.input ?? ctc.arguments ?? "";
                 coreId = clusters.next(deriveMessageId("assistant", "tool-call", argText, { toolCallId: callId, toolName: ctc.name ?? "custom" }));
                 msgs.push({ id: coreId, role: "assistant", contentType: "tool-call", toolName: ctc.name ?? "custom", toolCallId: callId, text: argText, rawResponsesItem: item });
+                toolNames.set(callId, ctc.name ?? "custom");
                 break;
             }
             case "custom_tool_call_output": {
@@ -275,7 +281,8 @@ export function responsesToCore(body: ResponsesRequestBody): ResponsesProjection
                 customToolCallIds.add(callId);
                 const outText = typeof ctco.output === "string" ? ctco.output : JSON.stringify(ctco.output ?? "");
                 coreId = clusters.next(deriveMessageId("tool", "tool-result", outText, { toolCallId: callId }));
-                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: callId, text: outText, rawResponsesItem: item });
+                const name = toolNames.get(callId);
+                msgs.push({ id: coreId, role: "tool", contentType: "tool-result", toolCallId: callId, text: outText, ...(name ? { toolName: name } : {}), rawResponsesItem: item });
                 break;
             }
             default:

--- a/tests/wire-tool-result-toolname.test.ts
+++ b/tests/wire-tool-result-toolname.test.ts
@@ -1,0 +1,213 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { anthropicToCore, type AnthropicRequestBody } from "../src/wire/anthropic.js";
+import { openaiToCore, type OpenAIRequestBody } from "../src/wire/openai.js";
+import { responsesToCore, type ResponsesRequestBody } from "../src/wire/responses.js";
+import { deriveMessageId } from "../src/wire/message-id.js";
+import { applyAbsorb, isAbsorbCandidate } from "../src/absorb.js";
+import { isMessageProtected, isNeverPreserveRecent } from "../src/protected.js";
+import { defaultConfig } from "../src/config.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs, refForRaw } from "../src/refs.js";
+import type { Config, CoreMessage } from "../src/types.js";
+
+function absorbConfig(overrides: Partial<Config["absorb"]> = {}): Config {
+  return {
+    ...defaultConfig(200000),
+    absorb: {
+      enabled: true,
+      toolName: "absorb",
+      minToolTokens: 100,
+      contextThresholdPct: 0,
+      excludeTools: ["bash"],
+      ...overrides,
+    },
+  };
+}
+
+function refsFor(messages: CoreMessage[]) {
+  const state = createInitialState();
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+// --- Anthropic ---
+
+const ANTHROPIC_TEXT = "x".repeat(480);
+
+function anthropicBody(): AnthropicRequestBody {
+  return {
+    model: "claude-x",
+    messages: [
+      { role: "user", content: "run the build" },
+      { role: "assistant", content: [{ type: "tool_use", id: "tu_1", name: "bash", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_1", content: ANTHROPIC_TEXT }] },
+      { role: "assistant", content: [{ type: "tool_use", id: "tu_2", name: "compress", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_2", content: "ok" }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_orphan", content: "orphaned" }] },
+    ],
+  };
+}
+
+test("anthropicToCore backfills toolName onto paired tool_results", () => {
+  const { msgs } = anthropicToCore(anthropicBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_1");
+  const compressResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_2");
+  const orphan = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_orphan");
+  assert.equal(bashResult?.toolName, "bash");
+  assert.equal(compressResult?.toolName, "compress");
+  assert.ok(orphan && !("toolName" in orphan), "unpaired result must not gain a toolName");
+});
+
+test("anthropicToCore result ids stay stable under the toolName backfill", () => {
+  const { msgs } = anthropicToCore(anthropicBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_1")!;
+  assert.equal(
+    bashResult.id,
+    deriveMessageId("tool", "tool-result", ANTHROPIC_TEXT, { toolCallId: "tu_1" }),
+  );
+});
+
+test("excludeTools guard fires on wire-projected anthropic results (issue #213)", () => {
+  const { msgs } = anthropicToCore(anthropicBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_1")!;
+  assert.equal(isAbsorbCandidate(bashResult, absorbConfig({ excludeTools: ["bash"] })), false);
+  assert.equal(isAbsorbCandidate(bashResult, absorbConfig({ excludeTools: [] })), true);
+});
+
+test("isNeverPreserveRecent and isMessageProtected fire on wire-projected results", () => {
+  const { msgs } = anthropicToCore(anthropicBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_1")!;
+  const compressResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_2")!;
+  assert.equal(isNeverPreserveRecent(bashResult), true);
+  assert.equal(isMessageProtected(compressResult, defaultConfig(200000)), true);
+});
+
+test("applyAbsorb rejects absorbing an ACP-managed tool result projected from wire", () => {
+  const { msgs } = anthropicToCore(anthropicBody());
+  const coreMsgs = msgs as CoreMessage[];
+  const state = refsFor(coreMsgs);
+  const compressResult = coreMsgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_2")!;
+  const ref = refForRaw(state.messageRefs, compressResult.id)!;
+  const outcome = applyAbsorb({
+    ref,
+    summary: "distilled",
+    messages: coreMsgs,
+    state,
+    config: defaultConfig(200000),
+  });
+  assert.equal(outcome.ok, false);
+  assert.match(outcome.resultText, /absorb failed: .* is an ACP-managed tool result/);
+});
+
+test("applyAbsorb rejects absorbing a protectedTools-matched result projected from wire", () => {
+  const body: AnthropicRequestBody = {
+    model: "claude-x",
+    messages: [
+      { role: "user", content: "secret" },
+      { role: "assistant", content: [{ type: "tool_use", id: "tu_s", name: "vault_read", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_s", content: "s".repeat(480) }] },
+    ],
+  };
+  const { msgs } = anthropicToCore(body);
+  const coreMsgs = msgs as CoreMessage[];
+  const state = refsFor(coreMsgs);
+  const config = { ...defaultConfig(200000), protectedTools: ["vault_*"] };
+  const result = coreMsgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "tu_s")!;
+  const ref = refForRaw(state.messageRefs, result.id)!;
+  const outcome = applyAbsorb({
+    ref,
+    summary: "distilled",
+    messages: coreMsgs,
+    state,
+    config,
+  });
+  assert.equal(outcome.ok, false);
+  assert.match(outcome.resultText, /is a protected tool/);
+});
+
+// --- OpenAI ---
+
+function openaiBody(): OpenAIRequestBody {
+  return {
+    model: "gpt-x",
+    messages: [
+      { role: "user", content: "run" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "bash", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "y".repeat(480) },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_2", type: "function", function: { name: "read", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call_2", name: "legacy_name", content: "z" },
+      { role: "tool", tool_call_id: "call_orphan", content: "w" },
+    ],
+  };
+}
+
+test("openaiToCore backfills toolName onto paired role:tool results", () => {
+  const { msgs } = openaiToCore(openaiBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "call_1");
+  const legacyResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "call_2");
+  const orphan = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "call_orphan");
+  assert.equal(bashResult?.toolName, "bash");
+  assert.equal(legacyResult?.toolName, "legacy_name", "explicit message.name wins over the call map");
+  assert.ok(orphan && !("toolName" in orphan));
+});
+
+test("excludeTools guard fires on wire-projected openai results", () => {
+  const { msgs } = openaiToCore(openaiBody());
+  const bashResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "call_1")!;
+  assert.equal(isAbsorbCandidate(bashResult, absorbConfig({ excludeTools: ["bash"] })), false);
+  assert.equal(isAbsorbCandidate(bashResult, absorbConfig({ excludeTools: [] })), true);
+});
+
+// --- Responses ---
+
+function responsesBody(): ResponsesRequestBody {
+  return {
+    model: "gpt-x",
+    input: [
+      { type: "message", role: "user", content: "run" },
+      { type: "function_call", call_id: "fc_1", name: "bash", arguments: "{}" },
+      { type: "function_call_output", call_id: "fc_1", output: "z".repeat(480) },
+      { type: "custom_tool_call", call_id: "ctc_1", name: "my_tool", input: "{}" },
+      { type: "custom_tool_call_output", call_id: "ctc_1", output: "out" },
+      { type: "custom_tool_call_output", call_id: "ctc_orphan", output: "o" },
+    ],
+  };
+}
+
+test("responsesToCore backfills toolName onto paired call outputs", () => {
+  const { msgs } = responsesToCore(responsesBody());
+  const fnResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "fc_1");
+  const customResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "ctc_1");
+  const orphan = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "ctc_orphan");
+  assert.equal(fnResult?.toolName, "bash");
+  assert.equal(customResult?.toolName, "my_tool");
+  assert.ok(orphan && !("toolName" in orphan));
+});
+
+test("responsesToCore output ids stay stable under the toolName backfill", () => {
+  const { msgs } = responsesToCore(responsesBody());
+  const fnResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "fc_1")!;
+  assert.equal(
+    fnResult.id,
+    deriveMessageId("tool", "tool-result", "z".repeat(480), { toolCallId: "fc_1" }),
+  );
+});
+
+test("excludeTools guard fires on wire-projected responses results", () => {
+  const { msgs } = responsesToCore(responsesBody());
+  const fnResult = msgs.find((m) => m.contentType === "tool-result" && m.toolCallId === "fc_1")!;
+  assert.equal(isAbsorbCandidate(fnResult, absorbConfig({ excludeTools: ["bash"] })), false);
+  assert.equal(isAbsorbCandidate(fnResult, absorbConfig({ excludeTools: [] })), true);
+});


### PR DESCRIPTION
Fixes #213.

## Problem
The three wire projections (`anthropicToCore` / `openaiToCore` / `responsesToCore`) carried only the call id on tool-result messages; the paired tool-call held the name. Every name-based kernel guard was therefore silently dead on results projected from wire formats:

- `isAbsorbCandidate`'s `excludeTools` guard → the absorb feature's `excludeTools` config was a no-op end-to-end
- `isMessageProtected` / `protectedTools` / `isToolProtected` on results (direct calls)
- `NEVER_PRESERVE_RECENT_TOOLS` on results
- both `applyAbsorb` guards — a model could absorb an ACP-managed tool result (e.g. `compress`) without the intended `absorb failed: ... is an ACP-managed tool result` error

Verified at runtime pre-fix: all four impact points reproduced on master @ 04bd5ed.

## Fix
Single-pass `callId → name` map per projection, set on the result **after** id derivation. Deliberately NOT part of the `deriveMessageId` seed, so existing message ids stay byte-stable across versions (locked by a test asserting the exact derived id). Unpaired results keep `toolName` undefined. OpenAI `role:"tool"` prefers an explicit `message.name` over the call map when present (legacy function-calling clients).

Sites: anthropic `tool_use`→`tool_result`; openai `tool_calls`→`role:"tool"`; responses `function_call`→`function_call_output` and `custom_tool_call`→`custom_tool_call_output` (stores `name ?? "custom"`, matching the call side).

## Tag bytes decision (issue left this open)
`render-refs` `classifyType` now emits the real name (e.g. `type="bash"`) in acp tags for results instead of `type="tool"`. The paired tool-call half already renders its name today, so results become consistent with their calls rather than the odd half out; `message.toolName || "tool"` was designed as "name when known". Cost: one-time provider prefix-cache invalidation per session at upgrade — any behavior-changing release pays that anyway.

## Verification
- new `tests/wire-tool-result-toolname.test.ts`: 11 tests — backfill + unpaired-stays-undefined per codec, id stability vs `deriveMessageId`, `excludeTools` guard firing, `isNeverPreserveRecent`/`isMessageProtected` firing, `applyAbsorb` rejecting ACP-managed and `protectedTools`-matched projected results
- full suite: 591/591 pass · `tsc --noEmit` clean · `tsup` build clean
<!-- ework-agent-pr -->