### PR TITLE
fix: break the reasoning context floor and live-anchor summary duplication

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,7 +1,13 @@
 import { assignRefs, highestUsedIndex, indexToRef } from "./refs.js";
 import { prune, isSummaryMessageId } from "./prune.js";
 import { syncBlocks } from "./sync.js";
-import { advanceSurvival, activeBlocks, blockById } from "./state.js";
+import {
+  advanceSurvival,
+  activeBlocks,
+  baseMessageId,
+  blockById,
+  coveredMessageIds,
+} from "./state.js";
 import { allocateBlockId, allocateRunId, createInitialState } from "./state.js";
 import { defaultCountTokens } from "./tokenize.js";
 import { validateConfig } from "./config.js";
@@ -21,6 +27,7 @@ import type { RenderStrategy } from "./render-refs.js";
 import { isMessageProtected } from "./protected.js";
 import { adjustBoundariesForToolPairs } from "./tool-pairs.js";
 import { adjustBoundariesForReasoningPairs } from "./reasoning-pairs.js";
+import { stripReasoningByRound } from "./strip-reasoning.js";
 import {
   computeProtectedRefs,
   buildCompressibleRanges,
@@ -72,6 +79,13 @@ export interface ProcessTurnInput {
   state: CompressionState;
   config: Config;
   tokenCount: number;
+  /**
+   * Host-reported context mass the kernel cannot see (wire-level replayed
+   * reasoning, system prompt, provider overhead). Folded into usage and
+   * pressure so the pressure band tracks real provider-side usage instead of
+   * only the kernel-visible view.
+   */
+  extraTokens?: number;
   /**
    * Which messages get an <acp> ref tag injected into their text
    * (the render-refs pipeline node). Refs are ALWAYS assigned regardless
@@ -151,8 +165,13 @@ function danglingMessageRefs(
       state.messageRefs.byRef[parsed.raw] ??
       state.messageRefs.byRef[indexToRef(parsed.numericId)];
     if (!rawId || visible.has(rawId)) continue;
+    const base = baseMessageId(rawId);
     const covered = state.blocks.some(
-      (block) => block.active && block.effectiveMessageIds.includes(rawId),
+      (block) =>
+        block.active &&
+        block.effectiveMessageIds.some(
+          (id) => id === rawId || baseMessageId(id) === base,
+        ),
     );
     if (!covered) dangling.push(parsed.raw);
   }
@@ -184,7 +203,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
         countTokens,
       );
 
-    const preExistingCoverage = collectCoverage(state);
+    const preExistingCoverage = coveredMessageIds(state);
 
     // Classify every requested range ONCE. The result feeds overlap
     // skipSpecs, the minCompressRange pre-check, and the per-range loop —
@@ -399,7 +418,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
     }
     const ctx: PipelineContext = {
       config: input.config,
-      tokenCount: input.tokenCount,
+      tokenCount: input.tokenCount + (input.extraTokens ?? 0),
       countTokens,
     };
     const initial: NodeIO = {
@@ -467,6 +486,7 @@ export function createCore(ports: Ports = {}): CompressionCore {
     const base: PipelineNode[] = [
       assignRefsNode,
       syncBlocksNode,
+      stripReasoningNode,
       pruneNode,
       absorbHideNode,
       absorbPromptNode,
@@ -519,6 +539,28 @@ const syncBlocksNode: PipelineNode = {
     const synced = syncBlocks(io.messages, io.state);
     advanceSurvival(synced.state, ctx.config.promotionThreshold);
     return { ...io, state: synced.state };
+  },
+};
+
+// Runs AFTER sync-blocks (which must see the full message list — a block
+// whose only present ids are reasoning messages would otherwise be
+// deactivated) and BEFORE prune, so stripped reasoning gets no tags, no
+// nudge ranges, and no summary-anchor interference.
+const stripReasoningNode: PipelineNode = {
+  name: "strip-reasoning",
+  enabled: (_io, ctx) =>
+    ctx.config.reasoningReplay === "open-round" ||
+    ctx.config.reasoningReplay === "never",
+  run(io, ctx) {
+    const { messages, stripped } = stripReasoningByRound(
+      io.messages,
+      ctx.config.reasoningReplay!,
+    );
+    return {
+      ...io,
+      messages,
+      effects: { ...io.effects, reasoningStrippedCount: stripped },
+    };
   },
 };
 
@@ -1036,14 +1078,6 @@ function resolveTargetTier(
     if (block && block.tier < minTier) minTier = block.tier;
   }
   return minTier;
-}
-
-function collectCoverage(state: CompressionState): Set<string> {
-  const coverage = new Set<string>();
-  for (const block of activeBlocks(state)) {
-    for (const id of block.effectiveMessageIds) coverage.add(id);
-  }
-  return coverage;
 }
 
 interface NudgeInput {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export function defaultConfig(
     preserveRecentMessages: 5,
     preserveRecentTokens: 5000,
     modelContextLimit,
+    reasoningReplay: "always",
     absorb: {
       enabled: false,
       toolName: "absorb",
@@ -76,6 +77,14 @@ export function validateConfig(config: Config): string[] {
       config.nudge.minPressureBenefitTokens < 0)
   ) {
     errors.push("nudge.minPressureBenefitTokens must be finite and >= 0");
+  }
+  if (
+    config.reasoningReplay !== undefined &&
+    config.reasoningReplay !== "always" &&
+    config.reasoningReplay !== "open-round" &&
+    config.reasoningReplay !== "never"
+  ) {
+    errors.push('reasoningReplay must be "always", "open-round", or "never"');
   }
   if (config.promotionThreshold < 1) {
     errors.push("promotionThreshold must be >= 1");

--- a/src/hide-consumed.ts
+++ b/src/hide-consumed.ts
@@ -19,10 +19,43 @@ function rangeKey(startRef: string, endRef: string): string {
     return `${startRef}::${endRef}`;
 }
 
+const LT = "\x3c";
+const GT = "\x3e";
+// Ref-tag prefix render-refs prepends to every tagged message (acpTag in
+// render-refs.ts): `<acp tokens="…" type="…">mNNNNN</acp>\n`. With the
+// default "all" strategy a live compress call's args carry it, so
+// JSON.parse on the raw text always failed and the rewrite never applied.
+const REF_TAG_PREFIX_RE = new RegExp(
+    "^" + LT + "acp [^" + GT + "]*" + GT + "m\\d{1,5}" + LT + "/acp" + GT + "\\n?",
+);
+
+// Live anchor args duplicate the rendered acp_summary message; the full
+// summary text in the args is the duplication, so it is stubbed to a short
+// prefix. The block's rendered summary remains the authoritative copy.
+const SUMMARY_STUB_CHARS = 200;
+
+function stubSummary(entry: Record<string, unknown>): Record<string, unknown> {
+    const summary = entry.summary;
+    if (typeof summary === "string" && summary.length > SUMMARY_STUB_CHARS) {
+        return { ...entry, summary: summary.slice(0, SUMMARY_STUB_CHARS) + "…" };
+    }
+    return entry;
+}
+
+// Field-name precedence mirrors parse-compress-input.ts: canonical
+// startRef/endRef first, then the legacy/drift spellings.
+function entryRef(entry: Record<string, unknown>, ...fields: string[]): string {
+    for (const field of fields) {
+        const value = entry[field];
+        if (typeof value === "string") return value;
+    }
+    return "";
+}
+
 function rewriteCompressText(text: string | undefined, liveKeys: Set<string>): string | null {
     let parsed: unknown;
     try {
-        parsed = JSON.parse(text ?? "");
+        parsed = JSON.parse((text ?? "").replace(REF_TAG_PREFIX_RE, ""));
     } catch {
         return null;
     }
@@ -31,14 +64,16 @@ function rewriteCompressText(text: string | undefined, liveKeys: Set<string>): s
     const content = obj.content;
     if (!Array.isArray(content) || content.length === 0) return null;
 
-    const kept = content.filter((entry): entry is Record<string, unknown> => {
-        if (!entry || typeof entry !== "object") return false;
-        const s = typeof entry.startId === "string" ? entry.startId : typeof entry.messageId === "string" ? entry.messageId : "";
-        const e = typeof entry.endId === "string" ? entry.endId : typeof entry.messageId === "string" ? entry.messageId : "";
-        return liveKeys.has(rangeKey(s, e));
-    });
+    const kept = content
+        .filter((entry): entry is Record<string, unknown> => {
+            if (!entry || typeof entry !== "object") return false;
+            const s = entryRef(entry, "startRef", "startId", "messageId");
+            const e = entryRef(entry, "endRef", "endId", "messageId");
+            return liveKeys.has(rangeKey(s, e));
+        })
+        .map(stubSummary);
 
-    if (kept.length === content.length || kept.length === 0) return null;
+    if (kept.length === 0) return null;
 
     return JSON.stringify({ ...obj, content: kept });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export {
   coveredMessageIds,
   highestActiveTier,
   advanceSurvival,
+  baseMessageId,
+  isIdCovered,
 } from "./state.js";
 export { defaultConfig, validateConfig } from "./config.js";
 export * from "./compress-tools.js";
@@ -80,6 +82,8 @@ export { renderHandoff, renderMessage, matchSession } from "./handoff.js";
 export type { HandoffInput, HandoffMeta } from "./handoff.js";
 export { hideConsumedCompressCalls } from "./hide-consumed.js";
 export type { HideConsumedResult } from "./hide-consumed.js";
+export { stripReasoningByRound, isRealUserMessage } from "./strip-reasoning.js";
+export type { StripReasoningResult } from "./strip-reasoning.js";
 export {
   ABSORB_TOOL_NAME,
   ABSORB_TOOL,

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -1,4 +1,4 @@
-import { activeBlocks, coveredMessageIds } from "./state.js";
+import { activeBlocks, coveredMessageIds, isIdCovered } from "./state.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
 export const SUMMARY_HEADER = "[Compressed conversation section]";
@@ -141,7 +141,7 @@ function rebuildMessages(
       result.push(messages[index]!);
       continue;
     }
-    if (covered.has(messages[index]!.id)) continue;
+    if (isIdCovered(covered, messages[index]!.id)) continue;
     // A stale copy of this block's summary from a previously-pruned view:
     // the freshly rendered one above replaces it. Only rendered-summary
     // shaped messages qualify — a host message that merely reuses the

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -25,6 +25,7 @@ import {
   isMessageProtectedWithPairing,
   isNeverPreserveRecent,
 } from "./protected.js";
+import { baseMessageId } from "./state.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -49,8 +50,15 @@ function isSyntheticOrPruned(
   state: CompressionState,
 ): boolean {
   if (message.text?.startsWith("[Compressed conversation section]")) return true;
+  const base = baseMessageId(message.id);
   for (const block of state.blocks) {
-    if (block.active && block.effectiveMessageIds.includes(message.id)) return true;
+    if (
+      block.active &&
+      block.effectiveMessageIds.some(
+        (id) => id === message.id || baseMessageId(id) === base,
+      )
+    )
+      return true;
   }
   return false;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -42,11 +42,30 @@ export function activeBlocks(state: CompressionState): CompressionBlock[] {
   return state.blocks.filter((block) => block.active);
 }
 
+/**
+ * Host projections may append a `#suffix` to a core message id (e.g.
+ * `base#callId`, `base#r0`) to represent a variant of the same logical
+ * message. Coverage is defined on the base id: a message is covered when any
+ * sibling projection of it is covered by an active block.
+ */
+export function baseMessageId(id: string): string {
+  const hash = id.indexOf("#");
+  return hash === -1 ? id : id.slice(0, hash);
+}
+
+/** True when `id` or any sibling projection of it is in `covered`. */
+export function isIdCovered(covered: Set<string>, id: string): boolean {
+  return covered.has(id) || covered.has(baseMessageId(id));
+}
+
 export function coveredMessageIds(state: CompressionState): Set<string> {
   const covered = new Set<string>();
   for (const block of state.blocks) {
     if (!block.active) continue;
-    for (const id of block.effectiveMessageIds) covered.add(id);
+    for (const id of block.effectiveMessageIds) {
+      covered.add(id);
+      covered.add(baseMessageId(id));
+    }
   }
   return covered;
 }

--- a/src/strip-reasoning.ts
+++ b/src/strip-reasoning.ts
@@ -1,0 +1,59 @@
+import type { CoreMessage, ReasoningReplay } from "./types.js";
+
+/**
+ * A real user message: user-role text. Tool results are `role: "tool"` in
+ * every wire codec (anthropic/openai/responses), so this is provider-agnostic
+ * and marks the round boundary the provider's thinking-replay requirement
+ * keys off of — the provider only replays the CURRENT open round's thinking
+ * (Anthropic signature / Gemini thought_signature), never closed rounds.
+ */
+export function isRealUserMessage(message: CoreMessage): boolean {
+  return message.role === "user" && message.contentType === "text";
+}
+
+export interface StripReasoningResult {
+  messages: CoreMessage[];
+  stripped: number;
+}
+
+/**
+ * Strip `reasoning` messages per the replay policy.
+ *
+ * "always" is a no-op (legacy behavior). "open-round" keeps reasoning only
+ * after the last real user message — the open round. "never" strips
+ * everything. When no real user message exists, "open-round" keeps
+ * everything (no closed round exists — conservative).
+ */
+export function stripReasoningByRound(
+  messages: CoreMessage[],
+  mode: ReasoningReplay,
+): StripReasoningResult {
+  if (mode === "always") return { messages, stripped: 0 };
+
+  let cutoff: number;
+  if (mode === "never") {
+    cutoff = messages.length;
+  } else {
+    let lastRealUserIndex = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (isRealUserMessage(messages[i]!)) {
+        lastRealUserIndex = i;
+        break;
+      }
+    }
+    if (lastRealUserIndex === -1) return { messages, stripped: 0 };
+    cutoff = lastRealUserIndex + 1;
+  }
+
+  let stripped = 0;
+  const kept: CoreMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]!;
+    if (message.contentType === "reasoning" && i < cutoff) {
+      stripped++;
+      continue;
+    }
+    kept.push(message);
+  }
+  return { messages: kept, stripped };
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,5 @@
 import { summaryMessageId } from "./prune.js";
