### PR TITLE
feat: CoreMessage.thinkingTokens — meter host-projected thinking payload

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -3,7 +3,7 @@ import { prune, isSummaryMessageId } from "./prune.js";
 import { syncBlocks } from "./sync.js";
 import { advanceSurvival, activeBlocks, blockById } from "./state.js";
 import { allocateBlockId, allocateRunId, createInitialState } from "./state.js";
-import { defaultCountTokens } from "./tokenize.js";
+import { countMessageTokens, defaultCountTokens } from "./tokenize.js";
 import { validateConfig } from "./config.js";
 import {
   BoundaryNotFoundError,
@@ -862,7 +862,9 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
   let compressedTokens = 0;
   for (const id of filteredIds) {
     const message = input.messages.find((entry) => entry.id === id);
-    compressedTokens += input.countTokens(message?.text ?? "");
+    compressedTokens += message
+      ? countMessageTokens(message, input.countTokens)
+      : 0;
   }
   for (const consumedId of consumedBlockIds) {
     const consumed = blockById(input.state, consumedId);
@@ -1407,7 +1409,7 @@ function computeContextBreakdown(
     code = 0,
     text = 0;
   for (const msg of messages) {
-    const tokens = count(msg.text ?? "");
+    const tokens = countMessageTokens(msg, count);
     if (msg.text?.startsWith("[Compressed conversation section]")) {
       summaries += tokens;
     } else if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export {
   defaultCountTokens,
   estimateTokensFast,
   createBpeTokenizer,
+  countMessageTokens,
 } from "./tokenize.js";
 export type { TokenCountFn } from "./tokenize.js";
 export { renderNudgeText, formatRanges } from "./nudge-text.js";

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -25,6 +25,7 @@ import {
   isMessageProtectedWithPairing,
   isNeverPreserveRecent,
 } from "./protected.js";
+import { countMessageTokens } from "./tokenize.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -84,7 +85,7 @@ export function computeProtectedRefs(
     if (isNeverPreserveRecent(msg)) continue;
     const ref = state.messageRefs.byRaw[msg.id];
     if (!ref || ref === "BLOCKED") continue;
-    visible.push({ ref, tokens: countTokens(msg.text ?? "") });
+    visible.push({ ref, tokens: countMessageTokens(msg, countTokens) });
   }
 
   // Rule 1: last N messages
@@ -188,7 +189,7 @@ export function buildCompressibleRanges(
       protectedMsgs.push({
         ref,
         gapBefore: skipSinceProtected,
-        tokens: countTokens(msg.text ?? ""),
+        tokens: countMessageTokens(msg, countTokens),
         tools: msg.toolName ? [msg.toolName] : [],
       });
       skipSinceProtected = false;
@@ -205,7 +206,7 @@ export function buildCompressibleRanges(
     compressibleMsgs.push({
       ref,
       gapBefore: skipSinceCompressible,
-      tokens: countTokens(msg.text ?? ""),
+      tokens: countMessageTokens(msg, countTokens),
       chars: (msg.text ?? "").length,
       isTool: isToolMessage(msg),
       isUser: msg.role === "user",

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -72,9 +72,17 @@ function renderMessage(
 
   // Snapshot mode: token count is fixed at first render (stable prefix cache).
   // Live mode (snapshot = null): recompute every render — legacy behavior.
-  const tokens = snapshot
+  // The tag carries the metered total (text + host-projected thinking), so the
+  // size the model sees per message matches block/range/breakdown accounting.
+  const textTokens = snapshot
     ? (snapshot[ref] ?? (snapshot[ref] = countTokens(cleanText)))
     : countTokens(cleanText);
+  const thinking = message.thinkingTokens;
+  const tokens =
+    textTokens +
+    (typeof thinking === "number" && Number.isFinite(thinking) && thinking > 0
+      ? thinking
+      : 0);
   const type = classifyType(message);
   const prefix = acpTag(ref, tokens, type) + "\n";
 

--- a/src/render-refs.ts
+++ b/src/render-refs.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage, CompressionState, MessageRefMap } from "./types.js";
 import { refForRaw, BLOCKED_REF } from "./refs.js";
+import { thinkingTokenValue } from "./tokenize.js";
 import type { PipelineNode, PipelineContext, NodeIO } from "./pipeline.js";
 
 /**
@@ -77,12 +78,7 @@ function renderMessage(
   const textTokens = snapshot
     ? (snapshot[ref] ?? (snapshot[ref] = countTokens(cleanText)))
     : countTokens(cleanText);
-  const thinking = message.thinkingTokens;
-  const tokens =
-    textTokens +
-    (typeof thinking === "number" && Number.isFinite(thinking) && thinking > 0
-      ? thinking
-      : 0);
+  const tokens = textTokens + thinkingTokenValue(message.thinkingTokens);
   const type = classifyType(message);
   const prefix = acpTag(ref, tokens, type) + "\n";
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,5 +1,6 @@
 import { refForRaw } from "./refs.js";
 import { isToolMessage } from "./recommend.js";
+import { countMessageTokens } from "./tokenize.js";
 import type { CompressionBlock, CompressionState, CoreMessage } from "./types.js";
 
 function formatTokens(n: number): string {
@@ -93,7 +94,7 @@ function collectVisible(
         if (coveredIds.has(message.id)) return;
         const ref = refForRaw(state.messageRefs, message.id);
         if (!ref) return;
-        const tokens = countTokens(message.text ?? "");
+        const tokens = countMessageTokens(message, countTokens);
         const tool = isToolMessage(message)
             ? message.toolName ?? (message.toolCallId ? toolCallNames.get(message.toolCallId) : undefined) ?? "tool"
             : "text";

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -16,6 +16,22 @@ export function estimateMessageTokens(text: string | undefined): number {
   return defaultCountTokens(text ?? "");
 }
 
+/** Total metered size of a core message: visible text plus any host-projected
+ *  thinking payload (CoreMessage.thinkingTokens). Every per-message counting
+ *  site (range recommendations, block compressedTokens, status reports, context
+ *  breakdown) goes through this so all surfaces share one caliber. */
+export function countMessageTokens(
+  message: { text?: string; thinkingTokens?: number },
+  countTokens: TokenCountFn = defaultCountTokens,
+): number {
+  const thinking = message.thinkingTokens;
+  const thinkingPart =
+    typeof thinking === "number" && Number.isFinite(thinking) && thinking > 0
+      ? thinking
+      : 0;
+  return countTokens(message.text ?? "") + thinkingPart;
+}
+
 export function estimateTokensFast(text: string): number {
   if (!text) return 0;
   return Math.ceil(text.length / 4);

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -16,6 +16,17 @@ export function estimateMessageTokens(text: string | undefined): number {
   return defaultCountTokens(text ?? "");
 }
 
+/** Guarded contribution of a host-projected thinking payload to the metered
+ *  message size. Non-finite or non-positive values are treated as absent (0),
+ *  so a bad host value can never poison the accounting. */
+export function thinkingTokenValue(thinking: number | undefined): number {
+  return typeof thinking === "number" &&
+    Number.isFinite(thinking) &&
+    thinking > 0
+    ? thinking
+    : 0;
+}
+
 /** Total metered size of a core message: visible text plus any host-projected
  *  thinking payload (CoreMessage.thinkingTokens). Every per-message counting
  *  site (range recommendations, block compressedTokens, status reports, context
@@ -24,12 +35,9 @@ export function countMessageTokens(
   message: { text?: string; thinkingTokens?: number },
   countTokens: TokenCountFn = defaultCountTokens,
 ): number {
-  const thinking = message.thinkingTokens;
-  const thinkingPart =
-    typeof thinking === "number" && Number.isFinite(thinking) && thinking > 0
-      ? thinking
-      : 0;
-  return countTokens(message.text ?? "") + thinkingPart;
+  return (
+    countTokens(message.text ?? "") + thinkingTokenValue(message.thinkingTokens)
+  );
 }
 
 export function estimateTokensFast(text: string): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,14 @@ export interface CoreMessage {
   text?: string;
   toolName?: string;
   toolCallId?: string;
+  /** Host-projected token count of the reasoning/thinking payload that rides
+   *  along with this message every request but is NOT part of `text` (e.g. Pi's
+   *  `{type:"thinking"}` parts, which are resent each turn but invisible in the
+   *  visible text projection). Metering-only: never rendered, truncated, or
+   *  indexed. The host MUST attach it to exactly one core per original message
+   *  (e.g. the first emitted core) — split tool-call cores sharing a base id
+   *  must not repeat it or totals are multiplied. */
+  thinkingTokens?: number;
 }
 
 export type CompressionTier = 1 | 2 | 3;

--- a/tests/thinking-tokens.test.ts
+++ b/tests/thinking-tokens.test.ts
@@ -186,3 +186,18 @@ test("buildCompressibleRanges totals include projected thinking", () => {
     defaultCountTokens("alpha beta") + defaultCountTokens("gamma delta") + 4321,
   );
 });
+
+test("ref tag ignores missing or invalid thinking payloads", () => {
+  const state = createInitialState();
+  const messages = [msg("a", "some visible text", "assistant", Number.NaN)];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const rendered = renderVisibleRefs(messages, state, defaultCountTokens);
+  const out = rendered[0]!;
+  const match = /tokens="(\d+)"/.exec(out.text ?? "");
+  assert.ok(match, "ref tag with tokens attribute expected");
+  assert.equal(Number(match![1]), defaultCountTokens("some visible text"));
+});

--- a/tests/thinking-tokens.test.ts
+++ b/tests/thinking-tokens.test.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs } from "../src/refs.js";
+import { countMessageTokens, defaultCountTokens } from "../src/tokenize.js";
+import {
+  buildCompressibleRanges,
+  computeProtectedRefs,
+} from "../src/recommend.js";
+import { renderVisibleRefs } from "../src/render-refs.js";
+import type { Config, CoreMessage } from "../src/types.js";
+
+function msg(
+  id: string,
+  text: string,
+  role: CoreMessage["role"] = "user",
+  thinkingTokens?: number,
+): CoreMessage {
+  return {
+    id,
+    role,
+    contentType: "text",
+    text,
+    ...(thinkingTokens !== undefined ? { thinkingTokens } : {}),
+  };
+}
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+      growthFloor: 6000,
+      growthCap: 50000,
+      minGrowthFloor: 5000,
+      minGrowthRatio: 0.45,
+      emergencyThresholdPct: 0.98,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    merge: { maxSummaryLength: 3000, minOldGenBlocks: 3 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+    ...overrides,
+  };
+}
+
+test("countMessageTokens sums visible text and projected thinking", () => {
+  const text = "hello world";
+  assert.equal(countMessageTokens({ text }), defaultCountTokens(text));
+  assert.equal(countMessageTokens({}), 0);
+  assert.equal(
+    countMessageTokens({ text, thinkingTokens: 500 }),
+    defaultCountTokens(text) + 500,
+  );
+});
+
+test("countMessageTokens ignores missing or invalid thinking payloads", () => {
+  const text = "hello world";
+  const base = defaultCountTokens(text);
+  assert.equal(countMessageTokens({ text, thinkingTokens: undefined }), base);
+  assert.equal(countMessageTokens({ text, thinkingTokens: NaN }), base);
+  assert.equal(countMessageTokens({ text, thinkingTokens: -5 }), base);
+  assert.equal(
+    countMessageTokens({ text, thinkingTokens: Number.POSITIVE_INFINITY }),
+    base,
+  );
+  assert.equal(countMessageTokens({ text, thinkingTokens: 0 }), base);
+});
+
+test("processTurn preserves thinkingTokens on surviving messages", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "first user line"),
+    msg("b", "assistant reply", "assistant", 777),
+    msg("c", "second user line"),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const turn = core.processTurn({
+    messages,
+    state,
+    config: config(),
+    tokenCount: 1000,
+  });
+  const out = turn.messages.find((m) => m.id === "b");
+  assert.ok(out, "message b must survive the pipeline");
+  assert.equal(out!.thinkingTokens, 777);
+});
+
+test("ref tag token attribute carries the metered total including thinking", () => {
+  const state = createInitialState();
+  const messages = [msg("a", "some visible text", "assistant", 500)];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const rendered = renderVisibleRefs(messages, state, defaultCountTokens);
+  const out = rendered[0]!;
+  const match = /tokens="(\d+)"/.exec(out.text ?? "");
+  assert.ok(match, "ref tag with tokens attribute expected");
+  assert.equal(
+    Number(match![1]),
+    defaultCountTokens("some visible text") + 500,
+  );
+});
+
+test("applyCompression records projected thinking in block compressedTokens", () => {
+  const core = createCore();
+  const state = createInitialState();
+  const messages = [
+    msg("a", "alpha beta", "user"),
+    msg("b", "gamma delta", "assistant", 4321),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const result = core.applyCompression({
+    ranges: [
+      {
+        startRef: "m00001",
+        endRef: "m00002",
+        summary: "both summarized",
+        topic: "t",
+      },
+    ],
+    messages,
+    state,
+    config: config(),
+  });
+  assert.equal(result.result.errors.length, 0);
+  const block = result.state.blocks[0]!;
+  assert.equal(
+    block.compressedTokens,
+    defaultCountTokens("alpha beta") + defaultCountTokens("gamma delta") + 4321,
+  );
+});
+
+test("buildCompressibleRanges totals include projected thinking", () => {
+  const state = createInitialState();
+  const messages = [
+    msg("a", "alpha beta", "user"),
+    msg("b", "gamma delta", "assistant", 4321),
+  ];
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+
+  const cfg = config();
+  const ranges = buildCompressibleRanges(
+    messages,
+    state,
+    cfg,
+    computeProtectedRefs(messages, state, cfg),
+  );
+  assert.ok(
+    ranges.compressible.length > 0,
+    "expected at least one compressible range",
+  );
+  const charsTotal = ranges.compressible.reduce((s, r) => s + r.chars, 0);
+  assert.equal(
+    charsTotal,
+    "alpha beta".length + "gamma delta".length,
+    "chars must stay text-only",
+  );
+  const total = ranges.compressible.reduce((s, r) => s + r.tokens, 0);
+  assert.equal(
+    total,
+    defaultCountTokens("alpha beta") + defaultCountTokens("gamma delta") + 4321,
+  );
+});


### PR DESCRIPTION
<!-- ework-agent-pr -->
Fixes #241

Reasoning-model hosts resend thinking blocks every turn, but thinking is not part of the visible text projection — so every per-message counting site undercounted by exactly the cumulative thinking volume. With reliable usage reporting the realUsage floor masks this; without it (usage-less relays/providers) estimates run systematically low and nudge/emergency compression bands trigger late → upstream context overflow risk.

## Changes

- `CoreMessage.thinkingTokens?: number` (src/types.ts) — **metering-only**: never rendered, truncated, or indexed. Host contract: attach to exactly one core per original message (split tool-call cores must not repeat it or totals multiply).
- `countMessageTokens(message, countTokens)` in src/tokenize.ts — single counting caliber: text + guarded positive-finite thinking; exported from index.ts.
- All per-message counting sites switched to the caliber:
  - src/compress.ts — applyCompression `compressedTokens`; computeContextBreakdown
  - src/recommend.ts — computeProtectedRefs visible tokens; buildCompressibleRanges protected/compressible tokens (`chars` stays text-length: the truncation gate counts truncatable payload)
  - src/report.ts — collectVisible
  - src/render-refs.ts — ref-tag `tokens` attribute (what the model sees per message now matches block/range/breakdown accounting)

## Compatibility

Non-breaking: field is optional; hosts that never set it behave exactly as before.

## Verification

typecheck ✓ / 637 tests ✓ (incl. new tests/thinking-tokens.test.ts, 6 tests) / build ✓