### PR TITLE
release v0.0.58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.52",
+    "version": "0.0.58",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.52",
+            "version": "0.0.58",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.57",
+    "version": "0.0.58",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
发版内容自 0.0.57:

- **#215 wire-level `stripHistoricalImages(body, protocol, keepRecent)`** — anthropic/openai/responses 三协议历史图像剥离原语;图像独占消息折叠 `[image]` 占位;no-op 返回原引用。billion-context-pi 接入跟踪 issue: ranxianglei/billion-context-pi#321

合并后 release.yml 自动发布 npm。