### PR TITLE
release v0.0.62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.61",
+    "version": "0.0.62",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.61",
+            "version": "0.0.62",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.61",
+    "version": "0.0.62",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Release v0.0.62 — ships CoreMessage.thinkingTokens + countMessageTokens unified metering (#241 / PR #242): every per-message counting site (range recommendations, block compressedTokens, context breakdown, status report, ref-tag tokens attribute) now includes the host-projected thinking payload. Truncation gates keep the pure-text chars caliber. Optional field — hosts that do not attach it see zero behavior change.