+import { baseMessageId } from "./state.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
 export interface SyncResult {
@@ -11,6 +12,7 @@ export function syncBlocks(
   state: CompressionState,
 ): SyncResult {
   const presentIds = new Set(messages.map((message) => message.id));
+  const presentBases = new Set(messages.map((message) => baseMessageId(message.id)));
   const deactivated: string[] = [];
   // Deep-clone (not just `{...state}`) so the caller's input state is never
   // mutated: processTurn stamps `state.nudge.*` and reassigns `messageRefs`,
@@ -70,7 +72,9 @@ export function syncBlocks(
     // representation. Without this, hosts passing pruned views would lose
     // block activity every turn.
     const stillPresent =
-      block.effectiveMessageIds.some((id) => presentIds.has(id)) ||
+      block.effectiveMessageIds.some(
+        (id) => presentIds.has(id) || presentBases.has(baseMessageId(id)),
+      ) ||
       presentIds.has(summaryMessageId(block.blockId));
     if (!stillPresent) {
       block.active = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,14 @@ export interface CompressValidationConfig {
   minSummaryLength: number;
 }
 
+/** Replay policy for `reasoning` messages (see strip-reasoning.ts).
+ *  "always" (default, legacy behavior): every reasoning message stays
+ *  visible. "open-round": reasoning from closed rounds (everything up to and
+ *  including the last real user message) is stripped; only the open round
+ *  keeps its thinking — the one the provider still replays (Anthropic
+ *  signature / Gemini thought_signature). "never": all reasoning stripped. */
+export type ReasoningReplay = "always" | "open-round" | "never";
+
 export interface Config {
   tiers: TierConfig;
   nudge: NudgeConfig;
@@ -178,6 +186,8 @@ export interface Config {
   /** Instant tool-result absorption (see absorb.ts). Absent/disabled = feature off. */
   absorb?: AbsorbConfig;
   messageFilters?: import("./filter/types.js").MessageFiltersConfig;
+  /** Replay policy for reasoning messages. Absent = "always" (legacy). */
+  reasoningReplay?: ReasoningReplay;
 }
 
 export type CompressMode = "range" | "message";

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -27,6 +27,7 @@ test("defaultNodes exposes the canonical ordered pipeline", () => {
   assert.deepEqual(names, [
     "assign-refs",
     "sync-blocks",
+    "strip-reasoning",
     "prune",
     "absorb-hide",
     "absorb-prompt",

--- a/tests/reasoning-replay.test.ts
+++ b/tests/reasoning-replay.test.ts
@@ -1,0 +1,349 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripReasoningByRound, isRealUserMessage } from "../src/strip-reasoning.js";
+import { createCore } from "../src/compress.js";
+import { createInitialState, coveredMessageIds, baseMessageId } from "../src/state.js";
+import { prune } from "../src/prune.js";
+import { syncBlocks } from "../src/sync.js";
+import { hideConsumedCompressCalls } from "../src/hide-consumed.js";
+import { defaultConfig } from "../src/config.js";
+import type { CompressionBlock, CompressionState, CoreMessage } from "../src/types.js";
+
+function block(overrides: Partial<CompressionBlock>): CompressionBlock {
+  return {
+    blockId: "b1",
+    runId: "r1",
+    tier: 1,
+    summary: "summary",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    createdAt: 1000,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+function user(id: string, text: string): CoreMessage {
+  return { id, role: "user", contentType: "text", text };
+}
+
+function reasoning(id: string, text: string): CoreMessage {
+  return { id, role: "assistant", contentType: "reasoning", text };
+}
+
+function text(id: string, text: string): CoreMessage {
+  return { id, role: "assistant", contentType: "text", text };
+}
+
+// ---------- strip-reasoning unit ----------
+
+test("stripReasoningByRound: always is a no-op", () => {
+  const messages = [user("u1", "hi"), reasoning("r1", "think"), text("t1", "ok")];
+  const result = stripReasoningByRound(messages, "always");
+  assert.equal(result.stripped, 0);
+  assert.deepEqual(result.messages, messages);
+});
+
+test("stripReasoningByRound: open-round strips closed-round reasoning only", () => {
+  const messages = [
+    user("u1", "hi"),
+    reasoning("r1", "closed thinking"),
+    text("t1", "answer"),
+    user("u2", "next"),
+    reasoning("r2", "open thinking"),
+    text("t2", "answer"),
+  ];
+  const result = stripReasoningByRound(messages, "open-round");
+  assert.equal(result.stripped, 1);
+  assert.deepEqual(
+    result.messages.map((m) => m.id),
+    ["u1", "t1", "u2", "r2", "t2"],
+  );
+});
+
+test("stripReasoningByRound: open-round with no user message is a no-op", () => {
+  const messages = [reasoning("r1", "think"), text("t1", "ok")];
+  const result = stripReasoningByRound(messages, "open-round");
+  assert.equal(result.stripped, 0);
+  assert.deepEqual(result.messages, messages);
+});
+
+test("stripReasoningByRound: never strips all reasoning", () => {
+  const messages = [user("u1", "hi"), reasoning("r1", "a"), text("t1", "ok"), reasoning("r2", "b")];
+  const result = stripReasoningByRound(messages, "never");
+  assert.equal(result.stripped, 2);
+  assert.deepEqual(result.messages.map((m) => m.id), ["u1", "t1"]);
+});
+
+test("isRealUserMessage: tool results are not user messages", () => {
+  const toolResult: CoreMessage = {
+    id: "tr1",
+    role: "tool",
+    contentType: "tool-result",
+    toolName: "bash",
+    toolCallId: "c1",
+    text: "out",
+  };
+  assert.equal(isRealUserMessage(toolResult), false);
+  assert.equal(isRealUserMessage(user("u1", "hi")), true);
+});
+
+// ---------- processTurn integration ----------
+
+function replayMessages(): CoreMessage[] {
+  return [
+    user("u1", "hi"),
+    reasoning("r1", "closed thinking"),
+    text("t1", "answer"),
+    user("u2", "next"),
+    reasoning("r2", "open thinking"),
+    text("t2", "answer"),
+  ];
+}
+
+test("processTurn: reasoningReplay open-round strips closed-round reasoning", () => {
+  const core = createCore();
+  const config = defaultConfig(100000, { reasoningReplay: "open-round" });
+  const result = core.processTurn({
+    messages: replayMessages(),
+    state: createInitialState(),
+    config,
+    tokenCount: 1000,
+  });
+  const ids = result.messages.map((m) => m.id);
+  assert.ok(!ids.includes("r1"), "closed-round reasoning stripped");
+  assert.ok(ids.includes("r2"), "open-round reasoning kept");
+});
+
+test("processTurn: reasoningReplay never strips all reasoning", () => {
+  const core = createCore();
+  const config = defaultConfig(100000, { reasoningReplay: "never" });
+  const result = core.processTurn({
+    messages: replayMessages(),
+    state: createInitialState(),
+    config,
+    tokenCount: 1000,
+  });
+  const ids = result.messages.map((m) => m.id);
+  assert.ok(!ids.includes("r1"));
+  assert.ok(!ids.includes("r2"));
+});
+
+test("processTurn: default (always) keeps all reasoning — legacy behavior", () => {
+  const core = createCore();
+  const config = defaultConfig(100000);
+  const result = core.processTurn({
+    messages: replayMessages(),
+    state: createInitialState(),
+    config,
+    tokenCount: 1000,
+  });
+  const ids = result.messages.map((m) => m.id);
+  assert.ok(ids.includes("r1"), "always keeps closed-round reasoning");
+  assert.ok(ids.includes("r2"));
+});
+
+// ---------- base-id coverage normalization ----------
+
+test("baseMessageId: strips host #suffix projections", () => {
+  assert.equal(baseMessageId("m1"), "m1");
+  assert.equal(baseMessageId("m1#r0"), "m1");
+  assert.equal(baseMessageId("m1#callId"), "m1");
+  assert.equal(baseMessageId("a#b#c"), "a");
+});
+
+test("coveredMessageIds: includes base ids of projected members", () => {
+  const state: CompressionState = {
+    ...createInitialState(),
+    blocks: [block({ effectiveMessageIds: ["m1", "m2#callId"] })],
+  };
+  const covered = coveredMessageIds(state);
+  assert.ok(covered.has("m1"));
+  assert.ok(covered.has("m2"));
+  assert.ok(covered.has("m2#callId"));
+});
+
+test("prune: projected sibling (base#r0) is covered by a block on the base id", () => {
+  const state: CompressionState = {
+    ...createInitialState(),
+    blocks: [block({ effectiveMessageIds: ["m1"], directMessageIds: ["m1"] })],
+  };
+  const messages: CoreMessage[] = [
+    user("u1", "hi"),
+    text("m1", "a"),
+    reasoning("m1#r0", "reasoning projection"),
+    user("u2", "later"),
+  ];
+  const result = prune(messages, state);
+  const ids = result.map((m) => m.id);
+  assert.ok(!ids.includes("m1"), "base id pruned");
+  assert.ok(!ids.includes("m1#r0"), "sibling projection pruned with base");
+  assert.ok(ids.some((id) => id.startsWith("acp_summary_b1")), "summary injected");
+});
+
+test("syncBlocks: block stays active when only a sibling projection is present", () => {
+  const state: CompressionState = {
+    ...createInitialState(),
+    blocks: [block({ effectiveMessageIds: ["m1"] })],
+  };
+  const messages: CoreMessage[] = [
+    { id: "m1#callId", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "c1", text: "{}" },
+    user("u2", "hi"),
+  ];
+  const result = syncBlocks(messages, state);
+  assert.equal(result.deactivated.length, 0, "block must not be deactivated by id evolution");
+  assert.equal(result.state.blocks[0]!.active, true);
+});
+
+// ---------- live compress-call args rewrite ----------
+
+const REF_TAG = `<acp tokens="1.2K" type="compress">m00004</acp>\n`;
+
+function liveState(): CompressionState {
+  return {
+    ...createInitialState(),
+    blocks: [
+      block({
+        compressCallId: "call-1",
+        startRef: "m00001",
+        endRef: "m00003",
+      }),
+    ],
+  };
+}
+
+function compressCall(id: string, toolCallId: string, text: string): CoreMessage {
+  return { id, role: "assistant", contentType: "tool-call", toolName: "compress", toolCallId, text };
+}
+
+test("rewrite: ref-tag prefix + canonical startRef/endRef + long summary → stubbed", () => {
+  const longSummary = "x".repeat(500);
+  const args = JSON.stringify({
+    content: [{ startRef: "m00001", endRef: "m00003", summary: longSummary }],
+  });
+  const messages: CoreMessage[] = [
+    compressCall("c1", "call-1", REF_TAG + args),
+    user("u1", "hi"),
+  ];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  assert.equal(result.hidden, 0);
+  const rewritten = result.messages[0]!.text!;
+  assert.ok(!rewritten.startsWith(REF_TAG), "ref-tag prefix removed");
+  const parsed = JSON.parse(rewritten) as { content: Array<{ summary: string }> };
+  assert.equal(parsed.content.length, 1);
+  assert.equal(parsed.content[0]!.summary.length, 201, "200 chars + ellipsis");
+  assert.ok(parsed.content[0]!.summary.endsWith("…"));
+});
+
+test("rewrite: pure JSON with legacy startId/endId still matches", () => {
+  const longSummary = "y".repeat(300);
+  const args = JSON.stringify({
+    content: [{ startId: "m00001", endId: "m00003", summary: longSummary }],
+  });
+  const messages: CoreMessage[] = [compressCall("c1", "call-1", args), user("u1", "hi")];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  const parsed = JSON.parse(result.messages[0]!.text!) as { content: Array<{ summary: string }> };
+  assert.equal(parsed.content.length, 1);
+  assert.equal(parsed.content[0]!.summary.length, 201);
+});
+
+test("rewrite: all-live single range is stubbed (no longer bails on kept === content)", () => {
+  const longSummary = "z".repeat(400);
+  const args = JSON.stringify({
+    content: [{ startRef: "m00001", endRef: "m00003", summary: longSummary }],
+  });
+  const messages: CoreMessage[] = [compressCall("c1", "call-1", args), user("u1", "hi")];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  const parsed = JSON.parse(result.messages[0]!.text!) as { content: Array<{ summary: string }> };
+  assert.equal(parsed.content.length, 1);
+  assert.equal(parsed.content[0]!.summary.length, 201);
+});
+
+test("rewrite: short summary is not stubbed", () => {
+  const args = JSON.stringify({
+    content: [{ startRef: "m00001", endRef: "m00003", summary: "short" }],
+  });
+  const messages: CoreMessage[] = [compressCall("c1", "call-1", args), user("u1", "hi")];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  const parsed = JSON.parse(result.messages[0]!.text!) as { content: Array<{ summary: string }> };
+  assert.equal(parsed.content[0]!.summary, "short");
+});
+
+test("rewrite: non-JSON args are left untouched", () => {
+  const messages: CoreMessage[] = [
+    compressCall("c1", "call-1", REF_TAG + "not json at all"),
+    user("u1", "hi"),
+  ];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  assert.equal(result.messages[0]!.text, REF_TAG + "not json at all");
+});
+
+test("rewrite: no live range match → call kept but untouched", () => {
+  const args = JSON.stringify({
+    content: [{ startRef: "m00005", endRef: "m00006", summary: "w".repeat(300) }],
+  });
+  const messages: CoreMessage[] = [compressCall("c1", "call-1", args), user("u1", "hi")];
+  const result = hideConsumedCompressCalls(liveState(), messages);
+  assert.equal(result.messages[0]!.text, args);
+});
+
+// ---------- extraTokens ----------
+
+function nudgeConfig() {
+  return defaultConfig(100000, {
+    nudge: {
+      maxContextLimitPct: 0.9,
+      minContextLimitPct: 0.45,
+      frequency: 1,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+  });
+}
+
+function textMessage(role: CoreMessage["role"], id: string, text: string): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function makeMessages(count: number): CoreMessage[] {
+  return Array.from({ length: count }, (_, i) =>
+    textMessage(i % 2 === 0 ? "user" : "assistant", `m${i}`, `message ${i} `.repeat(2000)),
+  );
+}
+
+test("extraTokens: host-invisible mass folds into usage/pressure", () => {
+  const core = createCore();
+  const config = nudgeConfig();
+  const messages = makeMessages(10);
+  let state = createInitialState();
+
+  // Stamp the growth baseline at 89% (just under the 90% pressure threshold).
+  state = core.processTurn({ messages, state, config, tokenCount: 89000 }).state;
+
+  // 89% visible, no invisible mass → below the 90% pressure threshold → no nudge.
+  const below = core.processTurn({ messages, state, config, tokenCount: 89000 });
+  assert.equal(below.nudge.shouldInject, false, "89% < 90% pressure threshold");
+
+  // Same 89% visible + 2000 invisible (replayed reasoning) → 91% → pressure → nudge.
+  const withExtra = core.processTurn({
+    messages,
+    state,
+    config,
+    tokenCount: 89000,
+    extraTokens: 2000,
+  });
+  assert.equal(
+    withExtra.nudge.shouldInject,
+    true,
+    "extraTokens push usage past the 90% pressure threshold",
+  );
+});


### PR DESCRIPTION
Fixes #224

## Problem

Measured on a real storm session (billion-context-paper, qwen3.8-27b), ~50% of visible context was replayed thinking pinned to compress-anchor messages, and live compress-call args duplicated the rendered `acp_summary` text. Five root causes were verified in code (see #224 for the full measurement).

## Changes

1. **`Config.reasoningReplay`** (`"always" | "open-round" | "never"`, default `"always"` = legacy). New `strip-reasoning` pipeline node (after `sync-blocks`, before `prune`) drops closed-round reasoning by round-closure gating on the last real user message. Provider replay only requires the *open* round's thinking (Anthropic signature / Gemini thought_signature), so the gate is provider-agnostic. `"always"` is a no-op kill-switch.

2. **Base-id coverage normalization.** `prune`/`sync`/`recommend`/`dangling` coverage now normalizes on the base id (`baseMessageId`), so a host `#suffix` projection (`base#r0`) is covered whenever any sibling projection is — stops historical messages resurrecting as reasoning cores after projection evolution (the 762K resurrection under `always`).

3. **Live compress-call args.** `rewriteCompressText` now skips the ref-tag prefix before `JSON.parse` (previously it always failed on tagged calls, so the rewrite never applied) and stubs the summary to a 200-char prefix, since the rendered `acp_summary` is the authoritative copy.

4. **`ProcessTurnInput.extraTokens`.** Host-reported kernel-invisible mass is folded into usage/pressure so the pressure band tracks real provider-side usage instead of only the kernel-visible view.

## Measured impact (real storm session replay)

- `open-round`: visible ~155K → **48.8K** (thinking 75.8K → 0.9K, only the open round kept)
- compress-call args: 21.6K → 16.5K (stubbing effective)
- `always` (kill-switch): behavior identical to before

## Verification

- `npm run typecheck` — clean
- `npm test` — 599/599 pass (19 new tests in `tests/reasoning-replay.test.ts`)
- `npm run build` — success

<!-- ework-agent-pr -->