### PR TITLE
feat: StateStore optional record codec (compress/encrypt at rest)

### DIFF
--- a/src/persist/index.ts
+++ b/src/persist/index.ts
@@ -14,5 +14,5 @@
  * - the store never deletes files; cleanup is a downstream decision
  */
 export { StateStore, flatFileNameFor } from "./store.js";
-export type { PersistedEnvelope, PersistLogger, StateStoreOptions } from "./store.js";
+export type { PersistedEnvelope, PersistLogger, StateStoreCodec, StateStoreOptions } from "./store.js";
 export { mergeCompressionState } from "./state-merge.js";

--- a/src/persist/store.ts
+++ b/src/persist/store.ts
@@ -27,6 +27,21 @@ export interface LegacyAdoption<T> {
     savedAt?: number;
 }
 
+/**
+ * Optional record codec: transforms serialized envelopes between the store
+ * and disk (e.g. compress and/or encrypt at rest). The store is
+ * codec-agnostic — it hands `encode` the exact JSON string it would have
+ * written and passes raw file bytes to `decode`, which must return that same
+ * JSON string or throw, in which case the file is treated as corrupt
+ * (skipped + logged) like any unreadable record. Format detection (magic
+ * bytes, plaintext fallback for unencoded legacy files) is the codec's job,
+ * so mixed trees of legacy plaintext and encoded files load fine.
+ */
+export interface StateStoreCodec {
+    encode(data: string): Buffer | string;
+    decode(buf: Buffer): string;
+}
+
 export interface StateStoreOptions<T> {
     /**
      * Storage root. The kernel deliberately has NO default location: the
@@ -75,6 +90,11 @@ export interface StateStoreOptions<T> {
      */
     validate?: (envelope: PersistedEnvelope<T>) => boolean;
     /**
+     * Optional codec applied around every write (canonical + spill) and
+     * read. See StateStoreCodec. Default: none — files are plain UTF-8 JSON.
+     */
+    codec?: StateStoreCodec;
+    /**
      * Transient-write retry policy (Windows + hostile temp environments).
      * The whole write cycle — mkdir, temp write, rename — is retried with
      * exponential backoff when it fails with a TRANSIENT code: EPERM/EBUSY/
@@ -109,6 +129,8 @@ export interface StateStoreOptions<T> {
  *   temp-file names or reorders writes
  * - debounced scheduleSave coalesces bursts into one write; the record is
  *   built at WRITE time from a builder, so late mutations are picked up
+ * - optional record codec (compress/encrypt at rest): encode on every write,
+ *   decode on every read; a decode failure is corrupt-file semantics
  * - loadAll skips `.tmp-*` orphans, corrupt JSON, and records whose
  *   filename does not match their id — one bad file never blocks boot; it
  *   reconciles a canonical record against its spill by savedAt (freshest wins)
@@ -127,6 +149,7 @@ export class StateStore<T> {
     private readonly legacyFn?: (parsed: unknown) => LegacyAdoption<T> | null;
     private readonly relPathFn?: (id: string, payload: T) => string;
     private readonly validateFn: (envelope: PersistedEnvelope<T>) => boolean;
+    private readonly codec?: StateStoreCodec;
     private readonly retryAttempts: number;
     private readonly retryBaseMs: number;
     private readonly retryMaxMs: number;
@@ -149,6 +172,7 @@ export class StateStore<T> {
         this.relPathFn = opts.relPath;
         this.legacyFn = opts.legacy;
         this.validateFn = opts.validate ?? defaultValidate;
+        this.codec = opts.codec;
         this.retryAttempts = Math.max(1, opts.retryAttempts ?? 6);
         this.retryBaseMs = Math.max(1, opts.retryBaseMs ?? 50);
         this.retryMaxMs = Math.max(this.retryBaseMs, opts.retryMaxMs ?? 1600);
@@ -215,7 +239,7 @@ export class StateStore<T> {
             return false;
         }
         const file = this.resolvePath(id, payload);
-        const data = JSON.stringify(this.envelope(id, payload));
+        const data = this.serialize(id, payload);
         let lastErr: unknown;
         for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
             // Fresh temp name + mkdir per attempt — same reasoning as the
@@ -223,7 +247,7 @@ export class StateStore<T> {
             const tmp = this.tempPath(file);
             try {
                 fs.mkdirSync(path.dirname(file), { recursive: true });
-                fs.writeFileSync(tmp, data, "utf8");
+                fs.writeFileSync(tmp, data);
                 fs.renameSync(tmp, file);
                 lastErr = undefined;
                 break;
@@ -254,7 +278,7 @@ export class StateStore<T> {
         for (let attempt = 0; attempt < this.retryAttempts && spillPath === null; attempt++) {
             try {
                 fs.mkdirSync(path.dirname(spill), { recursive: true });
-                fs.writeFileSync(spill, data, "utf8");
+                fs.writeFileSync(spill, data);
                 spillPath = spill;
             } catch (e) {
                 if (!isTransientFsError(e) || attempt === this.retryAttempts - 1) break;
@@ -377,7 +401,7 @@ export class StateStore<T> {
             throw e;
         }
         const file = this.resolvePath(id, payload);
-        const data = JSON.stringify(this.envelope(id, payload));
+        const data = this.serialize(id, payload);
         let lastErr: unknown;
         for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
             // Fresh temp name per attempt: on Windows a failed cleanup can
@@ -389,7 +413,7 @@ export class StateStore<T> {
             const tmp = this.tempPath(file);
             try {
                 await fsp.mkdir(path.dirname(file), { recursive: true });
-                await fsp.writeFile(tmp, data, "utf8");
+                await fsp.writeFile(tmp, data);
                 await fsp.rename(tmp, file);
                 this.discovered.set(id, file);
                 this.clearFailure(id);
@@ -418,7 +442,7 @@ export class StateStore<T> {
         for (let attempt = 0; attempt < this.retryAttempts && spillPath === null; attempt++) {
             try {
                 await fsp.mkdir(path.dirname(spill), { recursive: true });
-                await fsp.writeFile(spill, data, "utf8");
+                await fsp.writeFile(spill, data);
                 spillPath = spill;
             } catch (e) {
                 if (!isTransientFsError(e) || attempt === this.retryAttempts - 1) break;
@@ -434,6 +458,14 @@ export class StateStore<T> {
 
     private envelope(id: string, payload: T): PersistedEnvelope<T> {
         return { version: this.version, savedAt: Date.now(), id, payload };
+    }
+
+    /** Serialize an envelope for disk, applying the optional codec. Strings
+     *  are written as UTF-8 (the fs default); Buffer results pass through as
+     *  raw bytes. */
+    private serialize(id: string, payload: T): Buffer | string {
+        const json = JSON.stringify(this.envelope(id, payload));
+        return this.codec ? this.codec.encode(json) : json;
     }
 
     /** Absolute path for a record: custom relPath (guarded against path
@@ -513,7 +545,9 @@ export class StateStore<T> {
     private readEnvelope(file: string): PersistedEnvelope<T> | null {
         let parsed: unknown;
         try {
-            parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+            const buf = fs.readFileSync(file);
+            const text = this.codec ? this.codec.decode(buf) : buf.toString("utf8");
+            parsed = JSON.parse(text);
         } catch (e) {
             // A missing candidate path is an expected miss (loadSync probes);
             // only genuinely unreadable/corrupt files get logged.

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -6,6 +6,7 @@ import fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { StateStore, flatFileNameFor } from "../src/persist/store.js";
+import type { StateStoreCodec } from "../src/persist/store.js";
 import { mergeCompressionState } from "../src/persist/state-merge.js";
 import { createInitialState } from "../src/state.js";
 import type { CompressionState } from "../src/types.js";
@@ -751,6 +752,134 @@ test("flushSync heals an ENOENT sweep the same way", (t) => {
         assert.ok(calls >= 2, "renameSync was retried");
     } finally {
         t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function xorCodec(): StateStoreCodec {
+    const x = (buf: Buffer): Buffer => {
+        const out = Buffer.alloc(buf.length);
+        for (let i = 0; i < buf.length; i++) out[i] = buf[i] ^ 0x5a;
+        return out;
+    };
+    return { encode: (data) => x(Buffer.from(data, "utf8")), decode: (buf) => x(buf).toString("utf8") };
+}
+
+const ENC_MAGIC = Buffer.from("ENC1", "utf8");
+
+function magicCodec(): StateStoreCodec {
+    const inner = xorCodec();
+    return {
+        encode: (data) => Buffer.concat([ENC_MAGIC, inner.encode(data)]),
+        decode: (buf) => (buf.subarray(0, 4).equals(ENC_MAGIC) ? inner.decode(buf.subarray(4)) : buf.toString("utf8")),
+    };
+}
+
+test("codec round-trips records and keeps files opaque on disk", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { codec: xorCodec() });
+        await s.writeNow("sid-enc", () => ({ label: "secret", count: 7 }));
+        const raw = readFileSync(path.join(dir, flatFileNameFor("sid-enc")));
+        assert.ok(!raw.includes(Buffer.from('"label"')), "on-disk bytes are not plaintext JSON");
+        const hit = s.loadSync("sid-enc");
+        assert.ok(hit);
+        assert.deepEqual(hit.payload, { label: "secret", count: 7 });
+        const all = await s.loadAll();
+        assert.deepEqual(all.get("sid-enc")?.payload, { label: "secret", count: 7 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("codec applies to debounced scheduleSave writes", async () => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { codec: xorCodec(), debounceMs: 10 });
+        s.scheduleSave("sid-deb", () => ({ label: "deb", count: 3 }));
+        await s.flushAll();
+        const all = await s.loadAll();
+        assert.deepEqual(all.get("sid-deb")?.payload, { label: "deb", count: 3 });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("codec applies to spill writes as well", async (t) => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { codec: xorCodec(), retryAttempts: 2, retryBaseMs: 1, retryMaxMs: 2 });
+        t.mock.method(fsp, "rename", async () => {
+            throw eperm();
+        });
+        let threw = false;
+        try {
+            await s.writeNow("sid-espill", () => ({ label: "kept", count: 1 }));
+        } catch {
+            threw = true;
+        }
+        assert.equal(threw, true);
+        const raw = readFileSync(path.join(dir, spillNameFor("sid-espill")));
+        assert.ok(!raw.includes(Buffer.from('"label"')), "spill is encoded");
+        const env = JSON.parse(xorCodec().decode(raw)) as { id: string; payload: Payload };
+        assert.equal(env.id, "sid-espill");
+        assert.deepEqual(env.payload, { label: "kept", count: 1 });
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("flushSync spill is encoded too", (t) => {
+    const dir = tmpDir();
+    try {
+        const s = store(dir, { codec: xorCodec(), retryAttempts: 2, retryBaseMs: 1, retryMaxMs: 2 });
+        t.mock.method(fs, "renameSync", () => {
+            throw eperm();
+        });
+        const ok = s.flushSync("sid-fsenc", () => ({ label: "sync", count: 9 }));
+        assert.equal(ok, true);
+        const raw = readFileSync(path.join(dir, spillNameFor("sid-fsenc")));
+        assert.ok(!raw.includes(Buffer.from('"label"')), "spill is encoded");
+        const env = JSON.parse(xorCodec().decode(raw)) as { payload: Payload };
+        assert.deepEqual(env.payload, { label: "sync", count: 9 });
+    } finally {
+        t.mock.restoreAll();
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("codec decode failure is treated as a corrupt file, not fatal", async () => {
+    const dir = tmpDir();
+    try {
+        const plain = store(dir);
+        await plain.writeNow("sid-corrupt", () => ({ label: "x", count: 1 }));
+        const logs: Array<{ level: string; msg: string }> = [];
+        const strict = store(dir, {
+            codec: { encode: (d) => d, decode: () => { throw new Error("auth failed"); } },
+            log: (level, msg) => logs.push({ level, msg }),
+        });
+        assert.equal(strict.loadSync("sid-corrupt"), null);
+        const all = await strict.loadAll();
+        assert.equal(all.size, 0);
+        assert.ok(logs.some((l) => l.level === "warn" && l.msg.includes("corrupt")), "logged as corrupt");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("mixed tree: unencoded legacy files and encoded files both load", async () => {
+    const dir = tmpDir();
+    try {
+        const plain = store(dir);
+        await plain.writeNow("sid-old", () => ({ label: "legacy", count: 1 }));
+        const enc = store(dir, { codec: magicCodec() });
+        await enc.writeNow("sid-new", () => ({ label: "encoded", count: 2 }));
+        const fresh = store(dir, { codec: magicCodec() });
+        const all = await fresh.loadAll();
+        assert.deepEqual(all.get("sid-old")?.payload, { label: "legacy", count: 1 });
+        assert.deepEqual(all.get("sid-new")?.payload, { label: "encoded", count: 2 });
+    } finally {
         rmSync(dir, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
## What

Adds an optional `codec` to `StateStoreOptions` (`src/persist/store.ts`):

```ts
interface StateStoreCodec {
    encode(data: string): Buffer | string;  // applied to the exact JSON string before every write
    decode(buf: Buffer): string;            // applied to raw file bytes before JSON.parse on every read
}
```

- `encode` runs around **every** serialized write site: canonical + spill, sync (`flushSync`) + async (`writeInner`) — both funnel through one new `serialize()` helper.
- `decode` runs in `readEnvelope`, the single read path for `loadSync`/`loadAll`. A decode failure (e.g. AES-GCM auth tag mismatch) falls into the **existing corrupt-file semantics**: logged as corrupt, skipped, boot never blocks.
- The store stays mechanism-only. Format detection — magic bytes, plaintext fallback for unencoded legacy files — is the codec's job, so a mixed tree of legacy plaintext and encoded files loads fine.
- Default: no codec → files stay plain UTF-8 JSON, byte-identical behavior to today.
- File writes drop the explicit `"utf8"` argument: strings still default to UTF-8 (unchanged), and `Buffer` codec output now passes through as raw bytes.

## Why

Consumer: [ranxianglei/billion-context#708](https://github.com/ranxianglei/billion-context/issues/708) — encrypt session state files at rest for deployments on untrusted remote nodes. The fs I/O lives in this store (billion-context's `src/persist.ts` is policy-only), so the hook has to be here; billion-context will supply an AES-256-GCM(zstd(JSON)) codec keyed by env var.

## Tests

6 new tests in `tests/persist.test.ts`: round-trip through writeNow/loadSync/loadAll with opaque on-disk bytes; debounced scheduleSave path; spill writes (async rename-failure + flushSync); decode failure = corrupt-file skip with warn log; mixed plaintext+encoded tree loads both. Binary-safe codec (XOR) so the Buffer path is genuinely exercised.

Pre-flight: `npm run typecheck` clean, `npm test` 651/651 pass, `npm run build` OK.

<!-- ework-agent-pr -->