### PR TITLE
feat(#251): nudge carries active block map + user-msg counts per range

### DIFF
--- a/src/block-map.ts
+++ b/src/block-map.ts
@@ -10,15 +10,24 @@ function refNum(ref: string): number {
   return m ? parseInt(m[0], 10) : 0;
 }
 
+const M_REF = /^m\d+$/;
+
 /** Resolve a block's current ref span. Prefers the stored startRef/endRef
  *  (assigned at creation from the requested range); falls back to the
  *  min/max of effectiveMessageIds' refs for blocks persisted before those
- *  fields existed. Returns null when no covered message still resolves. */
+ *  fields existed. Stored refs are only trusted when both are message refs —
+ *  block-boundary specs (startId "bN") are stored verbatim on tier-distilled
+ *  blocks and must not render as spans. Returns null when nothing resolves. */
 export function resolveBlockSpan(
   block: CompressionBlock,
   byRaw: MessageRefMap["byRaw"],
 ): { startRef: string; endRef: string } | null {
-  if (block.startRef && block.endRef) {
+  if (
+    block.startRef &&
+    block.endRef &&
+    M_REF.test(block.startRef) &&
+    M_REF.test(block.endRef)
+  ) {
     return { startRef: block.startRef, endRef: block.endRef };
   }
   const refs = block.effectiveMessageIds

--- a/src/block-map.ts
+++ b/src/block-map.ts
@@ -1,0 +1,60 @@
+import type {
+  BlockSpan,
+  CompressionBlock,
+  CompressionState,
+  MessageRefMap,
+} from "./types.js";
+
+function refNum(ref: string): number {
+  const m = ref.match(/\d+/);
+  return m ? parseInt(m[0], 10) : 0;
+}
+
+/** Resolve a block's current ref span. Prefers the stored startRef/endRef
+ *  (assigned at creation from the requested range); falls back to the
+ *  min/max of effectiveMessageIds' refs for blocks persisted before those
+ *  fields existed. Returns null when no covered message still resolves. */
+export function resolveBlockSpan(
+  block: CompressionBlock,
+  byRaw: MessageRefMap["byRaw"],
+): { startRef: string; endRef: string } | null {
+  if (block.startRef && block.endRef) {
+    return { startRef: block.startRef, endRef: block.endRef };
+  }
+  const refs = block.effectiveMessageIds
+    .map((id) => byRaw[id])
+    .filter((r): r is string => typeof r === "string" && r !== "BLOCKED");
+  if (refs.length === 0) return null;
+  const sorted = [...refs].sort((a, b) => refNum(a) - refNum(b));
+  return { startRef: sorted[0]!, endRef: sorted[sorted.length - 1]! };
+}
+
+export function activeBlockSpans(state: CompressionState): BlockSpan[] {
+  const spans: BlockSpan[] = [];
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    const span = resolveBlockSpan(block, state.messageRefs.byRaw);
+    if (!span) continue;
+    spans.push({ blockId: block.blockId, tier: block.tier, ...span });
+  }
+  return spans;
+}
+
+/** Format newly created blocks for tool-result display, e.g.
+ *  `blocks: b3=m00044–m00097, b4=m00103–m00123`. Adapters append this to their
+ *  compress result line so the model's block ledger comes from the kernel
+ *  instead of being inferred from its own arguments (#376). Empty string when
+ *  no blocks were created. */
+export function formatCreatedBlocks(
+  state: CompressionState,
+  newBlocks: CompressionBlock[],
+): string {
+  const parts: string[] = [];
+  for (const block of newBlocks) {
+    const span = resolveBlockSpan(block, state.messageRefs.byRaw);
+    parts.push(
+      span ? `${block.blockId}=${span.startRef}–${span.endRef}` : block.blockId,
+    );
+  }
+  return parts.length > 0 ? `blocks: ${parts.join(", ")}` : "";
+}

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -16,6 +16,7 @@ import { truncateLargeToolOutputs } from "./truncate-tools.js";
 import { hideConsumedCompressCalls } from "./hide-consumed.js";
 import { appendAbsorbPrompts, hideAbsorbedMessages } from "./absorb.js";
 import { applyMessageFilters, listMessageFilters } from "./filter/index.js";
+import { activeBlockSpans } from "./block-map.js";
 import { createRenderRefsNode } from "./render-refs.js";
 import type { RenderStrategy } from "./render-refs.js";
 import { isMessageProtected } from "./protected.js";
@@ -1422,6 +1423,7 @@ function decideNudge(input: NudgeInput): NudgeDecision {
     reason,
     compressibleRanges: rec?.recommendedRanges ?? [],
     protectedRanges: rec?.contextRanges.protected ?? [],
+    activeBlockSpans: activeBlockSpans(state),
     tierTargetBlocks: injectedTier ? tiers[injectedTier]!.targetBlocks : [],
     contextUsage: usage,
     tier: injectedTier,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export {
 export type { TokenCountFn } from "./tokenize.js";
 export { renderNudgeText, formatRanges } from "./nudge-text.js";
 export type { NudgeVoice, RenderedNudge } from "./nudge-text.js";
+export { resolveBlockSpan, activeBlockSpans, formatCreatedBlocks } from "./block-map.js";
 export {
   COMPRESS_PHILOSOPHY,
   HOW_TO_COMPRESS_RULES,

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -1,4 +1,4 @@
-import type { NudgeDecision, CompressibleRange, ProtectedRange, ContextBreakdown, CompressionBlock } from "./types.js";
+import type { NudgeDecision, CompressibleRange, ProtectedRange, ContextBreakdown, CompressionBlock, BlockSpan } from "./types.js";
 import { defaultPrompts } from "./prompts.js";
 import type { Prompts } from "./prompts.js";
 
@@ -48,6 +48,19 @@ function formatTierTargetBlocks(blocks: CompressionBlock[]): string {
   return `Target ${blocks[0]!.tier === 1 ? "tier-1" : "tier-2"} blocks to distill (${blocks.length}):\n${lines.join("\n")}`;
 }
 
+const BLOCK_MAP_MAX_SHOWN = 8;
+
+function formatBlockMap(spans: BlockSpan[]): string {
+  if (spans.length === 0) return "";
+  const hidden = Math.max(0, spans.length - BLOCK_MAP_MAX_SHOWN);
+  const shown = hidden > 0 ? spans.slice(-BLOCK_MAP_MAX_SHOWN) : spans;
+  const items = shown.map(
+    (s) => `${s.blockId}=${s.startRef}–${s.endRef}${s.tier > 1 ? ` t${s.tier}` : ""}`,
+  );
+  const prefix = hidden > 0 ? `…+${hidden} older · ` : "";
+  return `Active blocks (${spans.length}): ${prefix}${items.join(" · ")}`;
+}
+
 export function formatRanges(compressible: CompressibleRange[], protectedRanges: ProtectedRange[]): string {
   if (compressible.length === 0 && protectedRanges.length === 0) {
     return "[No specific ranges detected — compress any consumed content.]";
@@ -59,7 +72,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   // and partly protected, which only the merged view shows correctly.
   interface Merged {
     startRef: string; endRef: string; startNum: number; endNum: number;
-    count: number; tokens: number;
+    count: number; tokens: number; userMsgs: number;
     compressibleTokens: number; compressibleCount: number;
     protectedTokens: number; protectedCount: number; protectedTools: string[];
     toolPct: number; textPct: number; dangerous: boolean;
@@ -72,7 +85,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   for (const r of compressible) {
     entries.push({
       startRef: r.startRef, endRef: r.endRef, startNum: refNum(r.startRef), endNum: refNum(r.endRef),
-      count: r.count, tokens: r.tokens, toolPct: r.toolPct, textPct: r.textPct,
+      count: r.count, tokens: r.tokens, userMsgs: r.userMsgs ?? 0, toolPct: r.toolPct, textPct: r.textPct,
       compressibleTokens: r.tokens, compressibleCount: r.count,
       protectedTokens: 0, protectedCount: 0, protectedTools: [], dangerous: r.dangerous ?? false,
     });
@@ -80,7 +93,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   for (const r of protectedRanges) {
     entries.push({
       startRef: r.startRef, endRef: r.endRef, startNum: refNum(r.startRef), endNum: refNum(r.endRef),
-      count: r.count, tokens: r.tokens, toolPct: 0, textPct: 0,
+      count: r.count, tokens: r.tokens, userMsgs: 0, toolPct: 0, textPct: 0,
       compressibleTokens: 0, compressibleCount: 0,
       protectedTokens: r.tokens, protectedCount: r.count, protectedTools: [...r.tools], dangerous: false,
     });
@@ -95,6 +108,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
       last.endNum = Math.max(last.endNum, e.endNum);
       last.count += e.count;
       last.tokens += e.tokens;
+      last.userMsgs += e.userMsgs;
       last.compressibleTokens += e.compressibleTokens;
       last.compressibleCount += e.compressibleCount;
       last.protectedTokens += e.protectedTokens;
@@ -107,15 +121,17 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
       merged.push({ ...e });
     }
   }
+  const userNote = (n: number): string =>
+    n > 0 ? ` · ${n} user msg${n > 1 ? "s" : ""}` : "";
   const lines = merged.map((e) => {
     const suffix = e.dangerous && e.compressibleTokens > 0 ? "  ⚠️ NOT recommended unless you are certain." : "";
     if (e.protectedTokens > 0 && e.compressibleTokens === 0) {
       return `  ${e.startRef}–${e.endRef}  ${e.count} msgs  ${formatK(e.tokens)} [PROTECTED: ${e.protectedTools.join(", ")} — not compressible]${suffix}`;
     }
     if (e.protectedTokens > 0 && e.compressibleTokens > 0) {
-      return `  ${e.startRef}–${e.endRef}  ${e.count} msgs  ${formatK(e.tokens)} [${formatK(e.compressibleTokens)} compressible | ${formatK(e.protectedTokens)} protected: ${e.protectedTools.join(", ")}]${suffix}`;
+      return `  ${e.startRef}–${e.endRef}  ${e.count} msgs  ${formatK(e.tokens)} [${formatK(e.compressibleTokens)} compressible | ${formatK(e.protectedTokens)} protected: ${e.protectedTools.join(", ")}]${userNote(e.userMsgs)}${suffix}`;
     }
-    return `  ${e.startRef}–${e.endRef}  ${e.count} msgs  ${formatK(e.tokens)} [tool ${e.toolPct}% | text ${e.textPct}%]${suffix}`;
+    return `  ${e.startRef}–${e.endRef}  ${e.count} msgs  ${formatK(e.tokens)} [tool ${e.toolPct}% | text ${e.textPct}%]${userNote(e.userMsgs)}${suffix}`;
   });
   return `Compressible ranges (${merged.length}, oldest first):\n${lines.join("\n")}`;
 }
@@ -123,6 +139,7 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
 export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts): RenderedNudge {
   const breakdownStr = formatBreakdown(decision.contextBreakdown);
   const rangesStr = formatRanges(decision.compressibleRanges, decision.protectedRanges ?? []);
+  const blockMapStr = formatBlockMap(decision.activeBlockSpans ?? []);
   const isEmergency = !!decision.breakdown?.emergencyOverride || !!decision.breakdown?.overLimit;
 
   if (decision.tier !== null && decision.tier >= 2) {
@@ -170,6 +187,7 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
         "Only use IDs from visible messages above. Compress older work first.",
         "",
         rangesStr,
+        ...(blockMapStr ? ["", blockMapStr] : []),
       ].join("\n"),
     };
   }
@@ -184,6 +202,7 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
       prompts.howToCompressRules,
       "",
       rangesStr,
+      ...(blockMapStr ? ["", blockMapStr] : []),
       "",
       `💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`,
     ].join("\n"),

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -237,12 +237,14 @@ export function buildCompressibleRanges(
         chars: info.chars,
         toolPct: info.isTool ? 100 : 0,
         textPct: info.isTool ? 0 : 100,
+        userMsgs: info.isUser ? 1 : 0,
       };
     } else {
       cur.endRef = info.ref;
       cur.count++;
       cur.tokens += info.tokens;
       cur.chars = (cur.chars ?? 0) + info.chars;
+      if (info.isUser) cur.userMsgs = (cur.userMsgs ?? 0) + 1;
       if (info.isTool) {
         cur.toolPct = Math.round((cur.toolPct * (cur.count - 1) + 100) / cur.count);
       } else {
@@ -304,6 +306,7 @@ function mergeBatch(batch: CompressibleRange[]): CompressibleRange {
     chars,
     toolPct,
     textPct: 100 - toolPct,
+    userMsgs: batch.reduce((s, r) => s + (r.userMsgs ?? 0), 0),
   };
   if (batch.some((r) => r.dangerous === true)) {
     merged.dangerous = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,14 @@ export interface CompressionBlock {
   endRef?: string;
 }
 
+/** A compression block's current ref span, pre-resolved for display. */
+export interface BlockSpan {
+  blockId: string;
+  tier: CompressionTier;
+  startRef: string;
+  endRef: string;
+}
+
 export interface MessageRefMap {
   byRaw: Record<string, string>;
   byRef: Record<string, string>;
@@ -228,6 +236,11 @@ export interface CompressibleRange {
   toolPct: number;
   textPct: number;
   dangerous?: boolean;
+  /** Count of user-role messages inside this range (set by
+   *  buildCompressibleRanges / mergeRangesToThreshold). Summaries must capture
+   *  every user request, so the count tells the model whether it needs a
+   *  per-message listing before compressing. Absent on hand-built ranges. */
+  userMsgs?: number;
 }
 
 export interface ProtectedRange {
@@ -264,6 +277,12 @@ export interface NudgeDecision {
   reason: string;
   compressibleRanges: CompressibleRange[];
   protectedRanges?: ProtectedRange[];
+  /** Active blocks with their current ref spans (creation order), pre-resolved
+   *  by decideNudge so renderers need no raw state. The nudge lists what to
+   *  compress; this ledger tells where existing blocks already stand, so a
+   *  remembered block boundary can be cross-checked without an acp_status
+   *  round-trip (#251). */
+  activeBlockSpans?: BlockSpan[];
   /** When `tier` is set, the active lower-tier blocks that should be distilled
    *  into a single higher-tier block. Empty when no tier nudge. */
   tierTargetBlocks?: CompressionBlock[];

--- a/tests/block-map.test.ts
+++ b/tests/block-map.test.ts
@@ -5,6 +5,7 @@ import {
   activeBlockSpans,
   formatCreatedBlocks,
 } from "../src/block-map.js";
+import { createCore } from "../src/compress.js";
 import {
   buildCompressibleRanges,
   mergeRangesToThreshold,
@@ -115,6 +116,70 @@ test("resolveBlockSpan sorts numerically, not lexicographically", () => {
 test("resolveBlockSpan returns null when nothing resolves", () => {
   const block = makeBlock({ effectiveMessageIds: ["gone"] });
   assert.equal(resolveBlockSpan(block, {}), null);
+});
+
+test("resolveBlockSpan ignores block-ID specs stored by block-boundary calls", () => {
+  const byRaw: Record<string, string> = {
+    a: "m00001",
+    b: "m00020",
+  };
+  const block = makeBlock({
+    tier: 2,
+    effectiveMessageIds: ["a", "b"],
+    startRef: "b1",
+    endRef: "b2",
+  });
+  assert.deepEqual(resolveBlockSpan(block, byRaw), {
+    startRef: "m00001",
+    endRef: "m00020",
+  });
+});
+
+test("resolveBlockSpan ignores mixed m-ref / block-ID specs", () => {
+  const byRaw: Record<string, string> = {
+    a: "m00001",
+    b: "m00020",
+  };
+  const block = makeBlock({
+    effectiveMessageIds: ["a", "b"],
+    startRef: "b1",
+    endRef: "m00020",
+  });
+  assert.deepEqual(resolveBlockSpan(block, byRaw), {
+    startRef: "m00001",
+    endRef: "m00020",
+  });
+});
+
+test("tier-distilled block created via bN..bM boundaries reports an m-ref span", () => {
+  const core = createCore();
+  let state = createInitialState();
+  const messages = Array.from({ length: 20 }, (_, i) =>
+    msg(`id${i + 1}`, `message ${i + 1}`),
+  );
+  state.messageRefs = assignRefs(messages, {
+    existing: state.messageRefs,
+    nextIndex: 1,
+  }).map;
+  state = core.applyCompression({
+    ranges: [
+      { startRef: "m00001", endRef: "m00010", summary: "first ten" },
+      { startRef: "m00011", endRef: "m00020", summary: "next ten" },
+    ],
+    messages, state, config: config(),
+  }).state;
+  state = core.applyCompression({
+    ranges: [{ startRef: "b1", endRef: "b2", summary: "distilled" }],
+    messages, state, config: config(),
+  }).state;
+  const t2 = state.blocks[state.blocks.length - 1]!;
+  assert.equal(t2.tier, 2);
+  assert.equal(t2.startRef, "b1");
+  assert.equal(t2.endRef, "b2");
+  const spans = activeBlockSpans(state);
+  assert.deepEqual(spans, [
+    { blockId: t2.blockId, tier: 2, startRef: "m00001", endRef: "m00020" },
+  ]);
 });
 
 // ─── activeBlockSpans ─────────────────────────────────────────────────────────

--- a/tests/block-map.test.ts
+++ b/tests/block-map.test.ts
@@ -1,0 +1,195 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveBlockSpan,
+  activeBlockSpans,
+  formatCreatedBlocks,
+} from "../src/block-map.js";
+import {
+  buildCompressibleRanges,
+  mergeRangesToThreshold,
+} from "../src/recommend.js";
+import { computeProtectedRefs } from "../src/recommend.js";
+import { createInitialState } from "../src/state.js";
+import { assignRefs } from "../src/refs.js";
+import type {
+  CompressionBlock,
+  Config,
+  CoreMessage,
+  CompressibleRange,
+} from "../src/types.js";
+import { defaultCountTokens } from "../src/tokenize.js";
+
+function config(): Config {
+  return {
+    tiers: { enabled: true, tier2Trigger: 5, tier3Trigger: 10 },
+    nudge: {
+      maxContextLimitPct: 0.55,
+      minContextLimitPct: 0.45,
+      frequency: 5,
+      iterationThreshold: 15,
+      force: "soft",
+      growthRatio: 0.05,
+    },
+    promotionThreshold: 5,
+    truncate: { threshold: 1 },
+    merge: { maxSummaryLength: 3000, minOldGenBlocks: 3 },
+    compress: { minCompressRange: 0, maxSummaryLength: 0, minSummaryLength: 0 },
+    protectedTools: [],
+    preserveRecentMessages: 0,
+    preserveRecentTokens: 0,
+    modelContextLimit: 100000,
+  };
+}
+
+function msg(id: string, text: string, role: CoreMessage["role"] = "user"): CoreMessage {
+  return { id, role, contentType: "text", text };
+}
+
+function makeState(ids: string[]): ReturnType<typeof createInitialState> {
+  const state = createInitialState();
+  state.messageRefs = assignRefs(
+    ids.map((id) => msg(id, "x")),
+    { existing: state.messageRefs, nextIndex: 1 },
+  ).map;
+  return state;
+}
+
+function makeBlock(overrides: Partial<CompressionBlock> = {}): CompressionBlock {
+  return {
+    blockId: "b1",
+    runId: "r1",
+    tier: 1,
+    summary: "s",
+    directMessageIds: [],
+    effectiveMessageIds: [],
+    directBlockIds: [],
+    compressedTokens: 100,
+    createdAt: Date.now(),
+    survivedCount: 0,
+    generation: "young",
+    active: true,
+    ...overrides,
+  };
+}
+
+// ─── resolveBlockSpan ─────────────────────────────────────────────────────────
+
+test("resolveBlockSpan prefers stored startRef/endRef", () => {
+  const block = makeBlock({
+    effectiveMessageIds: ["a", "b"],
+    startRef: "m00010",
+    endRef: "m00020",
+  });
+  assert.deepEqual(resolveBlockSpan(block, {}), {
+    startRef: "m00010",
+    endRef: "m00020",
+  });
+});
+
+test("resolveBlockSpan falls back to effectiveMessageIds when stored refs missing", () => {
+  const byRaw: Record<string, string> = {
+    a: "m00044",
+    b: "m00001",
+    c: "m00030",
+  };
+  const block = makeBlock({ effectiveMessageIds: ["a", "b", "c"] });
+  assert.deepEqual(resolveBlockSpan(block, byRaw), {
+    startRef: "m00001",
+    endRef: "m00044",
+  });
+});
+
+test("resolveBlockSpan sorts numerically, not lexicographically", () => {
+  const byRaw: Record<string, string> = {
+    a: "m00009",
+    b: "m000100",
+  };
+  const block = makeBlock({ effectiveMessageIds: ["a", "b"] });
+  assert.deepEqual(resolveBlockSpan(block, byRaw), {
+    startRef: "m00009",
+    endRef: "m000100",
+  });
+});
+
+test("resolveBlockSpan returns null when nothing resolves", () => {
+  const block = makeBlock({ effectiveMessageIds: ["gone"] });
+  assert.equal(resolveBlockSpan(block, {}), null);
+});
+
+// ─── activeBlockSpans ─────────────────────────────────────────────────────────
+
+test("activeBlockSpans skips inactive and unresolvable blocks, keeps order", () => {
+  const state = makeState(["a", "b"]);
+  state.blocks = [
+    makeBlock({ blockId: "b1", effectiveMessageIds: ["a"], startRef: "m00001", endRef: "m00001" }),
+    makeBlock({ blockId: "b2", active: false, startRef: "m00002", endRef: "m00002" }),
+    makeBlock({ blockId: "b3", effectiveMessageIds: ["vanished"], tier: 2 }),
+  ];
+  const spans = activeBlockSpans(state);
+  assert.deepEqual(
+    spans.map((s) => s.blockId),
+    ["b1"],
+  );
+});
+
+// ─── formatCreatedBlocks ──────────────────────────────────────────────────────
+
+test("formatCreatedBlocks formats id=span per block", () => {
+  const state = makeState([]);
+  state.blocks = [
+    makeBlock({ blockId: "b3", startRef: "m00044", endRef: "m00097" }),
+    makeBlock({ blockId: "b4", startRef: "m00103", endRef: "m00123" }),
+  ];
+  assert.equal(
+    formatCreatedBlocks(state, [state.blocks[0]!, state.blocks[1]!]),
+    "blocks: b3=m00044–m00097, b4=m00103–m00123",
+  );
+});
+
+test("formatCreatedBlocks falls back to bare id when span unresolvable", () => {
+  const state = makeState([]);
+  const block = makeBlock({ blockId: "b5", effectiveMessageIds: ["gone"] });
+  assert.equal(formatCreatedBlocks(state, [block]), "blocks: b5");
+});
+
+test("formatCreatedBlocks returns empty string for no blocks", () => {
+  assert.equal(formatCreatedBlocks(makeState([]), []), "");
+});
+
+// ─── userMsgs tracking ────────────────────────────────────────────────────────
+
+test("buildCompressibleRanges counts user messages per range", () => {
+  const messages = [
+    msg("u1", "first user request"),
+    msg("a1", "assistant reply", "assistant"),
+    msg("u2", "second user request"),
+    msg("a2", "more assistant", "assistant"),
+  ];
+  const state = makeState(messages.map((m) => m.id));
+  const cfg = config();
+  const protectedRefs = computeProtectedRefs(messages, state, cfg, defaultCountTokens);
+  const ranges = buildCompressibleRanges(
+    messages,
+    state,
+    cfg,
+    protectedRefs,
+    defaultCountTokens,
+  ).compressible;
+  assert.equal(ranges.length, 1);
+  assert.equal(ranges[0]!.userMsgs, 2);
+});
+
+test("mergeRangesToThreshold sums userMsgs across merged ranges", () => {
+  const base = { count: 2, chars: 100, toolPct: 50, textPct: 50, tokens: 500 };
+  const ranges: CompressibleRange[] = [
+    { startRef: "m00001", endRef: "m00002", userMsgs: 1, ...base },
+    { startRef: "m00003", endRef: "m00004", userMsgs: 2, ...base },
+    { startRef: "m00005", endRef: "m00006", ...base },
+  ];
+  const merged = mergeRangesToThreshold(ranges, 1000);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0]!.startRef, "m00001");
+  assert.equal(merged[0]!.endRef, "m00006");
+  assert.equal(merged[0]!.userMsgs, 3);
+});

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { renderNudgeText } from "../src/nudge-text.js";
-import type { NudgeDecision, CompressibleRange } from "../src/types.js";
+import type { NudgeDecision, CompressibleRange, BlockSpan } from "../src/types.js";
 
 function makeRanges(count: number): CompressibleRange[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -173,4 +173,69 @@ test("over-limit renders with emergency voice (MAJOR-2 fix)", () => {
   );
   assert.equal(result.voice, "emergency", "over-limit should use emergency voice, not gentle");
   assert.ok(!result.text.includes("not an overflow warning"), "should NOT contain gentle reassurance");
+});
+
+function makeSpans(n: number): BlockSpan[] {
+  return Array.from({ length: n }, (_, i) => ({
+    blockId: `b${i + 1}`,
+    tier: 1,
+    startRef: `m${String(i * 10 + 1).padStart(5, "0")}`,
+    endRef: `m${String(i * 10 + 9).padStart(5, "0")}`,
+  }));
+}
+
+test("gentle nudge renders active block map", () => {
+  const result = renderNudgeText(makeDecision({ activeBlockSpans: makeSpans(2) }));
+  assert.ok(
+    result.text.includes("Active blocks (2): b1=m00001–m00009 · b2=m00011–m00019"),
+    "should list each active block with its ref span",
+  );
+});
+
+test("block map marks non-tier-1 blocks with tier suffix", () => {
+  const spans = [{ ...makeSpans(1)[0]!, tier: 2 }];
+  const result = renderNudgeText(makeDecision({ activeBlockSpans: spans }));
+  assert.ok(result.text.includes("b1=m00001–m00009 t2"));
+});
+
+test("block map truncates beyond 8 blocks, keeping newest", () => {
+  const result = renderNudgeText(makeDecision({ activeBlockSpans: makeSpans(10) }));
+  assert.ok(result.text.includes("Active blocks (10): …+2 older · "), "should show hidden count");
+  assert.ok(!result.text.includes("b1="), "oldest hidden blocks must not be listed");
+  assert.ok(result.text.includes("b8="));
+  assert.ok(result.text.includes("b10="));
+});
+
+test("no block map line when absent or empty", () => {
+  const r1 = renderNudgeText(makeDecision());
+  assert.ok(!r1.text.includes("Active blocks"), "absent activeBlockSpans → no line");
+  const r2 = renderNudgeText(makeDecision({ activeBlockSpans: [] }));
+  assert.ok(!r2.text.includes("Active blocks"), "empty activeBlockSpans → no line");
+});
+
+test("emergency nudge also renders block map", () => {
+  const result = renderNudgeText(
+    makeDecision({
+      contextUsage: 0.99,
+      breakdown: { emergencyOverride: 1 },
+      activeBlockSpans: makeSpans(1),
+    }),
+  );
+  assert.equal(result.voice, "emergency");
+  assert.ok(result.text.includes("Active blocks (1): b1=m00001–m00009"));
+});
+
+test("range lines annotate user message count", () => {
+  const ranges: CompressibleRange[] = [
+    { startRef: "m00001", endRef: "m00005", count: 5, tokens: 2000, toolPct: 0.5, textPct: 0.5, userMsgs: 3 },
+    { startRef: "m00010", endRef: "m00011", count: 2, tokens: 500, toolPct: 1, textPct: 0, userMsgs: 1 },
+  ];
+  const result = renderNudgeText(makeDecision({ compressibleRanges: ranges }));
+  assert.ok(result.text.includes("· 3 user msgs"));
+  assert.ok(result.text.includes("· 1 user msg"));
+});
+
+test("no user-msg annotation when count is zero or absent", () => {
+  const result = renderNudgeText(makeDecision());
+  assert.ok(!result.text.includes("user msg"), "makeRanges fixtures carry no userMsgs");
 });


### PR DESCRIPTION
## Problem

Root cause of ranxianglei/billion-context-pi#375 (模型不用推荐、自己调 acp_status):

The efficiency nudge lists compressible ranges but **no map of active blocks** (bN → ref span). When the model's remembered block coverage contradicts the listed ranges (e.g. "I thought b2 ended at m00056" vs "m00044–m00097 compressible"), the system prompt mandates verification via `acp_status` before re-compressing — costing an extra ~1–2K-token round-trip plus reconciliation reasoning every time memory diverges.

Secondary gap: range lines show token mix (`[tool 70% | text 30%]`) but never whether **user messages** sit inside the range, so the model can't know from the nudge alone whether it must do a per-message listing to satisfy "capture every user request in the summary".

## Changes

1. **Active block map in nudge text** (gentle + emergency): `Active blocks (2): b1=m00001–m00009 · b2=m00011–m00019`. Non-tier-1 blocks get a `t2`/`t3` suffix; beyond 8 blocks the oldest are collapsed to `…+K older` (newest kept — that's what the model reasons about most). Tier (T2/T3) nudges unchanged: they already list their target blocks.
2. **User-msg count per range**: `· N user msg(s)` appended to compressible/mixed range lines when `userMsgs > 0`. Tracked through `buildCompressibleRanges` and summed by `mergeRangesToThreshold` / the nudge's own adjacent-range merge.
3. **New `src/block-map.ts`** (exported): `resolveBlockSpan(block, byRaw)`, `activeBlockSpans(state)`, `formatCreatedBlocks(state, newBlocks)` → `blocks: b3=m00044–m00097, b4=m00103–m00123`. The third one is the building block for adapters reporting new block spans in the compress tool result (ranxianglei/billion-context-pi#376) — kernel-side half of that fix ships here so both downstream repos adopt it on their next kernel bump.

Ref spans come from each block's stored `startRef`/`endRef` (set at creation; refs are per-session snapshots assigned once, so they stay valid), with fallback to min/max of `effectiveMessageIds` mapped through the current ref table.

## Tests

- `tests/block-map.test.ts` (new): resolveBlockSpan (stored-refs preference, fallback, numeric ordering m00009 < m000100, null), activeBlockSpans filtering/order, formatCreatedBlocks variants, userMsgs counting + merge summing.
- `tests/nudge-text.test.ts`: block map rendering (exact line, tier suffix, truncation, absent/empty, emergency voice), user-msg annotation present/absent.
- 662/662 pass; typecheck + build clean.

Fixes #251