### PR TITLE
release v0.0.60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.58",
+    "version": "0.0.60",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.58",
+            "version": "0.0.60",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.59",
+    "version": "0.0.60",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## 内容

唯一实质变更:#230 / PR #232(已并入 master)

- `parseCallText`:从首个 `{` 定位 JSON,保留前缀回写(修标签前缀形态)
- 字符串形态 `content`(非严格 provider 双重编码)解析 + **原形态回写**
- `serializeCompacted` / `rewriteCompressText` / `compactCompressText` 相应扩展
- 活锚点 >200 字符 summary 存根化、死范围条目过滤照旧

## 校验

- typecheck ✅
- 测试 629/629 ✅
- build ✅
- 真实风暴会话回放:单条 compress 调用文本 924→278 chars,字符串形态保留

## 下游

- billion-context PR #659(bump pin,draft 待本版上线)
- billion-context-pi issue #340(出口同步,待 pin bump)

合并后 CI 自动发布 npm,请等待 `npm view acp-kernel version` = 0.0.60 再转正下游 PR。