### PR TITLE
feat(nudge): option to render nudges without the guidance sections

### DIFF
--- a/DESIGN-prompts.md
+++ b/DESIGN-prompts.md
@@ -72,6 +72,12 @@ export function resolvePrompts(
 - `renderNudgeText(decision, prompts = defaultPrompts)` now accepts a `Prompts`
   argument, so an override flows into every nudge tier (gentle / emergency /
   tier-2 / tier-3). The default keeps the one-arg call backward-compatible.
+- The renderer also accepts `options?: { includeGuidance?: boolean }` (default
+  `true`; exported as `RenderNudgeOptions`). Set `false` when the host already
+  delivers the four rules once via system prompt / tool descriptions: exactly
+  those texts are dropped from the nudge body, all per-injection dynamic content
+  survives, and the system-prompt surface is untouched. Field overrides cannot
+  express this split — they change both surfaces at once.
 
 ### Host usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export {
 } from "./tokenize.js";
 export type { TokenCountFn } from "./tokenize.js";
 export { renderNudgeText, formatRanges } from "./nudge-text.js";
-export type { NudgeVoice, RenderedNudge } from "./nudge-text.js";
+export type { NudgeVoice, RenderedNudge, RenderNudgeOptions } from "./nudge-text.js";
 export {
   COMPRESS_PHILOSOPHY,
   HOW_TO_COMPRESS_RULES,

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -9,12 +9,30 @@ export interface RenderedNudge {
   text: string;
 }
 
-function efficiencyNote(prompts: Prompts): string {
-  return `This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${prompts.compressPhilosophy}`;
+export interface RenderNudgeOptions {
+  /**
+   * Embed the load-bearing guidance texts (compressPhilosophy, howToCompressRules,
+   * and the active tier's distill/condense rules) in the nudge body. Defaults to
+   * true, so existing callers render byte-identical output. Set to false when the
+   * host already delivers these same texts once via its system prompt or tool
+   * descriptions — re-billing them on every injection is pure repetition. Only
+   * the four guidance texts are dropped; per-injection dynamic content
+   * (breakdown, trigger line, ranges, tier target blocks) survives. The
+   * system-prompt composition path reads {@link Prompts} directly and is
+   * unaffected by this flag — this is how a host keeps guidance in the system
+   * prompt while slimming every nudge.
+   */
+  includeGuidance?: boolean;
 }
 
-function emergencyHeader(prompts: Prompts): string {
-  return `⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n${prompts.compressPhilosophy}`;
+function efficiencyNote(prompts: Prompts, includeGuidance: boolean): string {
+  const note = "This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.";
+  return includeGuidance ? `${note}\n\n${prompts.compressPhilosophy}` : note;
+}
+
+function emergencyHeader(prompts: Prompts, includeGuidance: boolean): string {
+  const header = "⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.";
+  return includeGuidance ? `${header}\n\n${prompts.compressPhilosophy}` : header;
 }
 
 function formatK(n: number): string {
@@ -120,7 +138,12 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   return `Compressible ranges (${merged.length}, oldest first):\n${lines.join("\n")}`;
 }
 
-export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts): RenderedNudge {
+export function renderNudgeText(
+  decision: NudgeDecision,
+  prompts: Prompts = defaultPrompts,
+  options: RenderNudgeOptions = {},
+): RenderedNudge {
+  const includeGuidance = options.includeGuidance ?? true;
   const breakdownStr = formatBreakdown(decision.contextBreakdown);
   const rangesStr = formatRanges(decision.compressibleRanges, decision.protectedRanges ?? []);
   const isEmergency = !!decision.breakdown?.emergencyOverride || !!decision.breakdown?.overLimit;
@@ -135,57 +158,39 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
     const triggerLine = isEmergency
       ? `[EMERGENCY — TIER ${decision.tier} ${isT2 ? "DISTILLATION" : "CONDENSATION"}] Context limit reached — distill NOW into a denser summary to reclaim tokens.`
       : `[TIER ${decision.tier} ${isT2 ? "DISTILLATION" : "CONDENSATION"} TRIGGER]`;
-    return {
-      voice,
-      text: [
-        efficiencyNote(prompts),
-        "",
-        breakdownStr,
-        "",
-        triggerLine,
-        isT2
-          ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`
-          : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`,
-        blockList,
-        `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
-        "",
-        prompts.howToCompressRules,
-        "",
-        isT2 ? prompts.tier2DistillRules : prompts.tier3CondenseRules,
-      ].join("\n"),
-    };
-  }
-
-  if (isEmergency) {
-    return {
-      voice: "emergency",
-      text: [
-        emergencyHeader(prompts),
-        "",
-        breakdownStr,
-        "",
-        prompts.howToCompressRules,
-        "",
-        `{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }`,
-        "Only use IDs from visible messages above. Compress older work first.",
-        "",
-        rangesStr,
-      ].join("\n"),
-    };
-  }
-
-  return {
-    voice: "gentle",
-    text: [
-      efficiencyNote(prompts),
+    const parts = [
+      efficiencyNote(prompts, includeGuidance),
       "",
       breakdownStr,
       "",
-      prompts.howToCompressRules,
+      triggerLine,
+      isT2
+        ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`
+        : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`,
+      blockList,
+      `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
+    ];
+    if (includeGuidance) {
+      parts.push("", prompts.howToCompressRules, "", isT2 ? prompts.tier2DistillRules : prompts.tier3CondenseRules);
+    }
+    return { voice, text: parts.join("\n") };
+  }
+
+  if (isEmergency) {
+    const parts = [emergencyHeader(prompts, includeGuidance), "", breakdownStr];
+    if (includeGuidance) parts.push("", prompts.howToCompressRules);
+    parts.push(
+      "",
+      `{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }`,
+      "Only use IDs from visible messages above. Compress older work first.",
       "",
       rangesStr,
-      "",
-      `💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`,
-    ].join("\n"),
-  };
+    );
+    return { voice: "emergency", text: parts.join("\n") };
+  }
+
+  const parts = [efficiencyNote(prompts, includeGuidance), "", breakdownStr];
+  if (includeGuidance) parts.push("", prompts.howToCompressRules);
+  parts.push("", rangesStr, "", `💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`);
+  return { voice: "gentle", text: parts.join("\n") };
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -58,6 +58,11 @@ export interface ResolvePromptsOptions {
  * malformed partial never degrades the canonical rules. Resolve once at host
  * startup, then pass the resulting {@link Prompts} to {@link renderNudgeText}
  * and to the adapter's system-prompt composition so both layers stay consistent.
+ *
+ * To keep guidance in the system prompt but drop it from every nudge (hosts that
+ * deliver these texts once at startup), do NOT override fields here — that would
+ * change both surfaces at once. Pass `{ includeGuidance: false }` to
+ * {@link renderNudgeText} instead; the system-prompt path is unaffected by it.
  */
 export function resolvePrompts(
   overrides?: Partial<Prompts>,

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -2,6 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { renderNudgeText } from "../src/nudge-text.js";
 import type { NudgeDecision, CompressibleRange } from "../src/types.js";
+import { defaultPrompts } from "../src/prompts.js";
+import {
+  COMPRESS_PHILOSOPHY,
+  HOW_TO_COMPRESS_RULES,
+  TIER2_DISTILL_RULES,
+  TIER3_CONDENSE_RULES,
+} from "../src/compression-rules.js";
 
 function makeRanges(count: number): CompressibleRange[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -22,6 +29,9 @@ function makeDecision(overrides: Partial<NudgeDecision> = {}): NudgeDecision {
     contextUsage: 0.5,
     tier: null,
     breakdown: { emergencyOverride: 0 },
+    // decideNudge always populates this (src/compress.ts); keep the fixture realistic
+    // so renders exercise the breakdown section like production nudges do.
+    contextBreakdown: { system: 5_000, tool: 20_000, summaries: 2_000, code: 1_000, text: 3_000, total: 31_000, growth: 1_000 },
     ...overrides,
   };
 }
@@ -173,4 +183,97 @@ test("over-limit renders with emergency voice (MAJOR-2 fix)", () => {
   );
   assert.equal(result.voice, "emergency", "over-limit should use emergency voice, not gentle");
   assert.ok(!result.text.includes("not an overflow warning"), "should NOT contain gentle reassurance");
+});
+
+const SLIM = { includeGuidance: false } as const;
+
+function allModes() {
+  return [
+    ["gentle", makeDecision({ contextUsage: 0.5 })],
+    ["emergency", makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 } })],
+    ["tier-2", makeDecision({ tier: 2 })],
+    ["tier-3", makeDecision({ tier: 3 })],
+  ] as const;
+}
+
+test("includeGuidance defaults to true and is backwards compatible (all modes)", () => {
+  for (const [label, decision] of allModes()) {
+    const defaultOut = renderNudgeText(decision);
+    const explicitTrue = renderNudgeText(decision, defaultPrompts, { includeGuidance: true });
+    const noOptions = renderNudgeText(decision, defaultPrompts);
+    assert.equal(defaultOut.text, explicitTrue.text, `${label}: explicit true === default`);
+    assert.equal(defaultOut.text, noOptions.text, `${label}: omitted options === default`);
+  }
+});
+
+test("gentle + includeGuidance:false drops all four guidance texts, keeps dynamic chrome", () => {
+  const result = renderNudgeText(makeDecision({ contextUsage: 0.5 }), defaultPrompts, SLIM);
+  assert.ok(!result.text.includes(COMPRESS_PHILOSOPHY), "no philosophy");
+  assert.ok(!result.text.includes(HOW_TO_COMPRESS_RULES), "no how-to-compress rules");
+  assert.ok(!result.text.includes(TIER2_DISTILL_RULES), "no tier-2 rules");
+  assert.ok(!result.text.includes(TIER3_CONDENSE_RULES), "no tier-3 rules");
+  assert.ok(result.text.includes("efficiency nudge"), "keeps gentle header");
+  assert.ok(result.text.includes("not an overflow warning"), "keeps reassurance line");
+  assert.ok(result.text.includes("Compressible ranges"), "keeps range listing");
+  assert.ok(result.text.includes("m00001"), "keeps range refs");
+  assert.ok(result.text.includes("Compress all ranges in one call"), "keeps batch hint");
+  assert.ok(!result.text.includes("\n\n\n"), "no stacked blank lines");
+});
+
+test("emergency + includeGuidance:false drops guidance, keeps call-shape example", () => {
+  const result = renderNudgeText(
+    makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 } }),
+    defaultPrompts,
+    SLIM,
+  );
+  assert.equal(result.voice, "emergency");
+  assert.ok(!result.text.includes(COMPRESS_PHILOSOPHY), "no philosophy");
+  assert.ok(!result.text.includes(HOW_TO_COMPRESS_RULES), "no how-to-compress rules");
+  assert.ok(result.text.includes("Context limit reached"), "keeps emergency header");
+  assert.ok(result.text.includes('Only use IDs from visible messages above'), "keeps ID warning");
+  assert.ok(result.text.includes('"topic": "..."'), "keeps JSON call-shape example");
+  assert.ok(result.text.includes("Compressible ranges"), "keeps range listing");
+  assert.ok(!result.text.includes("\n\n\n"), "no stacked blank lines");
+});
+
+test("tier-2 + includeGuidance:false drops how-to-compress + tier rules, keeps target list", () => {
+  const result = renderNudgeText(makeDecision({ tier: 2 }), defaultPrompts, SLIM);
+  assert.ok(!result.text.includes(COMPRESS_PHILOSOPHY), "no philosophy");
+  assert.ok(!result.text.includes(HOW_TO_COMPRESS_RULES), "no how-to-compress rules");
+  assert.ok(!result.text.includes(TIER2_DISTILL_RULES), "no tier-2 rules");
+  assert.ok(!result.text.includes(TIER3_CONDENSE_RULES), "no tier-3 rules");
+  assert.ok(result.text.includes("TIER 2"), "keeps tier trigger line");
+  assert.ok(result.text.includes("Target blocks"), "keeps target block list");
+  assert.ok(result.text.includes("Example: compress("), "keeps example call");
+  assert.ok(!result.text.includes("\n\n\n"), "no stacked blank lines");
+});
+
+test("tier-3 + includeGuidance:false drops how-to-compress + tier rules, keeps target list", () => {
+  const result = renderNudgeText(makeDecision({ tier: 3 }), defaultPrompts, SLIM);
+  assert.ok(!result.text.includes(COMPRESS_PHILOSOPHY), "no philosophy");
+  assert.ok(!result.text.includes(HOW_TO_COMPRESS_RULES), "no how-to-compress rules");
+  assert.ok(!result.text.includes(TIER2_DISTILL_RULES), "no tier-2 rules");
+  assert.ok(!result.text.includes(TIER3_CONDENSE_RULES), "no tier-3 rules");
+  assert.ok(result.text.includes("TIER 3"), "keeps tier trigger line");
+  assert.ok(result.text.includes("Target blocks"), "keeps target block list");
+  assert.ok(!result.text.includes("\n\n\n"), "no stacked blank lines");
+});
+
+test("default tier nudges still embed how-to-compress + only the active tier's rules", () => {
+  const t2 = renderNudgeText(makeDecision({ tier: 2 }));
+  assert.ok(t2.text.includes(HOW_TO_COMPRESS_RULES));
+  assert.ok(t2.text.includes(TIER2_DISTILL_RULES));
+  assert.ok(!t2.text.includes(TIER3_CONDENSE_RULES), "tier-2 nudge must not carry tier-3 rules");
+  const t3 = renderNudgeText(makeDecision({ tier: 3 }));
+  assert.ok(t3.text.includes(HOW_TO_COMPRESS_RULES));
+  assert.ok(t3.text.includes(TIER3_CONDENSE_RULES));
+  assert.ok(!t3.text.includes(TIER2_DISTILL_RULES), "tier-3 nudge must not carry tier-2 rules");
+});
+
+test("includeGuidance:false is materially smaller than the full nudge", () => {
+  for (const [label, decision] of allModes()) {
+    const full = renderNudgeText(decision).text.length;
+    const slim = renderNudgeText(decision, defaultPrompts, SLIM).text.length;
+    assert.ok(slim < full / 2, `${label}: slim (${slim}) should be under half of full (${full})`);
+  }
 });


