### PR TITLE
feat: reasoningReplay policy + anchor arg stubs + extraTokens accounting

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -72,6 +72,11 @@ export interface ProcessTurnInput {
   state: CompressionState;
   config: Config;
   tokenCount: number;
+  /** Host-side prompt mass the kernel cannot see (replayed reasoning that
+   *  will be sent despite reasoningReplay, provider-mandated metadata, …).
+   *  Folded into every usage/pressure decision downstream. Hosts that pass
+   *  it must do so consistently — cadence baselines persist tokenCount. */
+  extraTokens?: number;
   /**
    * Which messages get an <acp> ref tag injected into their text
    * (the render-refs pipeline node). Refs are ALWAYS assigned regardless
@@ -399,7 +404,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
     }
     const ctx: PipelineContext = {
       config: input.config,
-      tokenCount: input.tokenCount,
+      tokenCount: input.tokenCount + (input.extraTokens ?? 0),
       countTokens,
     };
     const initial: NodeIO = {
@@ -468,6 +473,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
       assignRefsNode,
       syncBlocksNode,
       pruneNode,
+      stripReasoningNode,
       absorbHideNode,
       absorbPromptNode,
       filterNode,
@@ -526,6 +532,41 @@ const pruneNode: PipelineNode = {
   name: "prune",
   run(io) {
     return { ...io, messages: prune(io.messages, io.state) };
+  },
+};
+
+// History thinking is dead weight once its round closes — providers only
+// require reasoning replay for the current unresolved round (Anthropic
+// signature validation, Gemini thought_signature) — and on protected
+// (compress-carrying) messages it is excluded from every compression
+// selection, forming a permanently-incompressible floor that grows with
+// each compression (billion-context-pi #336 / opencode-acp #368).
+const stripReasoningNode: PipelineNode = {
+  name: "strip-reasoning",
+  run(io, ctx) {
+    const policy = ctx.config.reasoningReplay ?? "always";
+    if (policy === "always") return io;
+    const messages = io.messages;
+    if (policy === "never") {
+      const kept = messages.filter((m) => m.contentType !== "reasoning");
+      return kept.length === messages.length ? io : { ...io, messages: kept };
+    }
+    let boundary = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]!;
+      if (m.role === "user" && m.contentType === "text") {
+        boundary = i;
+        break;
+      }
+    }
+    if (boundary < 0) return io;
+    let changed = false;
+    const kept = messages.filter((m, i) => {
+      if (m.contentType !== "reasoning" || i >= boundary) return true;
+      changed = true;
+      return false;
+    });
+    return changed ? { ...io, messages: kept } : io;
   },
 };
 

--- a/src/hide-consumed.ts
+++ b/src/hide-consumed.ts
@@ -19,28 +19,69 @@ function rangeKey(startRef: string, endRef: string): string {
     return `${startRef}::${endRef}`;
 }
 
-function rewriteCompressText(text: string | undefined, liveKeys: Set<string>): string | null {
+function parseCallText(text: string | undefined): { prefix: string; obj: Record<string, unknown>; content: unknown[] } | null {
+    const raw = text ?? "";
+    const start = raw.indexOf("{");
+    if (start < 0) return null;
     let parsed: unknown;
     try {
-        parsed = JSON.parse(text ?? "");
+        parsed = JSON.parse(raw.slice(start));
     } catch {
         return null;
     }
     if (!parsed || typeof parsed !== "object") return null;
-    const obj = parsed as { content?: unknown };
-    const content = obj.content;
-    if (!Array.isArray(content) || content.length === 0) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (!Array.isArray(obj.content) || obj.content.length === 0) return null;
+    return { prefix: raw.slice(0, start), obj, content: obj.content };
+}
+
+function rewriteCompressText(text: string | undefined, liveKeys: Set<string>): string | null {
+    const parsed = parseCallText(text);
+    if (!parsed) return null;
+    const { prefix, obj, content } = parsed;
 
     const kept = content.filter((entry): entry is Record<string, unknown> => {
         if (!entry || typeof entry !== "object") return false;
-        const s = typeof entry.startId === "string" ? entry.startId : typeof entry.messageId === "string" ? entry.messageId : "";
-        const e = typeof entry.endId === "string" ? entry.endId : typeof entry.messageId === "string" ? entry.messageId : "";
-        return liveKeys.has(rangeKey(s, e));
+        const e = entry as Record<string, unknown>;
+        const s = typeof e.startId === "string" ? e.startId : typeof e.messageId === "string" ? e.messageId : "";
+        const end = typeof e.endId === "string" ? e.endId : typeof e.messageId === "string" ? e.messageId : "";
+        return liveKeys.has(rangeKey(s, end));
     });
 
-    if (kept.length === content.length || kept.length === 0) return null;
+    if (kept.length === 0) return null;
 
-    return JSON.stringify({ ...obj, content: kept });
+    return prefix + serializeCompacted(obj, kept).text;
+}
+
+// Live compress-call args duplicate every range's full summary text while
+// the rendered acp_summary message already carries it — on long sessions the
+// duplication alone measured ~22K tokens (billion-context-pi #336). Keep the
+// leading stub for recall; the block remains the durable record.
+const SUMMARY_STUB_CHARS = 200;
+
+function compactEntry(entry: unknown): unknown {
+    if (!entry || typeof entry !== "object") return entry;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.summary !== "string" || e.summary.length <= SUMMARY_STUB_CHARS) return entry;
+    return { ...e, summary: `${e.summary.slice(0, SUMMARY_STUB_CHARS - 1)}…` };
+}
+
+function serializeCompacted(obj: Record<string, unknown>, content: unknown[]): { text: string; changed: boolean } {
+    let changed = false;
+    const compacted = content.map((entry) => {
+        const out = compactEntry(entry);
+        if (out !== entry) changed = true;
+        return out;
+    });
+    return { text: JSON.stringify({ ...obj, content: compacted }), changed };
+}
+
+function compactCompressText(text: string | undefined): string | null {
+    const parsed = parseCallText(text);
+    if (!parsed) return null;
+    const { prefix, obj, content } = parsed;
+    const { text: out, changed } = serializeCompacted(obj, content);
+    return changed ? prefix + out : null;
 }
 
 export function hideConsumedCompressCalls(
@@ -123,6 +164,11 @@ export function hideConsumedCompressCalls(
                     result.push({ ...message, text: rewritten });
                     continue;
                 }
+            }
+            const compacted = compactCompressText(message.text);
+            if (compacted !== null) {
+                result.push({ ...message, text: compacted });
+                continue;
             }
         }
         result.push(message);

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -83,6 +83,22 @@ interface SummaryAnchor {
   insertAt: number;
 }
 
+// Blocks record the core ids that existed at compression time (`base`,
+// `base#callId`, …). Later projections of the same original message (`base#r0`)
+// share the base id, so coverage is decided on the base: a block that covered
+// any projection of an original message covered all of them.
+function isCovered(id: string, covered: Set<string>): boolean {
+  if (covered.has(id)) return true;
+  const hash = id.indexOf("#");
+  if (hash <= 0) return false;
+  const base = id.substring(0, hash);
+  if (covered.has(base)) return true;
+  for (const coveredId of covered) {
+    if (coveredId.startsWith(`${base}#`)) return true;
+  }
+  return false;
+}
+
 function collectSummaryAnchors(
   state: CompressionState,
   indexById: Map<string, number>,
@@ -141,7 +157,7 @@ function rebuildMessages(
       result.push(messages[index]!);
       continue;
     }
-    if (covered.has(messages[index]!.id)) continue;
+    if (isCovered(messages[index]!.id, covered)) continue;
     // A stale copy of this block's summary from a previously-pruned view:
     // the freshly rendered one above replaces it. Only rendered-summary
     // shaped messages qualify — a host message that merely reuses the

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,8 @@ export interface CompressValidationConfig {
   minSummaryLength: number;
 }
 
+export type ReasoningReplayPolicy = "always" | "open-round" | "never";
+
 export interface Config {
   tiers: TierConfig;
   nudge: NudgeConfig;
@@ -177,6 +179,18 @@ export interface Config {
   truncate: TruncateConfig;
   compress: CompressValidationConfig;
   protectedTools: string[];
+  /** Reasoning-block replay policy for the visible view. History replay is
+   *  only required by providers for the CURRENT unresolved round (Anthropic
+   *  thinking-signature validation, Gemini thought_signature on tool calls),
+   *  so gating on turn closure is provider-agnostic.
+   *  - "always" (default): keep every reasoning message (legacy behavior).
+   *  - "open-round": drop reasoning from closed history (strictly before the
+   *    last genuine user text message); keep the open round intact.
+   *  - "never": drop all reasoning messages.
+   *  Reasoning that rides on protected (compress-carrying) assistant
+   *  messages is the largest permanently-incompressible floor otherwise
+   *  (billion-context-pi #336 / opencode-acp #368). */
+  reasoningReplay?: ReasoningReplayPolicy;
   isToolProtected?: (toolName: string, toolInputText?: string) => boolean;
   preserveRecentMessages: number;
   preserveRecentTokens: number;

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -28,6 +28,7 @@ test("defaultNodes exposes the canonical ordered pipeline", () => {
     "assign-refs",
     "sync-blocks",
     "prune",
+    "strip-reasoning",
     "absorb-hide",
     "absorb-prompt",
     "filter",

--- a/tests/reasoning-replay.test.ts
+++ b/tests/reasoning-replay.test.ts
@@ -1,0 +1,248 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { defaultConfig } from "../src/config.js";
+import { hideConsumedCompressCalls } from "../src/hide-consumed.js";
+import type { CompressionState, Config, CoreMessage } from "../src/types.js";
+
+const countTokens = (text: string) => Math.ceil(text.length / 4);
+
+function cfg(limit: number, reasoningReplay: Config["reasoningReplay"]): Config {
+  return { ...defaultConfig(limit), reasoningReplay };
+}
+
+function user(id: string, text = "hi"): CoreMessage {
+  return { id, role: "user", contentType: "text", text };
+}
+
+function reasoning(id: string, text = "thinking…"): CoreMessage {
+  return { id, role: "assistant", contentType: "reasoning", text };
+}
+
+function asst(id: string, text = "answer"): CoreMessage {
+  return { id, role: "assistant", contentType: "text", text };
+}
+
+test("open-round keeps reasoning after the last genuine user text, drops closed history", () => {
+  const core = createCore({ countTokens });
+  const messages = [
+    user("u1"),
+    reasoning("r1"),
+    asst("a1"),
+    user("u2"),
+    reasoning("r2"),
+    asst("a2"),
+  ];
+  const out = core.processTurn({
+    messages,
+    state: createInitialState(),
+    config: cfg(262144, "open-round"),
+    tokenCount: 100,
+  });
+  const kinds = out.messages.map((m) => `${m.role}/${m.contentType}`);
+  assert.deepEqual(kinds, [
+    "user/text",
+    "assistant/text",
+    "user/text",
+    "assistant/reasoning",
+    "assistant/text",
+  ]);
+});
+
+test("never drops all reasoning; always keeps everything", () => {
+  const core = createCore({ countTokens });
+  const messages = [user("u1"), reasoning("r1"), asst("a1")];
+  const never = core.processTurn({
+    messages: messages.map((m) => ({ ...m })),
+    state: createInitialState(),
+    config: cfg(262144, "never"),
+    tokenCount: 100,
+  });
+  assert.equal(never.messages.some((m) => m.contentType === "reasoning"), false);
+  const always = core.processTurn({
+    messages: messages.map((m) => ({ ...m })),
+    state: createInitialState(),
+    config: cfg(262144, "always"),
+    tokenCount: 100,
+  });
+  assert.equal(always.messages.length, 3);
+});
+
+test("open-round without any user text message treats the view as open", () => {
+  const core = createCore({ countTokens });
+  const out = core.processTurn({
+    messages: [reasoning("r1"), asst("a1"), reasoning("r2")],
+    state: createInitialState(),
+    config: cfg(262144, "open-round"),
+    tokenCount: 100,
+  });
+  assert.equal(out.messages.length, 3);
+});
+
+test("tool-result user messages are not turn boundaries", () => {
+  const core = createCore({ countTokens });
+  const messages = [
+    user("u1"),
+    {
+      id: "t1",
+      role: "tool",
+      contentType: "tool-result",
+      toolName: "bash",
+      toolCallId: "c1",
+      text: "output",
+    },
+    reasoning("r1"),
+    asst("a1"),
+  ];
+  const out = core.processTurn({
+    messages,
+    state: createInitialState(),
+    config: cfg(262144, "open-round"),
+    tokenCount: 100,
+  });
+  assert.equal(out.messages.some((m) => m.contentType === "reasoning"), true);
+});
+
+function blockState(summary: string, startRef: string, endRef: string): CompressionState {
+  const state = createInitialState();
+  state.blocks.push({
+    blockId: "b1",
+    runId: "run1",
+    tier: 1,
+    summary,
+    directMessageIds: ["m1"],
+    effectiveMessageIds: ["m1"],
+    directBlockIds: [],
+    compressedTokens: 5000,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    compressCallId: "call1",
+    startRef,
+    endRef,
+  });
+  return state;
+}
+
+function compressCall(text: string): CoreMessage {
+  return {
+    id: "mc1",
+    role: "assistant",
+    contentType: "tool-call",
+    toolName: "compress",
+    toolCallId: "call1",
+    text,
+  };
+}
+
+test("fully-live compress call args get their long summaries stubbed", () => {
+  const longSummary = "x".repeat(5000);
+  const callText = JSON.stringify({
+    content: [{ startId: "m00001", endId: "m00050", topic: "T", summary: longSummary }],
+  });
+  const state = blockState(longSummary, "m00001", "m00050");
+  const { messages } = hideConsumedCompressCalls(state, [compressCall(callText)]);
+  assert.equal(messages.length, 1);
+  const parsed = JSON.parse(messages[0]!.text!) as {
+    content: { summary: string; topic: string }[];
+  };
+  assert.equal(parsed.content[0]!.summary.length, 200);
+  assert.ok(parsed.content[0]!.summary.endsWith("…"));
+  assert.equal(parsed.content[0]!.topic, "T");
+});
+
+test("short summaries and orphaned calls are left untouched", () => {
+  const callText = JSON.stringify({
+    content: [{ startId: "m00001", endId: "m00050", summary: "short" }],
+  });
+  const state = blockState("s", "m00001", "m00050");
+  const { messages } = hideConsumedCompressCalls(state, [compressCall(callText)]);
+  assert.equal(JSON.parse(messages[0]!.text!).content[0].summary, "short");
+
+  const orphanText = JSON.stringify({
+    content: [{ startId: "m00001", endId: "m00050", summary: "y".repeat(4000) }],
+  });
+  const emptyState = createInitialState();
+  const orphan = { ...compressCall(orphanText), toolCallId: "nope" };
+  const { messages: orphanOut } = hideConsumedCompressCalls(emptyState, [orphan]);
+  assert.equal(orphanOut.length, 1);
+  assert.equal(JSON.parse(orphanOut[0]!.text!).content[0].summary.length, 200);
+});
+
+test("extraTokens folds into usage for pressure decisions", () => {
+  const core = createCore({ countTokens });
+  const limit = 100000;
+  const config = defaultConfig(limit, { limit, preserveRecentMessages: 0 });
+  const filler = "x".repeat(240000);
+  const messages = [
+    user("u1", "go"),
+    {
+      id: "t1",
+      role: "tool",
+      contentType: "tool-result",
+      toolName: "bash",
+      toolCallId: "c1",
+      text: filler,
+    },
+    asst("a1", "done"),
+    user("u2"),
+    asst("a2"),
+  ];
+  const without = core.processTurn({
+    messages: messages.map((m) => ({ ...m })),
+    state: createInitialState(),
+    config,
+    tokenCount: 40000,
+  });
+  assert.equal(without.nudge?.shouldInject, false);
+  const withExtra = core.processTurn({
+    messages: messages.map((m) => ({ ...m })),
+    state: createInitialState(),
+    config,
+    tokenCount: 40000,
+    extraTokens: 15000,
+  });
+  assert.equal(withExtra.nudge?.shouldInject, true);
+});
+
+test("tag-prefixed compress call text is still stubbed (ref tag precedes the JSON)", () => {
+  const longSummary = "z".repeat(3000);
+  const tagged = `<acp tokens="1.4K" type="compress">m00097</acp>\n\n{"content":[{"startId":"m00001","endId":"m00050","summary":"${longSummary}"}]}`;
+  const state = blockState(longSummary, "m00001", "m00050");
+  const { messages } = hideConsumedCompressCalls(state, [compressCall(tagged)]);
+  const text = messages[0]!.text!;
+  const parsed = JSON.parse(text.slice(text.indexOf("{"))) as { content: { summary: string }[] };
+  assert.equal(parsed.content[0]!.summary.length, 200);
+  assert.ok(text.startsWith("<acp"));
+});
+
+test("sub-id cores are pruned when the block covered a sibling sub-id", () => {
+  const core = createCore({ countTokens });
+  const state = createInitialState();
+  state.blocks.push({
+    blockId: "b1",
+    runId: "run1",
+    tier: 1,
+    summary: "s",
+    directMessageIds: ["a1#c1"],
+    effectiveMessageIds: ["a1#c1"],
+    directBlockIds: [],
+    compressedTokens: 100,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+  });
+  const messages = [
+    user("u1"),
+    { id: "a1#r0", role: "assistant", contentType: "reasoning", text: "secret" },
+    { id: "a1#c1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "c1", text: "cmd" },
+    { id: "t1", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "c1", text: "out" },
+    user("u2"),
+  ];
+  const out = core.processTurn({ messages, state, config: cfg(262144, "always"), tokenCount: 100 });
+  assert.equal(out.messages.some((m) => m.id === "a1#r0"), false);
+  assert.equal(out.messages.some((m) => m.id === "a1#c1"), false);
+});


### PR DESCRIPTION
Fixes #224

## 变更

1. **`Config.reasoningReplay`**(`"always" | "open-round" | `"never"`,默认 `always` 保持旧行为):新增 `strip-reasoning` 管线节点(紧跟 prune)。`open-round` 以最后一条真实 user/text 消息为轮次边界,剥离闭合历史的 reasoning,保留开轮——provider 只要求当前未闭合轮次回放 thinking(Anthropic signature 校验、Gemini thought_signature),门控与 provider 无关。
2. **prune 覆盖判定 base-id 归一**:`isCovered(id, covered)` — 自身命中、base 命中、或任一兄弟子 id(`base#…`)命中皆算覆盖。修复投影演进后 `base#r0` 绕过旧块覆盖的泄漏。
3. **活锚点 args 存根化**:`rewriteCompressText`/`compactCompressText` 把 >200 字符的 summary 截为前缀存根(完整文本由渲染出的 acp_summary 承载);`parseCallText` 从第一个 `{` 定位 JSON,跳过 `<acp>` ref 标签前缀——此前 parse 失败导致改写从未生效(opencode-acp #368 finding 3 的同类根因)。
4. **`ProcessTurnInput.extraTokens`**:host 侧内核不可见质量(回放 reasoning 等)折入 ctx.tokenCount,参与全部 usage/压力决策。

## 测试

- 新增 `tests/reasoning-replay.test.ts`(9 例):三种策略、无用户消息回退、tool-result 非边界、全活调用存根化、短 summary/orphan 行为、带标签前缀的 JSON 定位、兄弟子 id 覆盖、extraTokens 压力触发。
- 全套 633/633 通过;typecheck、build 干净。

## 实测(真实风暴会话重放,billion-context-pi #336 场景)

| 指标 | 旧 | 新(open-round) |
|---|---|---|
| 视图总 tokens(CJK-aware) | ~155K | **48.8K** |
| thinking | 75.8K | 0.9K(仅开轮) |
| compress 调用 args | 21.6K | 16.5K(存根化) |