### PR TITLE
(fix) hybrid scoring: compute the score max in a loop — the Math.max(...) spread crashed at 130K+ docs

### DIFF
--- a/src/search/algorithms/hybrid.ts
+++ b/src/search/algorithms/hybrid.ts
@@ -22,14 +22,29 @@ import { fuzzyAlgorithm } from "./fuzzy.js";
 const W_BM25 = 0.7;
 const W_FUZZY = 0.3;
 
+/**
+ * Max of the scores with a floor, in loop form. `Math.max(...scores)` spreads
+ * the whole array into call arguments, which throws `RangeError: Maximum call
+ * stack size exceeded` once the doc count exceeds the V8 argument limit
+ * (~125K–130K on Node 22) — a 160K-doc corpus crashed the search instead of
+ * returning results (ranxianglei/acp-kernel#227).
+ */
+function maxScore(results: ScoredBlock[], floor: number): number {
+    let max = floor;
+    for (const r of results) {
+        if (r.score > max) max = r.score;
+    }
+    return max;
+}
+
 export const hybridAlgorithm: SearchAlgorithm = {
     name: "hybrid",
     description: "Weighted BM25(stem) + fuzzy n-gram. Default — best precision + recall.",
     score(docs: SearchDoc[], query: string): ScoredBlock[] {
         const bm = bm25Algorithm.score(docs, query);
         const fz = fuzzyAlgorithm.score(docs, query);
-        const maxBm = Math.max(...bm.map((r) => r.score), 1e-9);
-        const maxFz = Math.max(...fz.map((r) => r.score), 1e-9);
+        const maxBm = maxScore(bm, 1e-9);
+        const maxFz = maxScore(fz, 1e-9);
         const bmMap = new Map(bm.map((r) => [r.ref, r.score / maxBm]));
         const fzMap = new Map(fz.map((r) => [r.ref, r.score / maxFz]));
         return docs.map((d) => ({

--- a/tests/hybrid-large-corpus.test.ts
+++ b/tests/hybrid-large-corpus.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert";
+import { hybridAlgorithm } from "../src/search/algorithms/hybrid.js";
+import type { SearchDoc } from "../src/search/types.js";
+
+// 130K docs exceeds the V8 spread argument limit (~125K–130K on Node 22):
+// the old `Math.max(...scores)` normalization threw `RangeError: Maximum call
+// stack size exceeded` before returning any result (#227).
+const N = 130_000;
+
+function makeDocs(n: number): SearchDoc[] {
+    const docs: SearchDoc[] = new Array(n);
+    for (let i = 0; i < n; i += 1) {
+        docs[i] = {
+            kind: "message",
+            ref: `m${String(i).padStart(5, "0")}`,
+            text: `ledger entry ${i} alpha`,
+            title: `entry ${i}`,
+            role: "tool",
+        };
+    }
+    // one distinctive doc — scoring must still rank it first, not just not crash
+    docs[42] = {
+        kind: "message",
+        ref: "m00042",
+        text: "the zephyr marker document",
+        title: "entry 42",
+        role: "tool",
+    };
+    return docs;
+}
+
+test("hybridAlgorithm.score handles 130K docs without the spread RangeError (#227)", () => {
+    const docs = makeDocs(N);
+    const results = hybridAlgorithm.score(docs, "zephyr");
+    assert.equal(results.length, N);
+    const top = results.reduce((best, r) => (r.score > best.score ? r : best), results[0]!);
+    assert.equal(top.ref, "m00042");
+});


### PR DESCRIPTION
## Problem

`hybridAlgorithm.score` — the default search algorithm — crashes with `RangeError: Maximum call stack size exceeded` when the doc count gets large. Reproduced with 160,170 docs (46MB corpus, the scale of a long compressed session): the call throws before returning any result, so search breaks entirely instead of degrading. Found while analyzing Tyan66666/billion-context-dsh#133 (search latency in long sessions); reported as #227.

## Cause

`src/search/algorithms/hybrid.ts` normalizes the two channel scores with an argument spread:

```ts
const maxBm = Math.max(...bm.map((r) => r.score), 1e-9)
```

`Math.max(...array)` passes the whole array as call arguments, and V8 caps call arguments at ~125K–130K (Node 22: 125,000 works, 130,000 throws). Any corpus above that limit — ~30K+ compressed messages in a long session — crashes the search.

## Fix

Compute the max with a loop (`maxScore` helper) — same semantics (`max(floor, ...scores)`), no argument limit, O(n) either way. Two call sites changed; scoring behavior is byte-identical below the limit.

## Verification

- New regression test `tests/hybrid-large-corpus.test.ts`: 130,000 docs (just above the Node 22 limit) — the old code fails it with `RangeError` (verified by stashing the fix), the fixed code passes in ~1.1s and still ranks the distinctive doc first (normalization intact).
- Full suite: 625/625 pass; `tsc --noEmit` clean.

<!-- ework-agent-pr -->