### PR TITLE
fix: base-id membership at remaining exact-id check sites (#234)

### DIFF
--- a/src/boundaries.ts
+++ b/src/boundaries.ts
@@ -1,5 +1,9 @@
 import { activeBlocks, blockById } from "./state.js";
-import { isRenderedSummaryMessage, summaryMessageId } from "./prune.js";
+import {
+  baseIdOf,
+  isRenderedSummaryMessage,
+  summaryMessageId,
+} from "./prune.js";
 import type {
   CompressionBlock,
   CompressionState,
@@ -89,15 +93,24 @@ export function resolveBoundaries(
   }
 
   const indexByMessageId = new Map<string, number>();
-  input.messages.forEach((message, index) =>
-    indexByMessageId.set(message.id, index),
-  );
+  // Base-id view index (base → earliest index): anchor lookups fall back to
+  // it when the exact id form diverges from what refs/blocks recorded
+  // (issue #234).
+  const baseIndexById = new Map<string, number>();
+  input.messages.forEach((message, index) => {
+    indexByMessageId.set(message.id, index);
+    const base = baseIdOf(message.id);
+    const existing = baseIndexById.get(base);
+    if (existing === undefined || index < existing)
+      baseIndexById.set(base, index);
+  });
 
   let snappedBoundaries: string[] = [];
   const startAnchor = resolveAnchorIndex(
     start,
     input.state,
     indexByMessageId,
+    baseIndexById,
     "start",
   );
   if (startAnchor.snapped) snappedBoundaries.push(startAnchor.snapped);
@@ -105,6 +118,7 @@ export function resolveBoundaries(
     end,
     input.state,
     indexByMessageId,
+    baseIndexById,
     "end",
   );
   if (endAnchor.snapped) snappedBoundaries.push(endAnchor.snapped);
@@ -131,7 +145,15 @@ export function resolveBoundaries(
   const nestedBlockIds: string[] = [];
   const nestedSeen = new Set<string>();
   for (const block of activeBlocks(input.state)) {
-    if (blockVisibleInRange(block, indexByMessageId, startIndex, endIndex)) {
+    if (
+      blockVisibleInRange(
+        block,
+        indexByMessageId,
+        startIndex,
+        endIndex,
+        baseIndexById,
+      )
+    ) {
       if (!nestedSeen.has(block.blockId)) {
         nestedSeen.add(block.blockId);
         nestedBlockIds.push(block.blockId);
@@ -161,6 +183,7 @@ function resolveAnchorIndex(
   boundary: ParsedBoundary,
   state: CompressionState,
   indexByMessageId: Map<string, number>,
+  baseIndexById: Map<string, number>,
   endpoint: "start" | "end",
 ): AnchorResolution {
   const label = endpoint === "start" ? "startId" : "endId";
@@ -175,11 +198,12 @@ function resolveAnchorIndex(
         `${label}="${boundary.raw}" does not exist in this session (typo or wrong session) — run acp_status for current refs.`,
       );
     }
-    const index = indexByMessageId.get(rawId);
+    const index =
+      indexByMessageId.get(rawId) ?? baseIndexById.get(baseIdOf(rawId));
     if (index !== undefined) {
       return { index, snapped: null };
     }
-    const owner = activeOwnerAnchor(state, [rawId], indexByMessageId);
+    const owner = activeOwnerAnchor(state, [rawId], indexByMessageId, baseIndexById);
     if (owner !== null) {
       return {
         index: owner,
@@ -202,7 +226,7 @@ function resolveAnchorIndex(
     );
   }
   if (block.active) {
-    const anchor = visibleBlockAnchor(block, indexByMessageId);
+    const anchor = visibleBlockAnchor(block, indexByMessageId, baseIndexById);
     if (anchor !== null) {
       return { index: anchor, snapped: null };
     }
@@ -211,6 +235,7 @@ function resolveAnchorIndex(
     state,
     block.effectiveMessageIds,
     indexByMessageId,
+    baseIndexById,
   );
   if (owner !== null) {
     return {
@@ -247,9 +272,14 @@ function activeOwnerAnchor(
   state: CompressionState,
   ownedIds: string[],
   indexByMessageId: Map<string, number>,
+  baseIndexById: Map<string, number>,
 ): number | null {
   if (ownedIds.length === 0) return null;
-  const owned = new Set(ownedIds);
+  // Both sides normalized to base ids: the owned ids (from the ref map or a
+  // consumed block) and the inherited ids (from active children) may have been
+  // recorded under different projection forms (issue #234).
+  const owned = new Set<string>();
+  for (const id of ownedIds) owned.add(baseIdOf(id));
   let best: number | null = null;
   for (const block of state.blocks) {
     if (!block.active) continue;
@@ -262,7 +292,7 @@ function activeOwnerAnchor(
       }
     }
     if (!ownsInherited) continue;
-    const anchor = visibleBlockAnchor(block, indexByMessageId);
+    const anchor = visibleBlockAnchor(block, indexByMessageId, baseIndexById);
     if (anchor === null) continue;
     if (best === null || anchor < best) {
       best = anchor;
@@ -285,7 +315,7 @@ function inheritedContentIds(
   for (const childId of block.directBlockIds) {
     const child = blockById(state, childId);
     if (!child) continue;
-    for (const id of child.effectiveMessageIds) ids.add(id);
+    for (const id of child.effectiveMessageIds) ids.add(baseIdOf(id));
   }
   return ids;
 }
@@ -304,10 +334,15 @@ function formatPaddedRef(index: number): string {
 export function visibleBlockAnchor(
   block: CompressionBlock,
   indexByMessageId: Map<string, number>,
+  baseIndexById?: Map<string, number>,
 ): number | null {
   const summaryIndex = indexByMessageId.get(summaryMessageId(block.blockId));
   if (summaryIndex !== undefined) return summaryIndex;
-  return earliestIndexOfIds(block.effectiveMessageIds, indexByMessageId);
+  return earliestIndexOfIds(
+    block.effectiveMessageIds,
+    indexByMessageId,
+    baseIndexById,
+  );
 }
 
 // A block participates in a range when ANY of its visible representations
@@ -320,6 +355,7 @@ export function blockVisibleInRange(
   indexByMessageId: Map<string, number>,
   startIndex: number,
   endIndex: number,
+  baseIndexById?: Map<string, number>,
 ): boolean {
   const summaryIndex = indexByMessageId.get(summaryMessageId(block.blockId));
   if (
@@ -332,6 +368,7 @@ export function blockVisibleInRange(
   const rawIndex = earliestIndexOfIds(
     block.effectiveMessageIds,
     indexByMessageId,
+    baseIndexById,
   );
   return rawIndex !== null && rawIndex >= startIndex && rawIndex <= endIndex;
 }
@@ -339,15 +376,34 @@ export function blockVisibleInRange(
 export function earliestIndexOfIds(
   ids: string[],
   indexByMessageId: Map<string, number>,
+  baseIndexById?: Map<string, number>,
 ): number | null {
+  // Look up by base id so a block recorded under one projection form still
+  // resolves against a view emitting another (issue #234). The base index is
+  // derived from the exact-id map when the caller doesn't precompute it.
+  const baseIndex =
+    baseIndexById ??
+    deriveBaseIndex(indexByMessageId);
   let earliest: number | null = null;
   for (const id of ids) {
-    const index = indexByMessageId.get(id);
+    const index = baseIndex.get(baseIdOf(id));
     if (index !== undefined && (earliest === null || index < earliest)) {
       earliest = index;
     }
   }
   return earliest;
+}
+
+function deriveBaseIndex(
+  indexByMessageId: Map<string, number>,
+): Map<string, number> {
+  const baseIndex = new Map<string, number>();
+  for (const [id, index] of indexByMessageId) {
+    const base = baseIdOf(id);
+    const existing = baseIndex.get(base);
+    if (existing === undefined || index < existing) baseIndex.set(base, index);
+  }
+  return baseIndex;
 }
 
 export function toResolvedBoundary(range: ResolvedRange): ResolvedBoundary {

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,5 +1,5 @@
 import { assignRefs, highestUsedIndex, indexToRef } from "./refs.js";
-import { prune, isSummaryMessageId } from "./prune.js";
+import { baseIdOf, prune, isSummaryMessageId } from "./prune.js";
 import { syncBlocks } from "./sync.js";
 import { advanceSurvival, activeBlocks, blockById } from "./state.js";
 import { allocateBlockId, allocateRunId, createInitialState } from "./state.js";
@@ -143,6 +143,13 @@ function danglingMessageRefs(
   spec: { startRef: string; endRef: string },
 ): string[] {
   const visible = new Set(messages.map((m) => m.id));
+  const visibleBases = new Set<string>();
+  for (const id of visible) visibleBases.add(baseIdOf(id));
+  const coveredBases = new Set<string>();
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    for (const id of block.effectiveMessageIds) coveredBases.add(baseIdOf(id));
+  }
   const dangling: string[] = [];
   for (const ref of [spec.startRef, spec.endRef]) {
     const parsed = parseBoundary(ref);
@@ -150,11 +157,12 @@ function danglingMessageRefs(
     const rawId =
       state.messageRefs.byRef[parsed.raw] ??
       state.messageRefs.byRef[indexToRef(parsed.numericId)];
-    if (!rawId || visible.has(rawId)) continue;
-    const covered = state.blocks.some(
-      (block) => block.active && block.effectiveMessageIds.includes(rawId),
-    );
-    if (!covered) dangling.push(parsed.raw);
+    if (!rawId) continue;
+    const base = baseIdOf(rawId);
+    // The ref map may hold an older projection form than the current view
+    // (issue #234): test visibility and coverage per original message.
+    if (visible.has(rawId) || visibleBases.has(base)) continue;
+    if (!coveredBases.has(base)) dangling.push(parsed.raw);
   }
   return dangling;
 }
@@ -726,7 +734,13 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
   // have pulled in messages that are anchors of existing blocks).
   if (rangeMessageIds.length > resolved.messageIds.length) {
     const indexByMessageId = new Map<string, number>();
-    input.messages.forEach((m, i) => indexByMessageId.set(m.id, i));
+    const baseIndexById = new Map<string, number>();
+    input.messages.forEach((m, i) => {
+      indexByMessageId.set(m.id, i);
+      const base = baseIdOf(m.id);
+      const existing = baseIndexById.get(base);
+      if (existing === undefined || i < existing) baseIndexById.set(base, i);
+    });
     const adjustedStart =
       rangeMessageIds.length > 0
         ? (indexByMessageId.get(rangeMessageIds[0]!) ?? resolved.startIndex)
@@ -740,7 +754,13 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
     for (const block of activeBlocks(input.state)) {
       if (nestedSeen.has(block.blockId)) continue;
       if (
-        blockVisibleInRange(block, indexByMessageId, adjustedStart, adjustedEnd)
+        blockVisibleInRange(
+          block,
+          indexByMessageId,
+          adjustedStart,
+          adjustedEnd,
+          baseIndexById,
+        )
       ) {
         nestedSeen.add(block.blockId);
         resolved.nestedBlockIds.push(block.blockId);
@@ -773,7 +793,7 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
   }
 
   const directMessageIds = [...effectiveMessageIds].filter(
-    (id) => !input.preExistingCoverage.has(id),
+    (id) => !input.preExistingCoverage.has(baseIdOf(id)),
   );
 
   let filteredIds = filterProtectedToolMessages(
@@ -1038,10 +1058,13 @@ function resolveTargetTier(
   return minTier;
 }
 
+/** Base ids of every message already covered by an active block: the
+ *  pre-existing-coverage set is compared against range message ids that may
+ *  carry a different projection form (issue #234). */
 function collectCoverage(state: CompressionState): Set<string> {
   const coverage = new Set<string>();
   for (const block of activeBlocks(state)) {
-    for (const id of block.effectiveMessageIds) coverage.add(id);
+    for (const id of block.effectiveMessageIds) coverage.add(baseIdOf(id));
   }
   return coverage;
 }

--- a/src/decompress.ts
+++ b/src/decompress.ts
@@ -1,4 +1,4 @@
-import { SUMMARY_HEADER } from "./prune.js";
+import { SUMMARY_HEADER, baseIdOf } from "./prune.js";
 import type { CompressionBlock, CompressionState, CoreMessage } from "./types.js";
 
 export function parseBlockIdArg(arg: string): string | null {
@@ -15,10 +15,12 @@ export function findBlocksOverlappingMessages(
     messageIds: Set<string>,
 ): CompressionBlock[] {
     if (messageIds.size === 0) return [];
+    const messageBases = new Set<string>();
+    for (const id of messageIds) messageBases.add(baseIdOf(id));
     const matched: CompressionBlock[] = [];
     for (const block of state.blocks) {
         if (!block.active) continue;
-        if (block.effectiveMessageIds.some((id) => messageIds.has(id))) {
+        if (block.effectiveMessageIds.some((id) => messageBases.has(baseIdOf(id)))) {
             matched.push(block);
         }
     }
@@ -98,13 +100,15 @@ export function buildRestoredContentPreview(
     beforeActiveMessageIds: Set<string>,
     state: CompressionState,
 ): RestoredPreviewResult {
+    const coveredBases = new Set<string>();
+    for (const b of state.blocks) {
+        if (!b.active) continue;
+        for (const id of b.effectiveMessageIds) coveredBases.add(baseIdOf(id));
+    }
     const restored: CoreMessage[] = [];
     for (const message of messages) {
         if (!beforeActiveMessageIds.has(message.id)) continue;
-        const stillCovered = state.blocks.some(
-            (b) => b.active && b.effectiveMessageIds.includes(message.id),
-        );
-        if (!stillCovered) restored.push(message);
+        if (!coveredBases.has(baseIdOf(message.id))) restored.push(message);
     }
 
     if (restored.length === 0) return { preview: "", restoredCount: 0 };
@@ -166,10 +170,13 @@ export function collectBlockContent(
     options: CollectContentOptions = {},
 ): CollectedContentResult {
     const full = options.full ?? false;
-    const targetIds = new Set(block.effectiveMessageIds);
+    // Base-id sets: the block recorded one projection form, the current view
+    // may emit another (`base` vs `base#r0`); coverage is per original message.
+    const targetBases = new Set<string>();
+    for (const id of block.effectiveMessageIds) targetBases.add(baseIdOf(id));
 
     if (full) {
-        const msgs = messages.filter((m) => targetIds.has(m.id));
+        const msgs = messages.filter((m) => targetBases.has(baseIdOf(m.id)));
         if (msgs.length === 0) return { text: "", count: 0 };
         return { text: msgs.map(formatMessage).join("\n\n"), count: msgs.length };
     }
@@ -182,7 +189,7 @@ export function collectBlockContent(
         const child = state.blocks.find((b) => b.blockId === childId);
         if (!child?.active) continue;
         nestedChildren.push(child);
-        for (const id of child.effectiveMessageIds) nestedCovered.add(id);
+        for (const id of child.effectiveMessageIds) nestedCovered.add(baseIdOf(id));
     }
 
     const parts: string[] = [];
@@ -193,7 +200,8 @@ export function collectBlockContent(
 
     let directCount = 0;
     for (const m of messages) {
-        if (targetIds.has(m.id) && !nestedCovered.has(m.id)) {
+        const base = baseIdOf(m.id);
+        if (targetBases.has(base) && !nestedCovered.has(base)) {
             parts.push(formatMessage(m));
             directCount++;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export {
 } from "./refs.js";
 export {
   prune,
+  baseIdOf,
+  isCovered,
   SUMMARY_HEADER,
   summaryMessageId,
   isSummaryMessageId,

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -23,6 +23,28 @@ export function isSummaryMessageId(id: string): boolean {
 }
 
 /**
+ * Base id of a message id: everything before the first `#`. Sub-id
+ * projections (`base#callId`, `base#r0`, …) are alternate renderings of the
+ * same original message, so coverage is decided per original message — id
+ * comparisons normalize to the base (issue #231).
+ */
+export function baseIdOf(id: string): string {
+  const hash = id.indexOf("#");
+  return hash > 0 ? id.substring(0, hash) : id;
+}
+
+/**
+ * True when `id` falls under any covered original message, regardless of
+ * which projection form the block recorded and which the current view emits.
+ * `coveredBases` must be the set of `baseIdOf(c)` over the covered ids,
+ * built once per pass (O(1) per message instead of a scan). The exact
+ * membership test is subsumed: a covered id's own base is in the set.
+ */
+export function isCovered(id: string, coveredBases: Set<string>): boolean {
+  return coveredBases.has(baseIdOf(id));
+}
+
+/**
  * True when a message is a rendered block summary (the exact shape prune
  * emits). The id prefix alone is not sufficient — a host-authored message
  * that happens to carry a reserved id must not be treated as a rendered
@@ -49,28 +71,33 @@ export function prune(
 ): CoreMessage[] {
   const covered = coveredMessageIds(state);
   if (covered.size === 0) return [...messages];
+  const coveredBases = new Set<string>();
+  for (const id of covered) coveredBases.add(baseIdOf(id));
 
   const inject = options.injectSummaries ?? true;
   const firstUserIndex = messages.findIndex(
     (message) => message.role === "user",
   );
 
-  const indexById = new Map<string, number>();
+  const baseIndexById = new Map<string, number>();
   const summaryIndexById = new Map<string, number>();
   messages.forEach((message, index) => {
-    indexById.set(message.id, index);
+    const base = baseIdOf(message.id);
+    const existing = baseIndexById.get(base);
+    if (existing === undefined || index < existing)
+      baseIndexById.set(base, index);
     if (isRenderedSummaryMessage(message))
       summaryIndexById.set(message.id, index);
   });
 
   const anchors = inject
-    ? collectSummaryAnchors(state, indexById, summaryIndexById)
+    ? collectSummaryAnchors(state, baseIndexById, summaryIndexById)
     : [];
 
   return stripOrphanedReasoning(
     stripOrphanedToolResults(
       stripOrphanedToolCalls(
-        rebuildMessages(messages, covered, firstUserIndex, anchors),
+        rebuildMessages(messages, coveredBases, firstUserIndex, anchors),
       ),
     ),
   );
@@ -85,7 +112,7 @@ interface SummaryAnchor {
 
 function collectSummaryAnchors(
   state: CompressionState,
-  indexById: Map<string, number>,
+  baseIndexById: Map<string, number>,
   summaryIndexById: Map<string, number>,
 ): SummaryAnchor[] {
   const anchors: SummaryAnchor[] = [];
@@ -105,7 +132,7 @@ function collectSummaryAnchors(
     }
     let earliest: number | null = null;
     for (const id of block.effectiveMessageIds) {
-      const index = indexById.get(id);
+      const index = baseIndexById.get(baseIdOf(id));
       if (index !== undefined && (earliest === null || index < earliest)) {
         earliest = index;
       }
@@ -123,7 +150,7 @@ function collectSummaryAnchors(
 
 function rebuildMessages(
   messages: CoreMessage[],
-  covered: Set<string>,
+  coveredBases: Set<string>,
   firstUserIndex: number,
   anchors: SummaryAnchor[],
 ): CoreMessage[] {
@@ -141,7 +168,7 @@ function rebuildMessages(
       result.push(messages[index]!);
       continue;
     }
-    if (covered.has(messages[index]!.id)) continue;
+    if (isCovered(messages[index]!.id, coveredBases)) continue;
     // A stale copy of this block's summary from a previously-pruned view:
     // the freshly rendered one above replaces it. Only rendered-summary
     // shaped messages qualify — a host message that merely reuses the

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -25,6 +25,7 @@ import {
   isMessageProtectedWithPairing,
   isNeverPreserveRecent,
 } from "./protected.js";
+import { baseIdOf } from "./prune.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -39,15 +40,25 @@ export function isToolMessage(message: CoreMessage): boolean {
 }
 
 
+/** Base ids of every message covered by an active block, built once per
+ *  pass: coverage is decided per original message, so a message re-projected
+ *  under a sub-id form (`base#r0`) stays covered by a block that recorded the
+ *  plain base (and vice versa) — issue #234. */
+function activeBlockCoveredBases(state: CompressionState): Set<string> {
+  const covered = new Set<string>();
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    for (const id of block.effectiveMessageIds) covered.add(baseIdOf(id));
+  }
+  return covered;
+}
+
 function isSyntheticOrPruned(
   message: CoreMessage,
-  state: CompressionState,
+  coveredBases: Set<string>,
 ): boolean {
   if (message.text?.startsWith("[Compressed conversation section]")) return true;
-  for (const block of state.blocks) {
-    if (block.active && block.effectiveMessageIds.includes(message.id)) return true;
-  }
-  return false;
+  return coveredBases.has(baseIdOf(message.id));
 }
 
 // ─── 1. Protected Refs (soft protection zone) ─────────────────────────────────
@@ -73,9 +84,10 @@ export function computeProtectedRefs(
 
   const result = new Set<string>();
   const visible: { ref: string; tokens: number }[] = [];
+  const coveredBases = activeBlockCoveredBases(state);
 
   for (const msg of messages) {
-    if (isSyntheticOrPruned(msg, state)) continue;
+    if (isSyntheticOrPruned(msg, coveredBases)) continue;
     // Exclude decompress-style tool results from the recent-zone window.
     // These are large inline restorations that the model should be free to
     // compress again immediately; counting them toward the last-N window
@@ -115,7 +127,7 @@ export function computeProtectedRefs(
   if (preserveN > 0) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]!;
-      if (msg.role !== "user" || isSyntheticOrPruned(msg, state)) continue;
+      if (msg.role !== "user" || isSyntheticOrPruned(msg, coveredBases)) continue;
       const ref = state.messageRefs.byRaw[msg.id];
       if (ref && ref !== "BLOCKED") result.add(ref);
       break;
@@ -174,11 +186,12 @@ export function buildCompressibleRanges(
   // two rules coincide, so ranges are byte-identical to the old behavior.
   let skipSinceCompressible = false;
   let skipSinceProtected = false;
+  const coveredBases = activeBlockCoveredBases(state);
 
   for (const msg of messages) {
     const ref = state.messageRefs.byRaw[msg.id];
     if (!ref || ref === "BLOCKED") continue;
-    if (isSyntheticOrPruned(msg, state)) {
+    if (isSyntheticOrPruned(msg, coveredBases)) {
       skipSinceCompressible = true;
       skipSinceProtected = true;
       continue;

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,5 +1,6 @@
 import { refForRaw } from "./refs.js";
 import { isToolMessage } from "./recommend.js";
+import { baseIdOf } from "./prune.js";
 import type { CompressionBlock, CompressionState, CoreMessage } from "./types.js";
 
 function formatTokens(n: number): string {
@@ -72,7 +73,7 @@ function collectVisible(
     const coveredIds = new Set<string>();
     for (const block of state.blocks) {
         if (!block.active) continue;
-        for (const id of block.effectiveMessageIds) coveredIds.add(id);
+        for (const id of block.effectiveMessageIds) coveredIds.add(baseIdOf(id));
     }
     let summaryTokens = 0;
     for (const block of state.blocks) {
@@ -90,7 +91,7 @@ function collectVisible(
         }
     }
     messages.forEach((message, index) => {
-        if (coveredIds.has(message.id)) return;
+        if (coveredIds.has(baseIdOf(message.id))) return;
         const ref = refForRaw(state.messageRefs, message.id);
         if (!ref) return;
         const tokens = countTokens(message.text ?? "");

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,4 @@
-import { summaryMessageId } from "./prune.js";
+import { baseIdOf, summaryMessageId } from "./prune.js";
 import type { CompressionState, CoreMessage } from "./types.js";
 
 export interface SyncResult {
@@ -11,6 +11,8 @@ export function syncBlocks(
   state: CompressionState,
 ): SyncResult {
   const presentIds = new Set(messages.map((message) => message.id));
+  const presentBases = new Set<string>();
+  for (const message of messages) presentBases.add(baseIdOf(message.id));
   const deactivated: string[] = [];
   // Deep-clone (not just `{...state}`) so the caller's input state is never
   // mutated: processTurn stamps `state.nudge.*` and reassigns `messageRefs`,
@@ -78,7 +80,7 @@ export function syncBlocks(
     // representation. Without this, hosts passing pruned views would lose
     // block activity every turn.
     const stillPresent =
-      block.effectiveMessageIds.some((id) => presentIds.has(id)) ||
+      block.effectiveMessageIds.some((id) => presentBases.has(baseIdOf(id))) ||
       presentIds.has(summaryMessageId(block.blockId));
     if (!stillPresent) {
       block.active = false;

--- a/tests/state-prune.test.ts
+++ b/tests/state-prune.test.ts
@@ -157,6 +157,81 @@ test("prune without summary injection only removes covered messages", () => {
   );
 });
 
+test("prune covers plain base id when block recorded sub-id projections (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "subid summary",
+      effectiveMessageIds: ["h_abc#r0", "h_abc#call1"],
+    }),
+  );
+  const messages = [msg("h_pre"), msg("h_abc"), msg("h_post")];
+  const result = prune(messages, state);
+
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["h_pre", "acp_summary_b1", "h_post"],
+  );
+});
+
+test("prune covers sub-id projections when block recorded plain base id (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }),
+  );
+  const messages = [
+    msg("h_pre"),
+    msg("h_abc#r0"),
+    msg("h_abc#call1"),
+    msg("h_post"),
+  ];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_pre", "h_post"]);
+});
+
+test("prune covers sibling sub-id projections of the same base (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const messages = [msg("h_abc#call1", "assistant"), msg("h_post")];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_post"]);
+});
+
+test("prune does not cover a distinct id that extends a covered base (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const messages = [msg("h_abcde"), msg("h_post")];
+  const result = prune(messages, state, { injectSummaries: false });
+
+  assert.deepEqual(result.map((m) => m.id), ["h_abcde", "h_post"]);
+});
+
+test("prune anchors summary at base id when block recorded sub-ids (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      summary: "anchored",
+      effectiveMessageIds: ["h_abc#r0"],
+    }),
+  );
+  const messages = [msg("h_pre"), msg("h_abc"), msg("h_post")];
+  const result = prune(messages, state);
+
+  assert.deepEqual(
+    result.map((m) => m.id),
+    ["h_pre", "acp_summary_b1", "h_post"],
+  );
+  assert.ok(result[1]!.text!.includes("anchored"));
+});
+
 test("prune orders multiple summaries by their anchor position", () => {
   const state = createInitialState();
   state.blocks.push(

--- a/tests/subid-membership.test.ts
+++ b/tests/subid-membership.test.ts
@@ -1,0 +1,398 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import {
+  resolveBoundaries,
+  visibleBlockAnchor,
+  blockVisibleInRange,
+} from "../src/boundaries.js";
+import {
+  findBlocksOverlappingMessages,
+  buildRestoredContentPreview,
+  collectBlockContent,
+} from "../src/decompress.js";
+import {
+  computeProtectedRefs,
+  buildCompressibleRanges,
+} from "../src/recommend.js";
+import { buildStatusReport } from "../src/report.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs } from "../src/refs.js";
+import type {
+  CompressionBlock,
+  CompressionState,
+  Config,
+  CoreMessage,
+} from "../src/types.js";
+
+// #234: exact-id membership between block.effectiveMessageIds (or ref-map ids)
+// and current-view ids must normalize to the base id, so coverage survives a
+// projection-form change (base vs base#sub). Every test here fails on the
+// pre-fix exact-match code.
+
+function msg(
+  id: string,
+  text?: string,
+  role: CoreMessage["role"] = "user",
+): CoreMessage {
+  return { id, role, contentType: "text", text: text ?? id };
+}
+
+function summaryMsg(blockId: string, summary: string): CoreMessage {
+  return {
+    id: `acp_summary_${blockId}`,
+    role: "system",
+    contentType: "text",
+    text: `[Compressed conversation section]\n${summary}`,
+  };
+}
+
+function makeBlock(
+  overrides: Partial<CompressionBlock> & { blockId: string },
+): CompressionBlock {
+  return {
+    runId: "r1",
+    tier: 1,
+    summary: "summary",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    createdAt: 0,
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    merge: { maxSummaryLength: 3000, minOldGenBlocks: 3 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+    ...overrides,
+  };
+}
+
+function assignAll(
+  messages: CoreMessage[],
+  state: CompressionState = createInitialState(),
+): CompressionState {
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  return state;
+}
+
+// ─── recommend.ts: isSyntheticOrPruned ────────────────────────────────────────
+
+test("buildCompressibleRanges skips a sub-id view of a base-id block (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const messages = [msg("h_pre"), msg("h_abc#r0"), msg("h_post")];
+  assignAll(messages, state);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  // Covered m00002 must split the range — it must not sit inside a span.
+  assert.deepEqual(
+    ranges.compressible.map((r) => [r.startRef, r.endRef]),
+    [
+      ["m00001", "m00001"],
+      ["m00003", "m00003"],
+    ],
+  );
+});
+
+test("buildCompressibleRanges skips a base view of a sub-id block (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }));
+  const messages = [msg("h_pre"), msg("h_abc"), msg("h_post")];
+  assignAll(messages, state);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  assert.deepEqual(
+    ranges.compressible.map((r) => [r.startRef, r.endRef]),
+    [
+      ["m00001", "m00001"],
+      ["m00003", "m00003"],
+    ],
+  );
+});
+
+test("buildCompressibleRanges keeps a distinct id that extends a covered base (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }));
+  const messages = [msg("h_abcde"), msg("h_post")];
+  assignAll(messages, state);
+  const ranges = buildCompressibleRanges(messages, state, config());
+  const refs = ranges.compressible.flatMap((r) => [r.startRef, r.endRef]);
+  assert.ok(refs.includes("m00001"), "h_abcde is not covered by base h_abc");
+});
+
+test("computeProtectedRefs ignores covered messages re-projected under sub-ids (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_a"] }));
+  const messages = [msg("h_a#r0"), msg("h_b")];
+  assignAll(messages, state);
+  const refs = computeProtectedRefs(
+    messages,
+    state,
+    config({ preserveRecentMessages: 5 }),
+  );
+  assert.ok(refs.has("m00002"));
+  assert.ok(!refs.has("m00001"), "covered message must not occupy a recent-window slot");
+});
+
+// ─── decompress.ts: findBlocksOverlappingMessages ─────────────────────────────
+
+test("findBlocksOverlappingMessages matches a base-id block against sub-id view ids (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const matched = findBlocksOverlappingMessages(state, new Set(["h_abc#r0"]));
+  assert.deepEqual(matched.map((b) => b.blockId), ["b1"]);
+});
+
+test("findBlocksOverlappingMessages matches a sub-id block against a base view id (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }));
+  const matched = findBlocksOverlappingMessages(state, new Set(["h_abc"]));
+  assert.deepEqual(matched.map((b) => b.blockId), ["b1"]);
+});
+
+test("findBlocksOverlappingMessages does not match a distinct id extending the base (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const matched = findBlocksOverlappingMessages(state, new Set(["h_abcde"]));
+  assert.deepEqual(matched, []);
+});
+
+// ─── decompress.ts: buildRestoredContentPreview ───────────────────────────────
+
+test("buildRestoredContentPreview keeps a still-covered message out (base block, sub-id view) (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const messages = [msg("h_abc#r0", "restored?"), msg("h_post", "new content")];
+  const result = buildRestoredContentPreview(
+    messages,
+    new Set(["h_abc#r0", "h_post"]),
+    state,
+  );
+  assert.equal(result.restoredCount, 1);
+  assert.ok(result.preview.includes("new content"));
+  assert.ok(!result.preview.includes("restored?"));
+});
+
+test("buildRestoredContentPreview keeps a still-covered message out (sub-id block, base view) (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }));
+  const messages = [msg("h_abc", "restored?"), msg("h_post", "new content")];
+  const result = buildRestoredContentPreview(
+    messages,
+    new Set(["h_abc", "h_post"]),
+    state,
+  );
+  assert.equal(result.restoredCount, 1);
+  assert.ok(!result.preview.includes("restored?"));
+});
+
+// ─── decompress.ts: collectBlockContent ───────────────────────────────────────
+
+test("collectBlockContent collects sub-id view messages of a base-id block (#234)", () => {
+  const state = createInitialState();
+  const block = makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] });
+  state.blocks.push(block);
+  const messages = [msg("h_abc#r0", "the content")];
+  const result = collectBlockContent(state, block, messages, { full: true });
+  assert.equal(result.count, 1);
+  assert.ok(result.text.includes("the content"));
+});
+
+test("collectBlockContent folds nested children across forms (#234)", () => {
+  const state = createInitialState();
+  const parent = makeBlock({
+    blockId: "b1",
+    effectiveMessageIds: ["h_a", "h_b"],
+    directBlockIds: ["b2"],
+  });
+  const child = makeBlock({
+    blockId: "b2",
+    effectiveMessageIds: ["h_b#r0"],
+    summary: "child summary",
+  });
+  state.blocks.push(parent, child);
+  const messages = [msg("h_a#r0", "a content"), msg("h_b#r0", "b content")];
+  const result = collectBlockContent(state, parent, messages);
+  assert.ok(result.text.includes("a content"), "direct message rendered in full");
+  assert.ok(!result.text.includes("b content"), "nested-covered message stays folded");
+  assert.ok(result.text.includes("child summary"), "nested summary rendered in place");
+  assert.equal(result.count, 2, "1 direct message + 1 nested summary");
+});
+
+// ─── compress.ts: danglingMessageRefs ─────────────────────────────────────────
+
+test("dangling-ref report recognizes cross-form coverage as already-compressed (#234)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }));
+  // Ref map holds the older base form; the view is pruned (summary only).
+  state.messageRefs.byRaw = { "h_abc": "m00001" };
+  state.messageRefs.byRef = { m00001: "h_abc" };
+  const messages = [summaryMsg("b1", "subid summary")];
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00001", summary: "retry" }],
+    messages,
+    state,
+    config: config({
+      compress: { minCompressRange: 1000, maxSummaryLength: 0, minSummaryLength: 0 },
+    }),
+  });
+  assert.equal(result.result.blocksCreated, 0);
+  assert.ok(result.result.errors.length > 0);
+  assert.ok(
+    result.result.errors[0]!.includes("already compressed"),
+    `expected already-compressed guidance, got: ${result.result.errors[0]}`,
+  );
+  assert.ok(
+    !result.result.errors[0]!.includes("cannot be anchored"),
+    "cross-form coverage must not be reported as a dangling ref",
+  );
+});
+
+// ─── compress.ts: collectCoverage / preExistingCoverage (livelock guard) ──────
+
+test("livelock guard fires when a range is fully covered across forms (#234)", () => {
+  const core = createCore();
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const messages = [msg("h_abc#r0", "already compressed content"), msg("h_post", "post")];
+  assignAll(messages, state);
+  const result = core.applyCompression({
+    ranges: [{ startRef: "m00001", endRef: "m00001", summary: "fake" }],
+    messages,
+    state,
+    config: config(),
+  });
+  assert.equal(result.result.blocksCreated, 0, "no empty same-tier rewrite");
+  assert.ok(result.result.errors.length > 0);
+  assert.ok(
+    result.result.errors[0]!.includes("no new compressible messages"),
+    `expected livelock-guard error, got: ${result.result.errors[0]}`,
+  );
+});
+
+// ─── boundaries.ts: activeOwnerAnchor (inherited.has) ─────────────────────────
+
+test("message ref snaps to the inheriting block across projection forms (#234)", () => {
+  const state = createInitialState();
+  const b1 = makeBlock({
+    blockId: "b1",
+    effectiveMessageIds: ["h_a"],
+    active: false,
+  });
+  const b2 = makeBlock({
+    blockId: "b2",
+    tier: 2,
+    effectiveMessageIds: ["h_a", "h_b"],
+    directBlockIds: ["b1"],
+  });
+  state.blocks.push(b1, b2);
+  // Ref map holds the sub-id form recorded under an older projection.
+  state.messageRefs.byRaw = { "h_a#call1": "m00001" };
+  state.messageRefs.byRef = { m00001: "h_a#call1" };
+  const messages = [summaryMsg("b2", "tier2 summary")];
+  const resolved = resolveBoundaries({
+    startRef: "m00001",
+    endRef: "m00001",
+    messages,
+    state,
+  });
+  assert.equal(resolved.startIndex, 0);
+  assert.equal(resolved.endIndex, 0);
+  assert.equal(
+    resolved.snappedBoundaries.length,
+    2,
+    "both endpoints snap to the active ancestor",
+  );
+});
+
+// ─── boundaries.ts: visibleBlockAnchor / blockVisibleInRange ──────────────────
+
+test("visibleBlockAnchor resolves a base-id block against a sub-id view (#234)", () => {
+  const block = makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] });
+  const indexByMessageId = new Map<string, number>([["h_abc#r0", 1]]);
+  assert.equal(visibleBlockAnchor(block, indexByMessageId), 1);
+  const baseIndexById = new Map<string, number>([["h_abc", 1]]);
+  assert.equal(visibleBlockAnchor(block, indexByMessageId, baseIndexById), 1);
+});
+
+test("blockVisibleInRange detects a block whose recorded form differs from the view (#234)", () => {
+  const block = makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] });
+  const indexByMessageId = new Map<string, number>([["h_abc#r0", 1]]);
+  assert.equal(blockVisibleInRange(block, indexByMessageId, 0, 2), true);
+  assert.equal(blockVisibleInRange(block, indexByMessageId, 2, 3), false);
+});
+
+test("block-boundary anchor resolves a base-id block over a sub-id view (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_a", "h_b"] }));
+  const messages = [msg("h_a#r0"), msg("h_b#r0")];
+  const resolved = resolveBoundaries({
+    startRef: "b1",
+    endRef: "b1",
+    messages,
+    state,
+  });
+  assert.equal(resolved.startIndex, 0);
+  assert.equal(resolved.endIndex, 0);
+  assert.deepEqual(resolved.nestedBlockIds, ["b1"]);
+});
+
+// ─── boundaries.ts: message-ref exact lookup with base fallback ───────────────
+
+test("message ref in the older projection form still anchors to the visible message (#234)", () => {
+  const state = createInitialState();
+  state.messageRefs.byRaw = { "h_a": "m00001" };
+  state.messageRefs.byRef = { m00001: "h_a" };
+  const messages = [msg("h_a#r0")];
+  const resolved = resolveBoundaries({
+    startRef: "m00001",
+    endRef: "m00001",
+    messages,
+    state,
+  });
+  assert.equal(resolved.startIndex, 0);
+  assert.deepEqual(resolved.snappedBoundaries, [], "no snap — the message is visible");
+});
+
+// ─── report.ts: collectVisible ────────────────────────────────────────────────
+
+test("status report excludes a covered message re-projected under sub-ids (#234)", () => {
+  const state = createInitialState();
+  state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }));
+  const messages = [msg("h_abc#r0"), msg("h_post")];
+  assignAll(messages, state);
+  const report = buildStatusReport(state, messages, (t) => Math.ceil(t.length / 4), {
+    scope: "uncompressed",
+    view: "messages",
+  });
+  assert.ok(report.includes("m00002"), "uncovered message stays listed");
+  assert.ok(!report.includes("m00001"), "covered message must not be listed");
+});

--- a/tests/sync-config.test.ts
+++ b/tests/sync-config.test.ts
@@ -69,6 +69,38 @@ test("syncBlocks re-activates a deactivated (non-expanded) block when its messag
   assert.equal(result.state.blocks[0]!.active, true, "legacy resurrection preserved for non-expanded blocks");
 });
 
