### PR TITLE
fix(#684): turn gate is directional — fold call+result / keep reasoning+text stays legal

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -838,34 +838,47 @@ function applySingleRange(input: SingleRangeInput): SingleRangeOutcome {
 
   // TURN-INTEGRITY GATE (#684): the protected carve above (and the protected
   // tool filter before it) remove individual messages AFTER
-  // applyPairBoundaryAdjustments completed the range, which can split a turn:
-  // the recent-zone carve kept one tool-call of a multi-call turn alive while
-  // its reasoning run and sibling call folded into the block, and the rebuilt
-  // request shipped an assistant tool_calls message without reasoning_content
-  // — DeepSeek thinking mode rejects it with 400 ("reasoning_content ... must
-  // be passed back"). A turn is atomic: if any member survives, every member
-  // survives. Withdraw split turns from the compression set entirely.
+  // applyPairBoundaryAdjustments completed the range, which can split a turn.
+  // The DIRECTIONAL invariant that strict-echo providers enforce: an assistant
+  // tool-call message that survives the fold must keep its reasoning run
+  // (DeepSeek thinking mode: "reasoning_content ... must be passed back").
+  // The reverse split — reasoning + text kept while the call and result fold —
+  // leaves a valid message stream and stays allowed (#564 depends on it), so
+  // only turns whose KEPT side carries a tool-call while the FOLDED side
+  // carries the reasoning are withdrawn, entirely (all members stay visible).
   {
-    const splitTurnIds = new Set<string>();
+    const reasoningIds = new Set<string>();
+    const callIds = new Set<string>();
+    for (const m of input.messages) {
+      if (!m.id) continue;
+      if (m.contentType === "reasoning") reasoningIds.add(m.id);
+      if (m.role === "assistant" && m.contentType === "tool-call") callIds.add(m.id);
+    }
+    const withdrawIds = new Set<string>();
     let splitTurnCount = 0;
     for (const group of computeTurnGroups(input.messages)) {
-      const inFold = group.filter((id) => effectiveMessageIds.has(id));
-      if (inFold.length > 0 && inFold.length < group.length) {
-        splitTurnCount++;
-        for (const id of group) splitTurnIds.add(id);
-      }
+      const foldHasReasoning = group.some(
+        (id) => effectiveMessageIds.has(id) && reasoningIds.has(id),
+      );
+      if (!foldHasReasoning) continue;
+      const keptHasCall = group.some(
+        (id) => !effectiveMessageIds.has(id) && callIds.has(id),
+      );
+      if (!keptHasCall) continue;
+      splitTurnCount++;
+      for (const id of group) withdrawIds.add(id);
     }
-    if (splitTurnIds.size > 0) {
-      for (const id of splitTurnIds) effectiveMessageIds.delete(id);
+    if (withdrawIds.size > 0) {
+      for (const id of withdrawIds) effectiveMessageIds.delete(id);
       const beforeWithdraw = filteredIds.length;
-      filteredIds = filteredIds.filter((id) => !splitTurnIds.has(id));
+      filteredIds = filteredIds.filter((id) => !withdrawIds.has(id));
       if (filteredIds.length === 0 && consumedBlockIds.length === 0) {
         throw new Error(
-          `Range would split ${splitTurnCount} turn(s) at the protected-zone boundary: part of each turn must stay visible, so none of it can fold (reasoning and tool-calls are atomic — providers reject a half turn). Shrink the range to end before the turn starts, or wait until the whole turn ages out of the protected zone.`,
+          `Range would split ${splitTurnCount} turn(s) at the protected-zone boundary: a visible tool-call must keep its reasoning run (strict-echo providers reject a rebuilt request that lost it). Shrink the range to end before the turn starts, or wait until the whole turn ages out of the protected zone.`,
         );
       }
       warnings.push(
-        `Withdrawn ${beforeWithdraw - filteredIds.length} message(s) from compression range to keep ${splitTurnCount} turn(s) atomic (reasoning/tool-call split at the protected boundary).`,
+        `Withdrawn ${beforeWithdraw - filteredIds.length} message(s) from compression range to keep ${splitTurnCount} turn(s) intact (visible tool-call would lose its reasoning run).`,
       );
     }
   }

--- a/tests/issue684-turn-integrity.test.ts
+++ b/tests/issue684-turn-integrity.test.ts
@@ -115,4 +115,32 @@ describe("#684 regression: protected carve must not split a turn", () => {
         assert.equal(res.result.errors.length, 1);
         assert.match(res.result.errors[0]!, /split 1 turn/);
     });
+
+    it("#564 shape stays allowed: fold call+result, keep reasoning+text (directional)", () => {
+        const core = createCore();
+        const state = createInitialState();
+        const messages: CoreMessage[] = [
+            user("m1"),
+            reasoning("m2"),
+            { id: "m3", role: "assistant", contentType: "text", text: "TEXT-A " + "x".repeat(200) },
+            toolCall("m4", "ca"),
+            toolResult("m5", "ca"),
+            user("m6"),
+            user("m7"),
+        ];
+        const out = core.processTurn({ messages, state, config: config(), tokenCount: (t) => Math.ceil(t.length / 4) });
+        const res = core.applyCompression({
+            state: out.state,
+            messages,
+            config: config(),
+            protectedMessageIds: new Set(),
+            ranges: [{ startRef: "m00004", endRef: "m00005", summary: "s".repeat(400) }],
+        });
+        assert.equal(res.result.blocksCreated, 1, `call+result must fold; errors=${JSON.stringify(res.result.errors)}`);
+        const block = res.state.blocks.find((b) => b.active);
+        assert.ok(block);
+        assert.ok(block.effectiveMessageIds.includes("m4"));
+        assert.ok(block.effectiveMessageIds.includes("m5"));
+        assert.ok(!res.result.warnings.some((w) => /turn/.test(w)), JSON.stringify(res.result.warnings));
+    });
 });


### PR DESCRIPTION
Follow-up to #245 (same issue #244), caught by billion-context's suite during local pre-validation: the all-or-nothing withdrawal was too strong — it rejected the #564 fold shape (tool-call + result fold, reasoning + assistant text stay visible), which leaves a valid stream and the proxy depends on it.

The provider invariant is directional: an assistant tool\_calls message that SURVIVES must carry its reasoning\_content. So a turn is withdrawn only when its kept side has a tool-call and its folded side has the reasoning run.

- `src/compress.ts`: gate condition now uses reasoningIds/callIds membership (fold∩reasoning ≠ ∅ ∧ kept∩calls ≠ ∅), error/warning reworded accordingly.
- `tests/issue684-turn-integrity.test.ts`: new #564-shape case (no withdrawal, no warning, block created). 645/645.

Release branch `2026-09-11_release-v0.0.63` (#246) will be rebased onto this so v0.0.63 ships both. Merge is human-only.