### PR TITLE
release v0.0.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.58",
+    "version": "0.0.59",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## What's in v0.0.59

Everything merged since v0.0.58 (8a2a1aa):

- **#209 / #207** — segment compressible ranges by array adjacency, not ref arithmetic (fixes fragmentation + descending pairs + benefit-floor suppression on surface-replacing hosts like billion-context-dsh)
- **#102** — responses: fold EasyInputMessage items that omit `type` (omp shorthand)
- **#212 / #211** — salvage single-quoted JSON compress args (port of billion-context #603/#610)
- **#214 / #213** — backfill toolName onto wire-projected tool results
- **#190 / #188** — skip malformed `image_url:null` parts in openaiToCore (proxy-mode turn crash)
- **#192** — docs: codify the id-immutability invariant in AGENTS.md

## Pre-flight

- `npm run typecheck` OK
- `node --import tsx --test tests/*.test.ts` — **624/624 pass**
- `npm run build` OK
- Commit is version-only (`package.json` 0.0.58 → 0.0.59)