### PR TITLE
fix(search): hybrid max via reduce + LRU doc-cache (#227)

### DIFF
--- a/src/search/algorithms/hybrid.ts
+++ b/src/search/algorithms/hybrid.ts
@@ -28,8 +28,9 @@ export const hybridAlgorithm: SearchAlgorithm = {
     score(docs: SearchDoc[], query: string): ScoredBlock[] {
         const bm = bm25Algorithm.score(docs, query);
         const fz = fuzzyAlgorithm.score(docs, query);
-        const maxBm = Math.max(...bm.map((r) => r.score), 1e-9);
-        const maxFz = Math.max(...fz.map((r) => r.score), 1e-9);
+        // reduce, not Math.max(...spread): the spread trips V8's argument limit (~65K–125K docs) → RangeError.
+        const maxBm = bm.reduce((m, r) => (r.score > m ? r.score : m), 1e-9);
+        const maxFz = fz.reduce((m, r) => (r.score > m ? r.score : m), 1e-9);
         const bmMap = new Map(bm.map((r) => [r.ref, r.score / maxBm]));
         const fzMap = new Map(fz.map((r) => [r.ref, r.score / maxFz]));
         return docs.map((d) => ({

--- a/src/search/doc-cache.ts
+++ b/src/search/doc-cache.ts
@@ -10,10 +10,18 @@
  * processed once; later searches are O(docs × query-terms).
  *
  * Keyed by doc text (immutable). Bounded by total cached source chars —
- * oldest docs are evicted when the cap is exceeded, so a long-lived
- * process serving many sessions cannot grow unboundedly. Hosts that want to
- * release the memory eagerly on session shutdown/switch can call
- * clearDocFeatures() (optional: the cap already bounds it).
+ * least-recently-used docs are evicted when the cap is exceeded (LRU), so a
+ * long-lived process serving many sessions cannot grow unboundedly, and the
+ * docs a host keeps re-querying are the ones retained.
+ *
+ * The default cap (8MB) is a conservative bound for multi-session servers.
+ * A single-session host whose corpus exceeds it would otherwise re-tokenize
+ * (corpus − cap) on EVERY call; call setDocCacheCap() with a value ≥ corpus
+ * size (or Infinity) to cache the whole corpus once and make later calls
+ * O(docs × query-terms).
+ *
+ * Hosts that want to release the memory eagerly on session shutdown/switch
+ * can call clearDocFeatures() (optional: the cap already bounds it).
  */
 
 import { charBigrams, tfMap } from "./tokenizer.js";
@@ -44,7 +52,12 @@ function build(text: string): DocFeatures {
 
 export function docFeatures(text: string): DocFeatures {
     const hit = cache.get(text);
-    if (hit) return hit;
+    if (hit) {
+        // LRU: re-insert at the tail (most-recently-used); eviction takes from the head.
+        cache.delete(text);
+        cache.set(text, hit);
+        return hit;
+    }
     const f = build(text);
     if (text.length > 0 && text.length <= capChars) {
         while (cachedChars + text.length > capChars && cache.size > 0) {
@@ -66,7 +79,9 @@ export function clearDocFeatures(): void {
 
 /**
  * Set the cache cap in source chars. Docs larger than the cap are never
- * cached. Also used by tests to exercise eviction.
+ * cached. Pass a value ≥ the corpus size (or Infinity) to cache the whole
+ * corpus — a single-session host then avoids re-tokenizing on every call.
+ * Also used by tests to exercise eviction.
  */
 export function setDocCacheCap(chars: number): void {
     capChars = Math.max(1, chars);

--- a/src/search/doc-cache.ts
+++ b/src/search/doc-cache.ts
@@ -4,21 +4,35 @@
  * A search over the compressed history re-scores the SAME immutable docs on
  * every call — compressed block summaries and folded message text never
  * change. Without this cache, every search_context call re-tokenized the
- * entire corpus (segmenter CJK pass ≈ 0.3s/MB cold) plus re-lowercased it
- * and rebuilt the bigram set for each channel: a 5MB session cost ~3s PER
- * CALL, growing linearly with session length. With the cache the corpus is
- * processed once; later searches are O(docs × query-terms).
+ * entire corpus (segmenter pass ≈ 0.1–0.6s/MB cold, content-dependent) plus
+ * re-lowercased it and rebuilt the bigram set for each channel: a 5MB session
+ * cost seconds PER CALL, growing linearly with session length. With the cache
+ * the corpus is processed once; later searches are O(docs × query-terms).
  *
- * Keyed by doc text (immutable). Bounded by total cached source chars —
- * least-recently-used docs are evicted when the cap is exceeded (LRU), so a
- * long-lived process serving many sessions cannot grow unboundedly, and the
- * docs a host keeps re-querying are the ones retained.
+ * Keyed by doc text (immutable), bounded by total cached SOURCE CHARS. Eviction
+ * is least-recently-used: a hit re-inserts the doc at the tail, so the docs a
+ * host keeps re-touching are retained. LRU helps when access is HETEROGENEOUS
+ * (a hot subset across many queries; a long-lived multi-session process). It
+ * does NOT help when every call re-scans the ENTIRE corpus below the cap — no
+ * hot subset exists, the window slides past every doc each call, and
+ * (corpus − cap) is re-tokenized every time.
  *
- * The default cap (8MB) is a conservative bound for multi-session servers.
- * A single-session host whose corpus exceeds it would otherwise re-tokenize
- * (corpus − cap) on EVERY call; call setDocCacheCap() with a value ≥ corpus
- * size (or Infinity) to cache the whole corpus once and make later calls
- * O(docs × query-terms).
+ * Sizing consequence: if your corpus exceeds the cap and each search rescans
+ * it whole, the ONLY setting that stops re-tokenization is
+ * setDocCacheCap(≥ corpus) (or Infinity). Do NOT lower the cap to save memory
+ * there — it trades bounded memory for a full re-tokenize of the excess on
+ * EVERY call. The default (8MB) suits hosts running many sessions that cannot
+ * afford to pin one corpus.
+ *
+ * The cap is in SOURCE CHARS, a loose proxy for retained heap: feature memory
+ * scales with DISTINCT token/bigram count, content-dependent (≈ 2×–49× per
+ * source char, latin prose → high-entropy CJK). The cap bounds billed chars,
+ * not a hard memory limit.
+ *
+ * The cap is MODULE-GLOBAL — setDocCacheCap() sets process-wide state shared
+ * by every acp-kernel consumer in the process. Fine while one consumer runs
+ * per process; a per-scope cache (keyed by doc ref) would let a host scope a
+ * cap to one session instead (see #227).
  *
  * Hosts that want to release the memory eagerly on session shutdown/switch
  * can call clearDocFeatures() (optional: the cap already bounds it).

--- a/tests/doc-cache.test.ts
+++ b/tests/doc-cache.test.ts
@@ -59,17 +59,48 @@ test("clearDocFeatures: forces a rebuild", () => {
   assert.equal(docCacheInfo().entries, 1);
 });
 
-test("setDocCacheCap: small cap evicts oldest, info tracks occupancy", () => {
+test("setDocCacheCap: small cap evicts least-recently-used, info tracks occupancy", () => {
   clearDocFeatures();
   setDocCacheCap(20);
   try {
     docFeatures("a".repeat(10)); // 10 chars
-    docFeatures("b".repeat(10)); // evicts "a..." (10+10 <= 20 → both fit)
+    docFeatures("b".repeat(10)); // 10+10 <= 20 → both fit, no eviction
     assert.equal(docCacheInfo().entries, 2);
     assert.equal(docCacheInfo().chars, 20);
-    docFeatures("c".repeat(15)); // evicts "a...", then "b..." (15+10 > 20)
+    docFeatures("c".repeat(15)); // 20+15 > 20 → evict LRU head (a), then (b)
     assert.equal(docCacheInfo().entries, 1);
     assert.equal(docCacheInfo().chars, 15);
+  } finally {
+    setDocCacheCap(DEFAULT_CAP);
+    clearDocFeatures();
+  }
+});
+
+test("LRU: re-accessing a doc keeps it alive (FIFO would evict it)", () => {
+  clearDocFeatures();
+  setDocCacheCap(25);
+  try {
+    const a = docFeatures("a".repeat(10)); // cache [a]
+    docFeatures("b".repeat(10));           // cache [a, b]
+    docFeatures("a".repeat(10));           // re-access a → LRU order [b, a]
+    docFeatures("c".repeat(15));           // 20+15>25 → evict LRU head (b); a survives
+    const a2 = docFeatures("a".repeat(10));
+    assert.equal(a2, a, "LRU must keep the re-accessed doc; FIFO would have evicted it");
+  } finally {
+    setDocCacheCap(DEFAULT_CAP);
+    clearDocFeatures();
+  }
+});
+
+test("setDocCacheCap(Infinity): whole corpus cached, no eviction", () => {
+  clearDocFeatures();
+  setDocCacheCap(Infinity);
+  try {
+    docFeatures("a".repeat(100));
+    docFeatures("b".repeat(100));
+    docFeatures("c".repeat(100));
+    assert.equal(docCacheInfo().entries, 3, "no eviction under an Infinity cap");
+    assert.equal(docCacheInfo().chars, 300);
   } finally {
     setDocCacheCap(DEFAULT_CAP);
     clearDocFeatures();

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { searchBlocks, searchBlocksAsync, blockDocs, messageDocs } from "../src/search.js";
+import { searchBlocks, searchBlocksAsync, blockDocs, messageDocs, clearDocFeatures } from "../src/search.js";
 import { registerSearchAlgorithm, listSearchAlgorithms } from "../src/search.js";
 import { createInitialState } from "../src/state.js";
 import type { CompressionState, CompressionBlock } from "../src/types.js";
@@ -303,6 +303,24 @@ test("hybrid: OOV doc still recallable via bigram fallback", () => {
     ));
     const r = searchBlocks(docs, "可视化");
     assert.equal(r[0].ref, "b1");
+});
+
+test("hybrid: no RangeError at large doc counts (argument-spread → reduce, #227)", () => {
+    // The old `Math.max(...scores)` spread threw RangeError past V8's argument
+    // limit (~65K–125K docs). 160K is the scale that crashed on Node 22.
+    clearDocFeatures();
+    try {
+        const n = 160_000;
+        const docs: SearchDoc[] = new Array(n);
+        for (let i = 0; i < n; i++) {
+            docs[i] = { kind: "block", ref: `b${i}`, text: `doc ${i} alpha beta`, title: `b${i}`, blockId: `b${i}`, tier: 1, tokens: 10 };
+        }
+        const r = searchBlocks(docs, "alpha", { algorithm: "hybrid", limit: 10 });
+        assert.equal(r.length, 10);
+        assert.ok(r[0].score > 0);
+    } finally {
+        clearDocFeatures();
+    }
 });
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #227.

Two independent kernel-layer costs in the `searchBlocks` path. Both were reproduced locally on the current tree before changing anything.

## Item 1 (P1): `hybridAlgorithm.score` hard-crashes at large doc counts

`src/search/algorithms/hybrid.ts` normalized the two channel scores with an argument spread:

```ts
const maxBm = Math.max(...bm.map((r) => r.score), 1e-9)
```

The spread throws `RangeError: Maximum call stack size exceeded` once the doc count exceeds V8's argument limit (~65K–125K depending on build). **Reproduced**: 160,170 docs → the search tool *throws* instead of degrading, before returning any result.

**Fix**: compute the max with `reduce` (O(n), no argument limit, no extra allocation):

```ts
const maxBm = bm.reduce((m, r) => (r.score > m ? r.score : m), 1e-9)
```

This was the only argument-spread hazard in the codebase (audited every `Math.max/min(...spread)` and array spread).

## Item 2: `docFeatures` 8MB cap re-tokenizes large corpora on every call

The doc-features cache evicted in **insertion order (FIFO)**, keyed by full doc text. A corpus larger than the 8MB cap re-tokenized `(corpus − cap)` on **every** call. **Reproduced**: 12.0MB corpus / 27,741 docs / 8MB cap → cold 7242ms, warm 7524ms (warm/cold = 104%); cache pinned at 8.0MB.

**Fix** (design call — chose LRU over per-scope):
- Eviction is now **LRU**: a cache hit re-inserts the doc at the tail, so the docs a host keeps re-querying are the ones retained (strictly better than FIFO, no interface change).
- `setDocCacheCap(≥corpus)` / `Infinity` is now **documented + tested** as the opt-in for a single-session host to cache the whole corpus once and make later calls `O(docs × query-terms)` — this is what the host needs to stop re-tokenizing, without a per-scope cache redesign.

**Why not per-scope (key by doc `ref`)**: it would require threading a scope through the stateless public `SearchAlgorithm.score(docs, query)` contract — either a breaking change for custom algorithms, or a fragile non-async-safe module-level "active scope". That's a lot of surface for a multi-session-server use case that doesn't exist yet. The single-session host already gets full-corpus caching via the cap knob.

> The hybrid double pass (BM25 + fuzzy both scan all docs, then `applyRoleWeight`/`buildResults` each build a full Map) is left as-is: it's fine once features are warm (~140ms at 20K docs), per the issue.

## Tests

- `hybrid: no RangeError at large doc counts` — 160K docs (the crash scale) returns results instead of throwing.
- `LRU: re-accessing a doc keeps it alive (FIFO would evict it)` — pins the LRU-vs-FIFO difference via object identity.
- `setDocCacheCap(Infinity): whole corpus cached, no eviction` — pins the full-corpus opt-in.
- Renamed the eviction test to "evicts least-recently-used".

Full suite: **583 pass, 0 fail**. Typecheck clean, build succeeds.