+test("syncBlocks keeps block active when view emits base id for sub-id block (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({
+      blockId: "b1",
+      effectiveMessageIds: ["h_abc#r0", "h_abc#call1"],
+    }),
+  );
+  const result = syncBlocks([msg("h_abc")], state);
+  assert.deepEqual(result.deactivated, []);
+  assert.equal(result.state.blocks[0]!.active, true);
+});
+
+test("syncBlocks keeps block active when view emits sub-ids for base-id block (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc"] }),
+  );
+  const result = syncBlocks([msg("h_abc#r0")], state);
+  assert.deepEqual(result.deactivated, []);
+  assert.equal(result.state.blocks[0]!.active, true);
+});
+
+test("syncBlocks still deactivates when the base is truly gone (#231)", () => {
+  const state = createInitialState();
+  state.blocks.push(
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["h_abc#r0"] }),
+  );
+  const result = syncBlocks([msg("h_other")], state);
+  assert.deepEqual(result.deactivated, ["b1"]);
+});
+
 test("syncBlocks does not mutate input state", () => {
   const state = createInitialState();
   state.blocks.push(makeBlock({ blockId: "b1", effectiveMessageIds: ["x"] }));


### PR DESCRIPTION
## What

Fixes #234. PR #233 normalized `prune.ts` + `sync.ts` to compare block coverage by **base id** so sub-id projections (`base#r0`, `base#call1`) stay covered by blocks that recorded the plain base (and vice versa). This PR applies the same `baseIdOf` / base-set normalization to every remaining same-class site in the kernel.

**Stacked on #233** — this branch contains #233's commit (`ad78b45`, cherry-pick of `ed232f5`) so `baseIdOf` is available. Whichever PR merges first, the other auto-resolves. Merge #233 first if you prefer a clean single-PR history; otherwise this PR can merge directly.

## Sites fixed

**Listed in #234's table:**

| Site | Check | Fix |
|------|-------|-----|
| `src/recommend.ts` `isSyntheticOrPruned` | `block.effectiveMessageIds.includes(message.id)` | precomputed `activeBlockCoveredBases(state)` set, tested via `baseIdOf(message.id)`; built once per pass in `computeProtectedRefs` + `buildCompressibleRanges` |
| `src/decompress.ts` `findBlocksOverlappingMessages` | `messageIds.has(id)` | `messageBases` set from the param, tested via `baseIdOf(id)` |
| `src/decompress.ts` `buildRestoredContentPreview` | `b.effectiveMessageIds.includes(message.id)` | precomputed covered-bases set |
| `src/compress.ts` `danglingMessageRefs` | `block.effectiveMessageIds.includes(rawId)` | visible + covered base sets; ref-map form divergence handled |
| `src/compress.ts` `collectCoverage` + `directMessageIds` filter | coverage set vs range ids | coverage stored as base ids; filter tests `baseIdOf(id)` — livelock guard now fires across forms |
| `src/boundaries.ts` `activeOwnerAnchor` | `inherited.has(id)` | owned + inherited sets both base-normalized |
| `src/report.ts` `collectVisible` | `coveredIds.has(message.id)` | covered set + lookup base-normalized |

**Found during verification (same class, not in the table):**

| Site | Check | Fix |
|------|-------|-----|
| `src/decompress.ts` `collectBlockContent` | `targetIds.has(m.id)` + `nestedCovered.has(m.id)` | base sets for target and nested-fold (already flagged in #231 triage, floor 3) |
| `src/boundaries.ts` message-ref lookup | `indexByMessageId.get(rawId)` | exact first, then `baseIndexById.get(baseIdOf(rawId))` fallback — stale refs from an older projection form still anchor to the visible message |
| `src/boundaries.ts` `visibleBlockAnchor` / `blockVisibleInRange` / `earliestIndexOfIds` | block ids vs view index map | base→earliest-index map built in `resolveBoundaries` + `applySingleRange`; exported fns gained an **optional** trailing `baseIndexById?` param (backward-compatible, no API break; derived from the exact map when omitted) |

**Report-only (not fixed here):** `src/wire/compress-detect.ts:180` `boundaryRawCore` compares `block.effectiveMessageIds` (via ref map) against current core-message ids with exact equality — same class, but it's in the wire subpath (replay-guard, #91 lineage) with its own test suite; left out to keep this PR focused on the kernel path. Happy to fold it in or file a follow-up — your call.

## Tests

New `tests/subid-membership.test.ts` — 19 regression tests covering every fixed site, **both projection directions** (base block / sub-id view and sub-id block / base view) plus **prefix-safety controls** (`h_abcde` is NOT covered by base `h_abc` — no accidental prefix matching). Verified against the pre-fix code: **17/19 fail**, the 2 passing are the prefix-safety controls (correct in both states).

Full suite: 651/651 pass, `tsc --noEmit` clean, build OK.

## Minor note

`package-lock.json` on master is one version behind `package.json` (0.0.58 vs 0.0.59 — the release commit only bumps package.json). `npm install` rewrites it locally; I reverted that to keep this PR focused. Can be synced in a housekeeping commit if you want.

<!-- ework-agent-pr -->