### PR TITLE
feat: add active-block ledger to nudge text (#251)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -169,6 +169,8 @@ type NudgeDecision = {
     shouldInject: boolean;
     reason: string;
     compressibleRanges: { startRef: string; endRef: string; tokens: number }[];
+    activeBlocks?: CompressionBlock[];   // rendered as a compact block ledger (id → ref span) in the nudge text (#251)
+    messageRefs?: MessageRefMap;         // resolves each block's effectiveMessageIds back to m-refs
     contextUsage: number;       // 0..1
     tier: 1 | 2 | 3 | null;     // multi-tier trigger, if any
     breakdown: Record<string, number>;

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1354,6 +1354,8 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     compressibleRanges: rec?.recommendedRanges ?? [],
     protectedRanges: rec?.contextRanges.protected ?? [],
     tierTargetBlocks: injectedTier ? tiers[injectedTier]!.targetBlocks : [],
+    activeBlocks: activeBlocks(state),
+    messageRefs: state.messageRefs,
     contextUsage: usage,
     tier: injectedTier,
     breakdown: {

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -1,6 +1,7 @@
-import type { NudgeDecision, CompressibleRange, ProtectedRange, ContextBreakdown, CompressionBlock } from "./types.js";
+import type { NudgeDecision, CompressibleRange, ProtectedRange, ContextBreakdown, CompressionBlock, MessageRefMap } from "./types.js";
 import { defaultPrompts } from "./prompts.js";
 import type { Prompts } from "./prompts.js";
+import { refToIndex, BLOCKED_REF } from "./refs.js";
 
 export type NudgeVoice = "gentle" | "emergency";
 
@@ -120,9 +121,82 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   return `Compressible ranges (${merged.length}, oldest first):\n${lines.join("\n")}`;
 }
 
+export const MAX_BLOCK_LEDGER_ENTRIES = 8;
+
+function blockIndex(id: string): number {
+  const n = Number(id.slice(1));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function blockSpan(
+  block: CompressionBlock,
+  refs: MessageRefMap | undefined,
+): { start: string; end: string } | null {
+  let loIdx: number | null = null;
+  let hiIdx: number | null = null;
+  let loRef = "";
+  let hiRef = "";
+  for (const rawId of block.effectiveMessageIds) {
+    const ref = refs?.byRaw[rawId];
+    if (!ref || ref === BLOCKED_REF) continue;
+    const idx = refToIndex(ref);
+    if (idx === null) continue;
+    if (loIdx === null || idx < loIdx) {
+      loIdx = idx;
+      loRef = ref;
+    }
+    if (hiIdx === null || idx > hiIdx) {
+      hiIdx = idx;
+      hiRef = ref;
+    }
+  }
+  if (loIdx !== null && hiIdx !== null) return { start: loRef, end: hiRef };
+  // effectiveMessageIds may be unresolvable after fork/rebuild remapping.
+  // Fall back to the stored spec span only when it parses as m-refs —
+  // block-boundary calls store block IDs ("b1") there, which would mislead.
+  if (block.startRef && block.endRef) {
+    const s = refToIndex(block.startRef);
+    const e = refToIndex(block.endRef);
+    if (s !== null && e !== null) {
+      return s <= e
+        ? { start: block.startRef, end: block.endRef }
+        : { start: block.endRef, end: block.startRef };
+    }
+  }
+  return null;
+}
+
+export function formatBlockLedger(
+  blocks: CompressionBlock[],
+  refs?: MessageRefMap,
+  maxEntries: number = MAX_BLOCK_LEDGER_ENTRIES,
+): string {
+  const entries: string[] = [];
+  const sorted = [...blocks].sort((a, b) => blockIndex(a.blockId) - blockIndex(b.blockId));
+  for (const block of sorted) {
+    const span = blockSpan(block, refs);
+    if (!span) continue;
+    const range = span.start === span.end ? span.start : `${span.start}–${span.end}`;
+    entries.push(
+      block.tier >= 2
+        ? `${block.blockId}=tier${block.tier}(${range})`
+        : `${block.blockId}=${range}`,
+    );
+  }
+  if (entries.length === 0) return "";
+  let shown = entries;
+  let olderNote = "";
+  if (entries.length > maxEntries) {
+    shown = entries.slice(entries.length - maxEntries);
+    olderNote = ` (+${entries.length - maxEntries} older)`;
+  }
+  return `Blocks${olderNote}: ${shown.join(" · ")}`;
+}
+
 export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts): RenderedNudge {
   const breakdownStr = formatBreakdown(decision.contextBreakdown);
   const rangesStr = formatRanges(decision.compressibleRanges, decision.protectedRanges ?? []);
+  const ledgerStr = formatBlockLedger(decision.activeBlocks ?? [], decision.messageRefs);
   const isEmergency = !!decision.breakdown?.emergencyOverride || !!decision.breakdown?.overLimit;
 
   if (decision.tier !== null && decision.tier >= 2) {
@@ -147,6 +221,7 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
           ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`
           : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`,
         blockList,
+        ...(ledgerStr ? [ledgerStr] : []),
         `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
         "",
         prompts.howToCompressRules,
@@ -170,6 +245,7 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
         "Only use IDs from visible messages above. Compress older work first.",
         "",
         rangesStr,
+        ...(ledgerStr ? [ledgerStr] : []),
       ].join("\n"),
     };
   }
@@ -184,6 +260,7 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
       prompts.howToCompressRules,
       "",
       rangesStr,
+      ...(ledgerStr ? [ledgerStr] : []),
       "",
       `💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`,
     ].join("\n"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,12 @@ export interface NudgeDecision {
   /** When `tier` is set, the active lower-tier blocks that should be distilled
    *  into a single higher-tier block. Empty when no tier nudge. */
   tierTargetBlocks?: CompressionBlock[];
+  /** All ACTIVE blocks. Rendered as a compact block ledger (id → ref span) so
+   *  the model can reconcile its memory of prior compress coverage against the
+   *  recommended ranges without an acp_status round-trip (#251). */
+  activeBlocks?: CompressionBlock[];
+  /** Ref mapping used to resolve each block's effectiveMessageIds back to m-refs. */
+  messageRefs?: MessageRefMap;
   contextUsage: number;
   tier: CompressionTier | null;
   breakdown: NudgeBreakdown;

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { renderNudgeText } from "../src/nudge-text.js";
-import type { NudgeDecision, CompressibleRange } from "../src/types.js";
+import { renderNudgeText, formatBlockLedger } from "../src/nudge-text.js";
+import type { NudgeDecision, CompressibleRange, CompressionBlock, MessageRefMap } from "../src/types.js";
 
 function makeRanges(count: number): CompressibleRange[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -173,4 +173,119 @@ test("over-limit renders with emergency voice (MAJOR-2 fix)", () => {
   );
   assert.equal(result.voice, "emergency", "over-limit should use emergency voice, not gentle");
   assert.ok(!result.text.includes("not an overflow warning"), "should NOT contain gentle reassurance");
+});
+
+function makeBlock(blockId: string, rawIds: string[], overrides: Partial<CompressionBlock> = {}): CompressionBlock {
+  return {
+    blockId,
+    runId: "r1",
+    tier: 1,
+    summary: "summary",
+    directMessageIds: rawIds,
+    effectiveMessageIds: rawIds,
+    directBlockIds: [],
+    compressedTokens: 100,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+function makeRefMap(pairs: Array<[rawId: string, ref: string]>): MessageRefMap {
+  const byRaw: Record<string, string> = {};
+  const byRef: Record<string, string> = {};
+  for (const [rawId, ref] of pairs) {
+    byRaw[rawId] = ref;
+    byRef[ref] = rawId;
+  }
+  return { byRaw, byRef };
+}
+
+function rangeRefs(start: number, end: number): Array<[string, string]> {
+  const pairs: Array<[string, string]> = [];
+  for (let i = start; i <= end; i++) {
+    pairs.push([`raw-${i}`, `m${String(i).padStart(5, "0")}`]);
+  }
+  return pairs;
+}
+
+test("block ledger: gentle nudge shows active block id → ref span map (#251)", () => {
+  const refs = makeRefMap([...rangeRefs(1, 43), ...rangeRefs(57, 78)]);
+  const blocks = [makeBlock("b1", rangeRefs(1, 43).map(([r]) => r)), makeBlock("b2", rangeRefs(57, 78).map(([r]) => r))];
+  const result = renderNudgeText(makeDecision({ activeBlocks: blocks, messageRefs: refs }));
+  assert.ok(result.text.includes("Blocks: b1=m00001–m00043 · b2=m00057–m00078"), "should contain full block map");
+  assert.ok(
+    result.text.indexOf("Blocks:") > result.text.indexOf("Compressible ranges"),
+    "ledger should appear after the ranges section",
+  );
+});
+
+test("block ledger: single-message block renders bare ref without en-dash", () => {
+  const refs = makeRefMap([["only", "m00009"]]);
+  const blocks = [makeBlock("b1", ["only"])];
+  assert.equal(formatBlockLedger(blocks, refs), "Blocks: b1=m00009");
+});
+
+test("block ledger: tier-2/tier-3 blocks annotated with tier", () => {
+  const refs = makeRefMap(rangeRefs(1, 78));
+  const t2 = makeBlock("b3", rangeRefs(1, 78).map(([r]) => r), { tier: 2 });
+  const t3 = makeBlock("b4", rangeRefs(1, 78).map(([r]) => r), { tier: 3 });
+  assert.equal(
+    formatBlockLedger([t2, t3], refs),
+    "Blocks: b3=tier2(m00001–m00078) · b4=tier3(m00001–m00078)",
+  );
+  const nudge = renderNudgeText(
+    makeDecision({ tier: 2, activeBlocks: [t2], messageRefs: refs }),
+  );
+  assert.ok(nudge.text.includes("b3=tier2(m00001–m00078)"), "tier nudge should carry the ledger too");
+});
+
+test("block ledger: truncates to newest entries with older count", () => {
+  const pairs: Array<[string, string]> = [];
+  const blocks: CompressionBlock[] = [];
+  for (let i = 1; i <= 11; i++) {
+    const ref = `m${String(i * 10).padStart(5, "0")}`;
+    pairs.push([`raw-${i}`, ref]);
+    blocks.push(makeBlock(`b${i}`, [`raw-${i}`]));
+  }
+  const expected =
+    "Blocks (+3 older): b4=m00040 · b5=m00050 · b6=m00060 · b7=m00070 · b8=m00080 · b9=m00090 · b10=m00100 · b11=m00110";
+  assert.equal(formatBlockLedger(blocks, makeRefMap(pairs)), expected);
+  assert.ok(!expected.includes("b1="), "oldest truncated entries must be dropped");
+});
+
+test("block ledger: no line when there are no blocks or nothing resolvable", () => {
+  assert.equal(formatBlockLedger([]), "");
+  const unresolvable = makeBlock("b1", ["ghost"]);
+  assert.equal(formatBlockLedger([unresolvable], makeRefMap([])), "");
+  const result = renderNudgeText(makeDecision({ activeBlocks: [] }));
+  assert.ok(!result.text.includes("Blocks:"), "no ledger line without blocks");
+});
+
+test("block ledger: falls back to stored spec span only when it parses as m-refs", () => {
+  const orphan = makeBlock("b1", ["ghost"], { startRef: "m00010", endRef: "m00020" });
+  assert.equal(formatBlockLedger([orphan], makeRefMap([])), "Blocks: b1=m00010–m00020");
+  const blockBoundarySpec = makeBlock("b2", ["ghost"], { startRef: "b1", endRef: "b3" });
+  assert.equal(formatBlockLedger([blockBoundarySpec], makeRefMap([])), "");
+});
+
+test("block ledger: BLOCKED refs are skipped, remaining ids still spanned", () => {
+  const refs = makeRefMap([["blocked", "BLOCKED"], ["a", "m00005"], ["b", "m00007"]]);
+  const block = makeBlock("b1", ["blocked", "a", "b"]);
+  assert.equal(formatBlockLedger([block], refs), "Blocks: b1=m00005–m00007");
+  const allBlocked = makeBlock("b2", ["blocked"]);
+  assert.equal(formatBlockLedger([allBlocked], refs), "");
+});
+
+test("block ledger: appears in emergency nudge after ranges", () => {
+  const refs = makeRefMap(rangeRefs(1, 43));
+  const blocks = [makeBlock("b1", rangeRefs(1, 43).map(([r]) => r))];
+  const result = renderNudgeText(
+    makeDecision({ contextUsage: 0.99, breakdown: { emergencyOverride: 1 }, activeBlocks: blocks, messageRefs: refs }),
+  );
+  assert.equal(result.voice, "emergency");
+  assert.ok(result.text.includes("Blocks: b1=m00001–m00043"), "emergency nudge should carry the ledger");
+  assert.ok(result.text.indexOf("Blocks:") > result.text.indexOf("Compressible ranges"));
 });


### PR DESCRIPTION
## Problem (#251)

The nudge text lists recommended compressible ranges but carries no map of existing active blocks. When the model's memory of prior compress coverage drifted from actual coverage (protected-message exclusions, tool-pair boundary widening, consumed-block merges — all of which change `effectiveMessageIds` vs the requested range), it had to spend an `acp_status` round-trip (~1.8K tokens) to reconcile before acting.

## Changes

- `NudgeDecision` gains two optional fields: `activeBlocks` (all active blocks from `activeBlocks(state)`) and `messageRefs`. Populated by `decideNudge`; backward compatible for hosts that build decisions by hand.
- `renderNudgeText` appends a compact ledger line after the ranges section in **all three voices** (gentle / emergency / tier-2/3):
  ```
  Blocks: b1=m00001–m00043 · b2=m00057–m00078 · b3=tier2(m00001–m00078)
  ```
- Span = min/max ref of `effectiveMessageIds` resolved through `byRaw` (skips `BLOCKED` and unresolvable ids). Fallback to the stored spec span only when it parses as m-refs (block-boundary calls store block IDs like `b1` there, which would mislead); otherwise the block is omitted rather than shown with a wrong span.
- Truncation above `MAX_BLOCK_LEDGER_ENTRIES` (8): newest 8 shown + `( +N older)` count. Constant exported for tuning.
- `formatBlockLedger` exported for direct testing; DESIGN.md type sketch updated.

## Verification

- `npm run typecheck` ✅
- `npm test`: 588 pass / 0 fail (8 new tests: normal spans, single-message span, tier annotation incl. tier-nudge rendering, truncation, empty/unresolvable → no line, spec-span fallback + block-ID spec rejection, BLOCKED skipping, emergency placement)
- `npm run build` ✅

Cost ~50–100 tokens per nudge; opencode-acp and billion-context-pi both benefit without host changes (fields are optional).

<!-- ework-agent-pr -->