### PR TITLE
release v0.0.57

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Version bump only. Ships since v0.0.56:

- #216 — handoff `folded` (render already-pruned snapshot as-is; prevents re-prune resurrecting old summaries at index 0) + `blocksFull` (per-block full text appendix for `full && folded`); exports `HandoffBlockFull`.

Needed by billion-context #634 (PR#434 rework: export.ts delegates to kernel `renderHandoff`).

Pre-flight: typecheck ✓ · tests 586/586 ✓ · build ✓
