### PR TITLE
release v0.0.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.63",
+    "version": "0.0.64",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.63",
+            "version": "0.0.64",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.63",
+    "version": "0.0.64",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
v0.0.64 ships #253 (merged as 54b8fa0): nudge text now carries the active block map (`Active blocks (N): b1=m00001–m00009 · ...`) plus per-range user-message counts, and exports `src/block-map.ts` (`resolveBlockSpan` / `activeBlockSpans` / `formatCreatedBlocks`) for adapters to report new block spans in compress results.

Preflight on this branch: typecheck clean, 665/665 tests pass, build OK.

Downstream waiting on this publish:
- ranxianglei/billion-context-pi#376 (compress result block spans)
- ranxianglei/billion-context pin bump 0.0.61 → 0.0.64