### PR DESCRIPTION
## Problem

`renderNudgeText` always embeds all four load-bearing guidance texts (`COMPRESS_PHILOSOPHY`, `HOW_TO_COMPRESS_RULES`, `TIER2_DISTILL_RULES`, `TIER3_CONDENSE_RULES`) into every nudge body. A host that already delivers these same texts once via the system prompt + tool descriptions re-bills ~6 KB of identical text on **every** injection (~18.4 KB per stretch of turns in the B6 measurement), zero new information.

The existing override path (`resolvePrompts`) cannot express this split: its result feeds both the nudge renderer and system-prompt composition, so overriding a field changes both surfaces at once.

## Fix

Opt-out at nudge-render time, exactly as proposed in #248:

```ts
renderNudgeText(decision: NudgeDecision, prompts?: Prompts, options?: { includeGuidance?: boolean }): RenderedNudge
// includeGuidance defaults to true → fully backwards compatible
```

With `includeGuidance: false`, exactly the four exported guidance blocks are dropped (philosophy from both the efficiency note and emergency header, HOW TO COMPRESS, and the active tier's distill/condense rules). All per-injection dynamic content survives: context breakdown, trigger line, compressible ranges, tier target block list, the JSON call-shape example, and the batch-call hint — with no leftover stacked blank lines.

Chosen over the structured-parts alternative: additive, keeps `RenderedNudge.text` stable for existing hosts; structured parts would widen the public surface for what is effectively one boolean.

## Changes

- `src/nudge-text.ts` — new exported `RenderNudgeOptions`; all three render branches (gentle / emergency / tier) conditionally append the guidance sections
- `src/index.ts` — export `RenderNudgeOptions`
- `src/prompts.ts` — `resolvePrompts` JSDoc now cross-references the option so hosts don't try to express the surface split via field overrides
- `tests/nudge-text.test.ts` — 7 new tests: backwards-compat identity across all 4 modes, slim output per mode (guidance absent, chrome present, no stacked blanks), default tier nudges still embed only the active tier's rules, size-savings sanity (< 50% of full text); fixture now carries a realistic `contextBreakdown` (decideNudge always populates it)

## Verification

- `npm run typecheck` — clean
- `npm test` — 651/651 pass
- `npm run build` — success

## Consumer

billion-context-dsh (B6 "slim nudges", https://github.com/Tyan66666/billion-context-dsh/pull/143) pins acp-kernel 0.0.29 and post-processes rendered text today (`stripNudgeGuidance`, exact-match stripping of the four blocks — fragile against any rewording). Once this ships, it can delete that workaround and pass `{ includeGuidance: false }`.

Closes #248