### PR TITLE
feat(handoff): support persisted folded snapshots (folded + blocksFull)

### DIFF
--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -9,10 +9,26 @@ export interface HandoffMeta {
   extraBullets?: string[];
 }
 
+export interface HandoffBlockFull {
+  blockId: string;
+  topic?: string;
+  count: number;
+  fullText: string;
+}
+
 export interface HandoffInput {
   coreMessages: CoreMessage[];
   state: CompressionState;
   full: boolean;
+  /** coreMessages is an already-pruned persisted snapshot (#401 bounded
+   *  folded tail): render it as-is instead of re-running prune() — its
+   *  message ids no longer align with the state ranges, so pruning would
+   *  resurrect dropped summaries at index 0. */
+  folded?: boolean;
+  /** Original messages per active block, recovered from the block content
+   *  cache. Appended after the conversation when full && folded — the
+   *  folded snapshot itself no longer carries the folded ranges' originals. */
+  blocksFull?: HandoffBlockFull[];
   meta: HandoffMeta;
 }
 
@@ -48,10 +64,13 @@ export function renderHandoff(input: HandoffInput): string {
   if (meta.contextTokens) lines.push(`- last context tokens: ~${meta.contextTokens}`);
   lines.push(`- compression blocks: ${state.blocks.length} (active ${state.blocks.filter((b) => b.active).length})`);
   lines.push("");
-  const view = full ? coreMessages : prune(coreMessages, state);
-  lines.push(full
+  const folded = input.folded === true;
+  const view = full || folded ? coreMessages : prune(coreMessages, state);
+  lines.push(full && !folded
     ? `## Full conversation (${coreMessages.length} messages)`
-    : `## Conversation (folded view as the model saw it, ${coreMessages.length} client messages)`);
+    : folded
+      ? `## Conversation (persisted folded snapshot, ${coreMessages.length} messages)`
+      : `## Conversation (folded view as the model saw it, ${coreMessages.length} client messages)`);
   lines.push("");
   if (view.length === 0) {
     lines.push("No conversation messages to export.");
@@ -67,6 +86,16 @@ export function renderHandoff(input: HandoffInput): string {
     lines.push(renderMessage(m));
   }
   lines.push("");
+  if (full && folded) {
+    for (const b of input.blocksFull ?? []) {
+      lines.push(`## Block ${b.blockId}${b.topic ? ` — ${b.topic}` : ""}`);
+      lines.push("");
+      lines.push(`### Original messages (${b.count})`);
+      lines.push("");
+      lines.push(b.fullText.trim());
+      lines.push("");
+    }
+  }
   return lines.join("\n");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export type {
 export { buildStatusReport, buildRecap } from "./report.js";
 export type { StatusReportOptions } from "./report.js";
 export { renderHandoff, renderMessage, matchSession } from "./handoff.js";
-export type { HandoffInput, HandoffMeta } from "./handoff.js";
+export type { HandoffInput, HandoffMeta, HandoffBlockFull } from "./handoff.js";
 export { hideConsumedCompressCalls } from "./hide-consumed.js";
 export type { HideConsumedResult } from "./hide-consumed.js";
 export {

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -133,6 +133,19 @@ test("renderHandoff folded snapshot renders as-is without re-pruning", () => {
   assert.doesNotMatch(out, /summary/);
 });
 
+test("re-pruning the same snapshot without folded resurrects the summary at index 0", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b0", effectiveMessageIds: ["m1", "m2"], directMessageIds: ["m1", "m2"] }));
+  const snapshot = [msg("m3", "assistant", "hi"), msg("m4", "user", "final question")];
+  const out = renderHandoff({ coreMessages: snapshot, state, full: false, meta: { sessionId: "s1" } });
+  assert.match(out, /## Conversation \(folded view as the model saw it, 2 client messages\)/);
+  assert.match(out, /\[Compressed conversation section\]/);
+  assert.ok(
+    out.indexOf("[Compressed conversation section]") < out.indexOf("### assistant"),
+    "resurrected summary must land before the first surviving message",
+  );
+});
+
 test("renderHandoff full+folded appends block originals after the tail", () => {
   const state = createInitialState();
   state.blocks.push(makeBlock({ blockId: "b0", topic: "investigation", summary: "summary" }));
@@ -142,13 +155,21 @@ test("renderHandoff full+folded appends block originals after the tail", () => {
     state,
     full: true,
     folded: true,
-    blocksFull: [{ blockId: "b0", topic: "investigation", count: 7, fullText: "hello proxy\n778899" }],
+    blocksFull: [
+      { blockId: "b0", topic: "investigation", count: 7, fullText: "hello proxy\n778899" },
+      { blockId: "b1", count: 2, fullText: "tail content\n\n" },
+    ],
     meta: { sessionId: "s1" },
   });
   assert.match(out, /## Conversation \(persisted folded snapshot, 1 messages\)/);
   assert.match(out, /## Block b0 — investigation/);
   assert.match(out, /### Original messages \(7\)/);
   assert.match(out, /778899/);
+  assert.match(out, /^## Block b1$/m);
+  assert.doesNotMatch(out, /## Block b1 —/);
+  assert.match(out, /### Original messages \(2\)/);
+  assert.doesNotMatch(out, /tail content\n\n/);
+  assert.ok(out.indexOf("## Block b0") > out.indexOf("hi"), "blocks must follow the conversation");
 });
 
 test("renderHandoff folded flag is ignored for block append when not full", () => {

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -120,3 +120,47 @@ test("matchSession matches by exact id, label, and prefix", () => {
   assert.deepEqual(matchSession(sessions, "sess", labelOf).map((s) => s.id), ["sess-aaa-111", "sess-bbb-222"]);
   assert.deepEqual(matchSession(sessions, "nope", labelOf), []);
 });
+
+test("renderHandoff folded snapshot renders as-is without re-pruning", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b0", effectiveMessageIds: ["m1", "m2"], directMessageIds: ["m1", "m2"] }));
+  // Folded persisted snapshot: covered ids already replaced by a summary
+  // anchor; ids m1/m2 gone. Re-pruning must not resurrect them.
+  const snapshot = [msg("m3", "assistant", "hi"), msg("m4", "user", "final question")];
+  const out = renderHandoff({ coreMessages: snapshot, state, full: false, folded: true, meta: { sessionId: "s1" } });
+  assert.match(out, /## Conversation \(persisted folded snapshot, 2 messages\)/);
+  assert.match(out, /final question/);
+  assert.doesNotMatch(out, /summary/);
+});
+
+test("renderHandoff full+folded appends block originals after the tail", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b0", topic: "investigation", summary: "summary" }));
+  const snapshot = [msg("m3", "assistant", "hi")];
+  const out = renderHandoff({
+    coreMessages: snapshot,
+    state,
+    full: true,
+    folded: true,
+    blocksFull: [{ blockId: "b0", topic: "investigation", count: 7, fullText: "hello proxy\n778899" }],
+    meta: { sessionId: "s1" },
+  });
+  assert.match(out, /## Conversation \(persisted folded snapshot, 1 messages\)/);
+  assert.match(out, /## Block b0 — investigation/);
+  assert.match(out, /### Original messages \(7\)/);
+  assert.match(out, /778899/);
+});
+
+test("renderHandoff folded flag is ignored for block append when not full", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b0", topic: "t" }));
+  const out = renderHandoff({
+    coreMessages: [msg("m1", "user", "x")],
+    state,
+    full: false,
+    folded: true,
+    blocksFull: [{ blockId: "b0", count: 1, fullText: "ORIGINALS" }],
+    meta: { sessionId: "s1" },
+  });
+  assert.doesNotMatch(out, /ORIGINALS/);
+});


### PR DESCRIPTION
## What

`renderHandoff` grows two optional inputs so hosts that persist a bounded folded snapshot (billion-context #401-style tails) can delegate handoff rendering fully:

- **`folded?: boolean`** — `coreMessages` is an already-pruned persisted snapshot: render it as-is with a `## Conversation (persisted folded snapshot, N messages)` header instead of re-running `prune()`. Re-pruning is wrong there: the snapshot ids no longer align with the state ranges, so `prune()` resurrects dropped summaries at index 0.
- **`blocksFull?: HandoffBlockFull[]`** — per-active-block original content (`{blockId, topic?, count, fullText}`), appended after the conversation when `full && folded`. The folded tail no longer carries the folded ranges' originals; `--full` recovers them from the block content cache.

Backward compatible: both inputs optional, default behavior unchanged (583/583 tests pass, +3 new).

## Why

billion-context PR#434 (issue #601) wants to delete its duplicated handoff renderer and delegate to the kernel; its own renderer learned these two behaviors in #587. This PR gives the kernel parity so the delegation is byte-compatible.

## Consumers

- billion-context `src/export.ts` `renderHandoff(s, full)` — will pass `folded: s.lastMessagesFolded === true` + `blocksFull` built from its `blockContents` cache.
