### PR TITLE
fix: base-id coverage for sub-id projections in prune + sync (#231)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export {
 } from "./refs.js";
 export {
   prune,
+  baseIdOf,
+  isCovered,
   SUMMARY_HEADER,
   summaryMessageId,
   isSummaryMessageId,

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -23,6 +23,28 @@ export function isSummaryMessageId(id: string): boolean {
 }
 
 /**
+ * Base id of a message id: everything before the first `#`. Sub-id
+ * projections (`base#callId`, `base#r0`, …) are alternate renderings of the
+ * same original message, so coverage is decided per original message — id
+ * comparisons normalize to the base (issue #231).
+ */
+export function baseIdOf(id: string): string {
+  const hash = id.indexOf("#");
+  return hash > 0 ? id.substring(0, hash) : id;
+}
+
+/**
+ * True when `id` falls under any covered original message, regardless of
+ * which projection form the block recorded and which the current view emits.
+ * `coveredBases` must be the set of `baseIdOf(c)` over the covered ids,
+ * built once per pass (O(1) per message instead of a scan). The exact
+ * membership test is subsumed: a covered id's own base is in the set.
+ */
+export function isCovered(id: string, coveredBases: Set<string>): boolean {
+  return coveredBases.has(baseIdOf(id));
+}
+
+/**
  * True when a message is a rendered block summary (the exact shape prune
  * emits). The id prefix alone is not sufficient — a host-authored message
  * that happens to carry a reserved id must not be treated as a rendered
@@ -49,28 +71,33 @@ export function prune(
 ): CoreMessage[] {
   const covered = coveredMessageIds(state);
   if (covered.size === 0) return [...messages];
+  const coveredBases = new Set<string>();
+  for (const id of covered) coveredBases.add(baseIdOf(id));
 
   const inject = options.injectSummaries ?? true;
   const firstUserIndex = messages.findIndex(
     (message) => message.role === "user",
   );
 
-  const indexById = new Map<string, number>();
+  const baseIndexById = new Map<string, number>();
   const summaryIndexById = new Map<string, number>();
   messages.forEach((message, index) => {
-    indexById.set(message.id, index);
+    const base = baseIdOf(message.id);
+    const existing = baseIndexById.get(base);
+    if (existing === undefined || index < existing)
+      baseIndexById.set(base, index);
     if (isRenderedSummaryMessage(message))
       summaryIndexById.set(message.id, index);
   });
 
   const anchors = inject
-    ? collectSummaryAnchors(state, indexById, summaryIndexById)
+    ? collectSummaryAnchors(state, baseIndexById, summaryIndexById)
     : [];
 
   return stripOrphanedReasoning(
     stripOrphanedToolResults(
       stripOrphanedToolCalls(
-        rebuildMessages(messages, covered, firstUserIndex, anchors),
+        rebuildMessages(messages, coveredBases, firstUserIndex, anchors),
       ),
     ),
   );
@@ -85,7 +112,7 @@ interface SummaryAnchor {
 
 function collectSummaryAnchors(
   state: CompressionState,
-  indexById: Map<string, number>,
+  baseIndexById: Map<string, number>,
   summaryIndexById: Map<string, number>,
 ): SummaryAnchor[] {
   const anchors: SummaryAnchor[] = [];
@@ -105,7 +132,7 @@ function collectSummaryAnchors(
     }
     let earliest: number | null = null;
     for (const id of block.effectiveMessageIds) {
-      const index = indexById.get(id);
+      const index = baseIndexById.get(baseIdOf(id));
       if (index !== undefined && (earliest === null || index < earliest)) {
         earliest = index;
       }
@@ -123,7 +150,7 @@ function collectSummaryAnchors(
 
 function rebuildMessages(
   messages: CoreMessage[],
-  covered: Set<string>,
+  coveredBases: Set<string>,
   firstUserIndex: number,
   anchors: SummaryAnchor[],
 ): CoreMessage[] {
@@ -141,7 +168,7 @@ function rebuildMessages(
       result.push(messages[index]!);
       continue;
     }
-    if (covered.has(messages[index]!.id)) continue;
+    if (isCovered(messages[index]!.id, coveredBases)) continue;
     // A stale copy of this block's summary from a previously-pruned view:
     // the freshly rendered one above replaces it. Only rendered-summary
     // shaped messages qualify — a host message that merely reuses the

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,4 @@
-import { summaryMessageId } from "./prune.js";
+import { baseIdOf, summaryMessageId } from "./prune.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
 export interface SyncResult {
@@ -11,6 +11,8 @@ export function syncBlocks(
   state: CompressionState,
 ): SyncResult {
   const presentIds = new Set(messages.map((message) => message.id));
+  const presentBases = new Set<string>();
+  for (const message of messages) presentBases.add(baseIdOf(message.id));
   const deactivated: string[] = [];
   // Deep-clone (not just `{...state}`) so the caller's input state is never
   // mutated: processTurn stamps `state.nudge.*` and reassigns `messageRefs`,
@@ -70,7 +72,7 @@ export function syncBlocks(
     // representation. Without this, hosts passing pruned views would lose
     // block activity every turn.
     const stillPresent =
-      block.effectiveMessageIds.some((id) => presentIds.has(id)) ||
+      block.effectiveMessageIds.some((id) => presentBases.has(baseIdOf(id))) ||
       presentIds.has(summaryMessageId(block.blockId));
     if (!stillPresent) {
       block.active = false;

--- a/tests/state-prune.test.ts
+++ b/tests/state-prune.test.ts
@@ -157,6 +157,81 @@ test("prune without summary injection only removes covered messages", () => {
   );
 });
 
+test("prune covers plain base id when block recorded sub-id projections (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "subid summary",
+      effectiveMessageIds: ["h_abc#r0", "h_abc#call1"],
+    }),
+  );
+  const messages = [msg("h_pre"), msg("h_abc"), msg("h_post")];
+  const result = prune(messages, state);
+
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["h_pre", "acp_summary_b1", "h_post"],
+  );
+});
+
+test("prune covers sub-id projections when block recorded plain base id (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }),
+  );
+  const messages = [
+    msg("h_pre"),
+    msg("h_abc#r0"),
+    msg("h_abc#call1"),
+    msg("h_post"),
+  ];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_pre", "h_post"]);
+});
+
+test("prune covers sibling sub-id projections of the same base (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const messages = [msg("h_abc#call1", "assistant"), msg("h_post")];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_post"]);
+});
+
+test("prune does not cover a distinct id that extends a covered base (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const messages = [msg("h_abcde"), msg("h_post")];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_abcde", "h_post"]);
+});
+
+test("prune anchors summary at base id when block recorded sub-ids (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "anchored",
+      effectiveMessageIds: ["h_abc#r0"],
+    }),
+  );
+  const messages = [msg("h_pre"), msg("h_abc"), msg("h_post")];
+  const result = prune(messages, state);
+
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["h_pre", "acp_summary_b1", "h_post"],
+  );
+  assert.ok(result[1]!.text!.includes("anchored"));
+});
+
 test("prune orders multiple summaries by their anchor position", () => {
   const state = createInitialState();
   state.blocks.push(

--- a/tests/sync-config.test.ts
+++ b/tests/sync-config.test.ts
@@ -50,6 +50,38 @@ test("syncBlocks leaves blocks intact when at least one message remains", () => 
   assert.equal(result.state.blocks[0]!.active, true);
 });
 
+test("syncBlocks keeps block active when view emits base id for sub-id block (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      effectiveMessageIds: ["h_abc#r0", "h_abc#call1"],
+    }),
+  );
+  const result = syncBlocks([msg("h_abc")], state);
+  assert.deepEqual(result.deactivated, []);
+  assert.equal(result.state.blocks[0]!.active, true);
+});
+
+test("syncBlocks keeps block active when view emits sub-ids for base-id block (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }),
+  );
+  const result = syncBlocks([msg("h_abc#r0")], state);
+  assert.deepEqual(result.deactivated, []);
+  assert.equal(result.state.blocks[0]!.active, true);
+});
+
+test("syncBlocks still deactivates when the base is truly gone (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const result = syncBlocks([msg("h_other")], state);
+  assert.deepEqual(result.deactivated, ["b1"]);
+});
+
 test("syncBlocks does not mutate input state", () => {
   const state = createInitialState();
   state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["x"] }));


### PR DESCRIPTION
Fixes #231.

## Bug
`prune()` decided coverage with exact string membership (`covered.has(message.id)`, covered built verbatim from `block.effectiveMessageIds`). When a block recorded sub-id projections (`base#callId`, `base#r0`, …) and the current view emitted the plain `base` (or vice versa), coverage failed and already-compressed messages re-entered the visible view resurrected (762K-token leak measured in replay).

## Fix
Normalize to the base id on **both sides** before the membership test:
- `baseIdOf(id)` — everything before the first `#` (a `#` at position 0 or `#`-free ids map to themselves, so `h_abcde` is never confused with covered base `h_abc` — no prefix matching).
- `isCovered(id, coveredBases)` — O(1) lookup against a precomputed base set (built once per pass), instead of per-message linear scans.
- Summary anchoring uses the earliest index of the base group, so a summary no longer jumps to index 0 when only projection forms are present.

## Sibling fix (same root cause, found during triage)
`syncBlocks()` (`src/sync.ts`) had the same exact-match presence check and runs **before** prune in the pipeline: in the primary direction it deactivated the block (summary lost) before prune could cover the message. Fixed with the same base-set normalization. Fixing prune alone would not have stopped the leak.

Note: the `isCovered` in closed PR #225 early-returned for `#`-free ids, so it missed the primary direction (block recorded sub-ids, view emits base); this normalizes both sides.

## Tests
8 new regression tests (5 in `tests/state-prune.test.ts`, 3 in `tests/sync-config.test.ts`), covering: block-sub-id/view-base, block-base/view-sub-id, sibling sub-ids, distinct-id negative case, summary anchor placement, and sync deactivation in both directions. All 588 tests pass; typecheck + build clean.

Remaining same-class exact-match sites (`recommend.ts`, `decompress.ts`, `compress.ts` overlap detection, `boundaries.ts`) are tracked in a follow-up issue.