### PR TITLE
fix(#684): turns are atomic — reasoning run, assistant burst, and paired results fold together or not at all

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -21,6 +21,7 @@ import type { RenderStrategy } from "./render-refs.js";
 import { isMessageProtected } from "./protected.js";
 import { adjustBoundariesForToolPairs } from "./tool-pairs.js";
 import { adjustBoundariesForReasoningPairs } from "./reasoning-pairs.js";
+import { computeTurnGroups } from "./turn-integrity.js";
 import {
   computeProtectedRefs,
   buildCompressibleRanges,
@@ -833,6 +834,40 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
         ", ",
       )} from compression range (recent/last-user zone).`,
     );
+  }
+
+  // TURN-INTEGRITY GATE (#684): the protected carve above (and the protected
+  // tool filter before it) remove individual messages AFTER
+  // applyPairBoundaryAdjustments completed the range, which can split a turn:
+  // the recent-zone carve kept one tool-call of a multi-call turn alive while
+  // its reasoning run and sibling call folded into the block, and the rebuilt
+  // request shipped an assistant tool_calls message without reasoning_content
+  // — DeepSeek thinking mode rejects it with 400 ("reasoning_content ... must
+  // be passed back"). A turn is atomic: if any member survives, every member
+  // survives. Withdraw split turns from the compression set entirely.
+  {
+    const splitTurnIds = new Set<string>();
+    let splitTurnCount = 0;
+    for (const group of computeTurnGroups(input.messages)) {
+      const inFold = group.filter((id) => effectiveMessageIds.has(id));
+      if (inFold.length > 0 && inFold.length < group.length) {
+        splitTurnCount++;
+        for (const id of group) splitTurnIds.add(id);
+      }
+    }
+    if (splitTurnIds.size > 0) {
+      for (const id of splitTurnIds) effectiveMessageIds.delete(id);
+      const beforeWithdraw = filteredIds.length;
+      filteredIds = filteredIds.filter((id) => !splitTurnIds.has(id));
+      if (filteredIds.length === 0 && consumedBlockIds.length === 0) {
+        throw new Error(
+          `Range would split ${splitTurnCount} turn(s) at the protected-zone boundary: part of each turn must stay visible, so none of it can fold (reasoning and tool-calls are atomic — providers reject a half turn). Shrink the range to end before the turn starts, or wait until the whole turn ages out of the protected zone.`,
+        );
+      }
+      warnings.push(
+        `Withdrawn ${beforeWithdraw - filteredIds.length} message(s) from compression range to keep ${splitTurnCount} turn(s) atomic (reasoning/tool-call split at the protected boundary).`,
+      );
+    }
   }
 
   // Livelock guard (billion-context-pi#199): a message-ref range whose entire

--- a/src/reasoning-pairs.ts
+++ b/src/reasoning-pairs.ts
@@ -57,10 +57,22 @@ export function adjustBoundariesForReasoningPairs(
         companion !== undefined &&
         companion.role === "assistant" &&
         (companion.contentType === "text" ||
-          companion.contentType === "tool-call") &&
-        j + 1 > newEndIndex
+          companion.contentType === "tool-call")
       ) {
-        newEndIndex = j + 1;
+        // Pull the WHOLE assistant burst following the reasoning run, not just
+        // the first companion (#684): a turn may carry several tool-calls, and
+        // pulling one leaves its siblings outside the range. The composed
+        // fixpoint's tool-pair pass then widens for every result.
+        let e = j + 1;
+        while (
+          e + 1 < messages.length &&
+          messages[e + 1]!.role === "assistant" &&
+          (messages[e + 1]!.contentType === "text" ||
+            messages[e + 1]!.contentType === "tool-call")
+        ) {
+          e++;
+        }
+        if (e > newEndIndex) newEndIndex = e;
       }
     }
 

--- a/src/turn-integrity.ts
+++ b/src/turn-integrity.ts
@@ -1,0 +1,105 @@
+import type { CoreMessage } from "./types.js";
+
+function isAssistantAct(msg: CoreMessage): boolean {
+  return (
+    msg.role === "assistant" &&
+    (msg.contentType === "text" || msg.contentType === "tool-call")
+  );
+}
+
+/**
+ * Atomic turn groups for compression integrity (#684).
+ *
+ * A turn is a reasoning run, the assistant text/tool-call burst that follows
+ * it, and every tool-result paired (by toolCallId) to the burst's calls.
+ * Strict-echo thinking providers (DeepSeek: "The `reasoning_content` in the
+ * thinking mode must be passed back to the API") reject a rebuilt request
+ * whose assistant tool-call turn survives without its reasoning, and every
+ * OpenAI-wire provider rejects a result whose call is gone. Turns are
+ * therefore atomic for folding: all members fold together, or none do.
+ *
+ * Grouping is adjacency-based, mirroring {@link adjustBoundariesForReasoningPairs}:
+ * a reasoning run pairs with the assistant burst immediately following it.
+ * Bursts without a preceding reasoning run still group with their sibling
+ * calls and results. Messages belonging to no turn (user messages, system,
+ * orphan reasoning, summaries) get no group — they carry no pairing
+ * constraint. Groups are disjoint.
+ *
+ * @returns disjoint member-id arrays; a message appears in at most one group.
+ */
+export function computeTurnGroups(messages: CoreMessage[]): string[][] {
+  const resultIdByCallId = new Map<string, string>();
+  for (const msg of messages) {
+    if (
+      msg.contentType === "tool-result" &&
+      typeof msg.toolCallId === "string" &&
+      msg.id
+    ) {
+      if (!resultIdByCallId.has(msg.toolCallId))
+        resultIdByCallId.set(msg.toolCallId, msg.id);
+    }
+  }
+
+  const grouped = new Set<string>();
+  const groups: string[][] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
+    if (!msg.id || grouped.has(msg.id)) continue;
+    if (!(msg.contentType === "reasoning" || isAssistantAct(msg))) continue;
+
+    let reasoningStart = i;
+    if (msg.contentType === "reasoning") {
+      while (
+        reasoningStart > 0 &&
+        messages[reasoningStart - 1]!.contentType === "reasoning"
+      ) {
+        reasoningStart--;
+      }
+    } else {
+      let s = i;
+      while (s > 0 && isAssistantAct(messages[s - 1]!)) s--;
+      reasoningStart = s;
+      while (
+        reasoningStart > 0 &&
+        messages[reasoningStart - 1]!.contentType === "reasoning"
+      ) {
+        reasoningStart--;
+      }
+    }
+    const burstStart = (() => {
+      let s = reasoningStart;
+      while (s < messages.length && messages[s]!.contentType === "reasoning")
+        s++;
+      return s;
+    })();
+    if (burstStart >= messages.length || !isAssistantAct(messages[burstStart]!)) {
+      // Orphan reasoning run (no companion burst): no pairing constraint.
+      continue;
+    }
+    let burstEnd = burstStart;
+    while (
+      burstEnd + 1 < messages.length &&
+      isAssistantAct(messages[burstEnd + 1]!)
+    ) {
+      burstEnd++;
+    }
+
+    const members = new Set<string>();
+    for (let k = reasoningStart; k <= burstEnd; k++) {
+      const m = messages[k]!;
+      if (!m.id) continue;
+      members.add(m.id);
+      if (
+        m.role === "assistant" &&
+        m.contentType === "tool-call" &&
+        typeof m.toolCallId === "string"
+      ) {
+        const rid = resultIdByCallId.get(m.toolCallId);
+        if (rid) members.add(rid);
+      }
+    }
+    for (const id of members) grouped.add(id);
+    groups.push([...members]);
+  }
+  return groups;
+}

--- a/tests/issue684-turn-integrity.test.ts
+++ b/tests/issue684-turn-integrity.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createCore } from "../src/compress.js";
+import { createInitialState } from "../src/state.js";
+import { defaultConfig } from "../src/config.js";
+import { computeTurnGroups } from "../src/turn-integrity.js";
+import { adjustBoundariesForReasoningPairs } from "../src/reasoning-pairs.js";
+import type { CoreMessage } from "../src/types.js";
+
+function user(id: string, text = "u"): CoreMessage {
+    return { id, role: "user", contentType: "text", text: `${text}-${id} ` + "x".repeat(200) };
+}
+function reasoning(id: string): CoreMessage {
+    return { id, role: "assistant", contentType: "reasoning", text: `think-${id} ` + "t".repeat(400) };
+}
+function toolCall(id: string, callId: string, toolName = "pwsh"): CoreMessage {
+    return { id, role: "assistant", contentType: "tool-call", toolName, toolCallId: callId, text: `call-${callId}` };
+}
+function toolResult(id: string, callId: string, toolName = "pwsh"): CoreMessage {
+    return { id, role: "user", contentType: "tool-result", toolName, toolCallId: callId, text: `result-${callId} ` + "r".repeat(200) };
+}
+
+function buildMessages(): CoreMessage[] {
+    return [
+        user("m00001"),
+        user("m00002"),
+        reasoning("m00003"),
+        toolCall("m00004", "call_00_x"),
+        toolCall("m00005", "call_01_x"),
+        toolResult("m00006", "call_00_x"),
+        toolResult("m00007", "call_01_x"),
+        user("m00008"),
+        user("m00009"),
+    ];
+}
+
+const config = (over: Record<string, unknown> = {}) => ({
+    ...defaultConfig(150000),
+    compress: { ...defaultConfig(150000).compress, minCompressRange: 1, minSummaryLength: 1, ...over },
+});
+
+describe("computeTurnGroups", () => {
+    it("groups reasoning + multi-call burst + all results as one atomic turn", () => {
+        const groups = computeTurnGroups(buildMessages());
+        const big = groups.find((g) => g.includes("m00003"))!;
+        assert.deepEqual(new Set(big), new Set(["m00003", "m00004", "m00005", "m00006", "m00007"]));
+    });
+
+    it("groups a no-reasoning burst with its results", () => {
+        const msgs = [user("m1"), toolCall("m2", "c1"), toolResult("m3", "c1"), user("m4")];
+        const groups = computeTurnGroups(msgs);
+        assert.deepEqual(groups, [["m2", "m3"]]);
+    });
+
+    it("leaves orphan reasoning ungrouped", () => {
+        const msgs = [user("m1"), reasoning("m2"), user("m3")];
+        assert.deepEqual(computeTurnGroups(msgs), []);
+    });
+});
+
+describe("adjustBoundariesForReasoningPairs (#684 whole-burst pull)", () => {
+    it("forward pull covers the entire multi-call burst, not just the first companion", () => {
+        const msgs = buildMessages();
+        const r = adjustBoundariesForReasoningPairs(0, 2, msgs);
+        assert.equal(r.endIndex, 4);
+    });
+});
+
+describe("#684 regression: protected carve must not split a turn", () => {
+    it("withdraws the whole turn when the carve keeps one call alive", () => {
+        const core = createCore();
+        let state = createInitialState();
+        const messages = buildMessages();
+        const out = core.processTurn({ messages, state, config: config(), tokenCount: (t) => Math.ceil(t.length / 4) });
+        state = out.state;
+        const refs = state.messageRefs.byRaw;
+        // recent-zone protection covers call_01 + its result (as in the snapshot)
+        const protectedRefs = new Set([refs["m00005"]!, refs["m00007"]!]);
+        const res = core.applyCompression({
+            state,
+            messages,
+            config: config(),
+            protectedMessageIds: protectedRefs,
+            ranges: [{ startRef: "m00001", endRef: "m00007", summary: "s".repeat(400) }],
+        });
+        const block = res.state.blocks.find((b) => b.active);
+        assert.ok(block, "block created for the non-split part");
+        for (const id of ["m00003", "m00004", "m00005", "m00006", "m00007"]) {
+            assert.ok(!block.effectiveMessageIds.includes(id), `${id} must not fold (turn split by protected zone)`);
+        }
+        assert.ok(res.result.warnings.some((w) => /turn/.test(w)), JSON.stringify(res.result.warnings));
+        // the surviving view keeps the WHOLE turn visible: reasoning + both calls + results
+        const view = core.processTurn({ messages, state: res.state, config: config(), tokenCount: (t) => Math.ceil(t.length / 4) });
+        const visibleIds = new Set(view.messages.map((m) => (m as { id?: string }).id).filter(Boolean));
+        for (const id of ["m00003", "m00004", "m00005", "m00006", "m00007"]) {
+            assert.ok(visibleIds.has(id), `${id} must stay visible`);
+        }
+    });
+
+    it("fails with a clear error when the range is exactly the split turn", () => {
+        const core = createCore();
+        let state = createInitialState();
+        const messages = buildMessages();
+        const out = core.processTurn({ messages, state, config: config(), tokenCount: (t) => Math.ceil(t.length / 4) });
+        state = out.state;
+        const refs = state.messageRefs.byRaw;
+        const res = core.applyCompression({
+            state,
+            messages,
+            config: config(),
+            protectedMessageIds: new Set([refs["m00005"]!, refs["m00007"]!]),
+            ranges: [{ startRef: "m00003", endRef: "m00007", summary: "s".repeat(400) }],
+        });
+        assert.equal(res.result.blocksCreated, 0);
+        assert.equal(res.result.errors.length, 1);
+        assert.match(res.result.errors[0]!, /split 1 turn/);
+    });
+});

--- a/tests/tool-pairs.test.ts
+++ b/tests/tool-pairs.test.ts
@@ -311,7 +311,12 @@ describe("prune stripOrphanedToolCalls (defense-in-depth)", () => {
     assert.ok(!ids.includes("m5"), "compressed tool-result m5 removed");
   });
 
-  it("orphaned tool-result stripped when its call is compressed beyond maxScan", () => {
+  it("orphaned tool-result stripped when its call sits in a pre-gate block (defense-in-depth)", () => {
+    // Since the #684 turn-integrity gate, applyCompression can no longer
+    // create this orphan itself (a turn folds atomically or not at all). The
+    // prune-side strip remains defense-in-depth for states persisted by older
+    // builds and for block-boundary rewrites — so construct the split state
+    // directly: a block whose coverage contains only the tool-call.
     const core = createCore();
     const messages: CoreMessage[] = [
       toolCall("m1", "c1"),
@@ -323,29 +328,34 @@ describe("prune stripOrphanedToolCalls (defense-in-depth)", () => {
 
     const state = createInitialState();
     const stateWithRefs = core.processTurn({ messages, state, config: cfg, tokenCount: 5000 }).state;
+    const refOf = (raw: string) => stateWithRefs.messageRefs.byRaw[raw]!;
 
-    const result = core.applyCompression({
-      ranges: [{
-        startRef: "m00001",
-        endRef: "m00001",
-        summary: "Compress just the tool-call. Result is >20 messages away so extension can't reach it.",
-      }],
-      messages,
-      state: stateWithRefs,
-      config: cfg,
+    stateWithRefs.blocks.push({
+      blockId: "b1",
+      runId: "run1",
+      tier: 1,
+      summary: "Legacy split block covering only the call (pre-#684 state).",
+      directMessageIds: ["m1"],
+      effectiveMessageIds: ["m1"],
+      directBlockIds: [],
+      compressedTokens: 10,
+      createdAt: Date.now(),
+      survivedCount: 0,
+      generation: "young",
+      active: true,
+      startRef: refOf("m1"),
+      endRef: refOf("m1"),
     });
-
-    assert.equal(result.result.blocksCreated, 1);
 
     const pruned = core.processTurn({
       messages,
-      state: result.state,
+      state: stateWithRefs,
       config: cfg,
       tokenCount: 4000,
     }).messages;
 
     const ids = pruned.map((m) => m.id);
-    assert.ok(!ids.includes("m1"), "compressed tool-call m1 removed");
+    assert.ok(!ids.includes("m1"), "blocked tool-call m1 hidden");
     assert.ok(!ids.includes("result"), "orphaned tool-result stripped by defense-in-depth");
   });
 });


### PR DESCRIPTION
Fixes #244. Twin of the kernel-side half-turn bug reported as billion-context #684 (DeepSeek thinking-mode 400 `reasoning_content must be passed back` after a compress fold).

## Root cause
`applyPairBoundaryAdjustments` forward-pulled only the FIRST companion message after a reasoning run; the recent-zone carve could then keep a sibling tool-call visible while its reasoning folded — assistant tool_calls without reasoning_content → strict-echo upstreams reject the whole request.

## Fix
- **`src/turn-integrity.ts`** `computeTurnGroups()`: atomic turn groups (reasoning run + full assistant burst + all results paired by toolCallId), disjoint, orphans ungrouped.
- **`src/compress.ts`**: post-carve gate withdraws any split turn entirely (warning); a nothing-but-split-turns range fails with an explanatory error.
- **`src/reasoning-pairs.ts`**: forward pull covers the whole burst.

## Tests
`tests/issue684-turn-integrity.test.ts` (grouping / whole-burst pull / carve-split withdrawal + visibility / whole-range rejection); tool-pairs maxScan case rewritten as prune-side defense-in-depth. **644/644 green.**

Merge is human-only (AGENTS.md §4). Proxy-side twin: ranxianglei/billion-context#689.