### PR TITLE
release v0.0.61

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.60",
+    "version": "0.0.61",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.60",
+            "version": "0.0.61",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.60",
+    "version": "0.0.61",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
## 发版内容(自 v0.0.60)

- #238 `fix: usage-gate count-triggered tier nudges`(fixes #237:计数型 T2/T3 蒸馏 nudge 在 usage < 45% 时不注入,低使用率不再空烧模型轮次;token 质量路径不受影响)

## 校验

- tests 631 pass ✅ / build ✅

## 后续

合并 + CI 发布后, billion-context 下一版(0.1.97)pin 0.0.61。