### PR TITLE
feat(panel): optional localized labels for buildStatusPanel

### DIFF
--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -2,5 +2,7 @@ export { topicFallback } from "./topic.js";
 export { formatCompactTokens } from "./format.js";
 export { buildStatusPanel } from "./panel.js";
 export type { StatusPanelInput } from "./panel.js";
+export { DEFAULT_PANEL_LABELS, displayWidth, fill, padLabel, renderTitleBox } from "./labels.js";
+export type { PanelLabels } from "./labels.js";
 export { cacheHitStats, formatHitRate } from "./cache.js";
 export type { CacheUsageSample, CacheHitSummary } from "./cache.js";

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -2,7 +2,7 @@ export { topicFallback } from "./topic.js";
 export { formatCompactTokens } from "./format.js";
 export { buildStatusPanel } from "./panel.js";
 export type { StatusPanelInput } from "./panel.js";
-export { DEFAULT_PANEL_LABELS, displayWidth, fill, padLabel, renderTitleBox } from "./labels.js";
+export { DEFAULT_PANEL_LABELS, displayWidth, fill, padLabel, renderTitleBox, resolvePanelLabels } from "./labels.js";
 export type { PanelLabels } from "./labels.js";
 export { cacheHitStats, formatHitRate } from "./cache.js";
 export type { CacheUsageSample, CacheHitSummary } from "./cache.js";

--- a/src/panel/labels.ts
+++ b/src/panel/labels.ts
@@ -1,0 +1,126 @@
+/** Display labels for buildStatusPanel. The English defaults below are the
+ *  key source of truth; hosts pass Partial<PanelLabels> to localize the panel
+ *  (billion-context-pi issue #153). This is a DISPLAY-ONLY surface: these
+ *  strings render in the terminal and never reach the model, so translating
+ *  them cannot affect compression/nudge behavior.
+ *
+ *  Templates use `{name}` placeholders filled by fill(). Keys omitted by a
+ *  host pack fall back to the English default per key (partial packs degrade
+ *  gracefully instead of failing wholesale). */
+export interface PanelLabels {
+  /** Title rendered inside the decorative box. */
+  title: string;
+  /** Params: pct (number), used / limit (formatted token counts). */
+  context: string;
+  /** Params: growth (formatted). Line rendered only when growth > 0. */
+  growth: string;
+  /** Params: sent (formatted). */
+  sent: string;
+  /** Params: pct (number). Appended to the sent line only when a context
+   *  limit is configured; omit the placeholder in a pack to drop it. */
+  sentOfLimit: string;
+  /** Params: only (formatted). Line rendered only when unprunedTokens is
+   *  provided and the derived value is positive. */
+  sessionOnly: string;
+  breakdown: string;
+  catTool: string;
+  catSysPrompt: string;
+  catText: string;
+  catCode: string;
+  catSummaries: string;
+  /** Params: last / session (hit-rate strings), read / billed (formatted),
+   *  requests (number). */
+  promptCache: string;
+  /** Params: tierInfo (string, empty when no tier), reason (verbatim model-
+   *  facing text — keep it in your template verbatim). */
+  nudgeActive: string;
+  /** Params: tier (number). */
+  nudgeTierInfo: string;
+  /** Params: reason (verbatim model-facing text). */
+  nudgeIdle: string;
+  /** Params: active / total (numbers), tokens (formatted). Used for both the
+   *  active and zero-active block counts. */
+  blocksHeader: string;
+  /** Rendered when no blocks exist at all. */
+  blocksNone: string;
+  tagVisibility: string;
+}
+
+export const DEFAULT_PANEL_LABELS: PanelLabels = {
+  title: "ACP Context Analysis",
+  context: "Context (session accounting, host footer scale): {pct}% ({used} / {limit}) — includes compressed originals; shrinks slower than the sent view",
+  growth: "Growth: +{growth} since last nudge",
+  sent: "Sent to LLM (after compression, est.): {sent}",
+  sentOfLimit: " ({pct}% of limit)",
+  sessionOnly: "Session-only (compressed originals, est.): {only} — pruned from every request; the footer/nudge still count them",
+  breakdown: "Token Breakdown (sent view):",
+  catTool: "Tool",
+  catSysPrompt: "SysPrompt",
+  catText: "Text",
+  catCode: "Code",
+  catSummaries: "Summaries",
+  promptCache: "Prompt cache (provider-reported): {last} last · {session} session avg — {read} of {billed} billed prompt tokens served from cache ({requests} req)",
+  nudgeActive: "Nudge: ACTIVE{tierInfo} — {reason}",
+  nudgeTierInfo: " [T{tier} distillation]",
+  nudgeIdle: "Nudge: idle — {reason}",
+  blocksHeader: "Blocks: {active} active / {total} total ({tokens} tokens compressed, cumulative)",
+  blocksNone: "Blocks: none (nothing compressed yet)",
+  tagVisibility: "Tag visibility: tags injected to LLM only (deep copy), not persisted in session, not shown in terminal.",
+};
+
+/** Substitute `{name}` placeholders from params. Unknown placeholders are
+ *  left intact so a typo in a host pack is visible on screen instead of
+ *  silently dropping information. */
+export function fill(template: string, params: Record<string, string | number>): string {
+  return template.replace(/\{([A-Za-z][A-Za-z0-9_]*)\}/g, (m, k: string) => (k in params ? String(params[k]) : m));
+}
+
+// Legacy fixed-width title box (inner width 45). Frozen so the default
+// output stays byte-identical for hosts that don't pass labels.
+const LEGACY_TITLE_BOX = [
+  "╭─────────────────────────────────────────────╮",
+  "│           ACP Context Analysis              │",
+  "╰─────────────────────────────────────────────╯",
+];
+const MIN_INNER_WIDTH = 45;
+
+function charDisplayWidth(ch: string): number {
+  const cp = ch.codePointAt(0)!;
+  const wide =
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0xa4cf) || // CJK radicals .. Yi syllables
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK compatibility ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK compatibility forms
+    (cp >= 0xff00 && cp <= 0xff60) || // fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) || // halfwidth/fullwidth forms
+    cp >= 0x20000; // CJK extensions and beyond
+  return wide ? 2 : 1;
+}
+
+export function displayWidth(s: string): number {
+  let w = 0;
+  for (const ch of s) w += charDisplayWidth(ch);
+  return w;
+}
+
+/** Pad s with trailing spaces to a DISPLAY width (wide chars count as two
+ *  columns), keeping bar-chart columns aligned for CJK category labels.
+ *  Identical to String.prototype.padEnd for ASCII input. */
+export function padLabel(s: string, width: number): string {
+  const dw = displayWidth(s);
+  return dw >= width ? s : s + " ".repeat(width - dw);
+}
+
+/** Decorative title box, width-aware so CJK titles stay aligned (wide chars
+ *  occupy two terminal columns). The exact default title renders the legacy
+ *  fixed box; any other title gets a computed box that widens past
+ *  MIN_INNER_WIDTH when the title is long. */
+export function renderTitleBox(title: string): string[] {
+  if (title === DEFAULT_PANEL_LABELS.title) return LEGACY_TITLE_BOX;
+  const dw = displayWidth(title);
+  const inner = Math.max(MIN_INNER_WIDTH, dw + 2);
+  const padL = Math.floor((inner - dw) / 2);
+  const padR = inner - dw - padL;
+  return ["╭" + "─".repeat(inner) + "╮", `│${" ".repeat(padL)}${title}${" ".repeat(padR)}│`, "╰" + "─".repeat(inner) + "╯"];
+}

--- a/src/panel/labels.ts
+++ b/src/panel/labels.ts
@@ -68,6 +68,20 @@ export const DEFAULT_PANEL_LABELS: PanelLabels = {
   tagVisibility: "Tag visibility: tags injected to LLM only (deep copy), not persisted in session, not shown in terminal.",
 };
 
+/** Merge a partial label pack over the English defaults, ignoring entries
+ *  whose value is not a string (explicit `undefined` from a config merge,
+ *  `null`, …). A plain `{ ...defaults, ...pack }` spread lets one undefined
+ *  key blank out its default and crash the display-width renderers. */
+export function resolvePanelLabels(labels?: Partial<PanelLabels>): PanelLabels {
+  const out: PanelLabels = { ...DEFAULT_PANEL_LABELS };
+  if (!labels) return out;
+  for (const key of Object.keys(labels) as Array<keyof PanelLabels>) {
+    const value = labels[key];
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
 /** Substitute `{name}` placeholders from params. Unknown placeholders are
  *  left intact so a typo in a host pack is visible on screen instead of
  *  silently dropping information. */

--- a/src/panel/labels.ts
+++ b/src/panel/labels.ts
@@ -77,7 +77,7 @@ export function resolvePanelLabels(labels?: Partial<PanelLabels>): PanelLabels {
   if (!labels) return out;
   for (const key of Object.keys(labels) as Array<keyof PanelLabels>) {
     const value = labels[key];
-    if (typeof value === "string") out[key] = value;
+    if (typeof value === "string" && Object.hasOwn(DEFAULT_PANEL_LABELS, key)) out[key] = value;
   }
   return out;
 }

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -5,7 +5,7 @@ import { formatCompactTokens } from "./format.js";
 import { topicFallback } from "./topic.js";
 import { viableRanges } from "../viable.js";
 import { cacheHitStats, formatHitRate, type CacheUsageSample } from "./cache.js";
-import { DEFAULT_PANEL_LABELS, fill, padLabel, renderTitleBox, type PanelLabels } from "./labels.js";
+import { fill, padLabel, renderTitleBox, resolvePanelLabels, type PanelLabels } from "./labels.js";
 
 export interface StatusPanelInput {
   /** Adapter identifier for the header, e.g. "billion-context-omp@0.1.6".
@@ -71,7 +71,7 @@ function bar(value: number, total: number, width: number = 20): string {
  *  112k compressed") — that is what issue #18 reported. */
 export function buildStatusPanel(input: StatusPanelInput): string {
   const { tokenCount, state, nudge, modelContextLimit } = input;
-  const L: PanelLabels = { ...DEFAULT_PANEL_LABELS, ...input.labels };
+  const L = resolvePanelLabels(input.labels);
   const fmt = input.fmtTokens ?? formatCompactTokens;
   const bd = nudge?.contextBreakdown;
   const limit = modelContextLimit;

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -5,6 +5,7 @@ import { formatCompactTokens } from "./format.js";
 import { topicFallback } from "./topic.js";
 import { viableRanges } from "../viable.js";
 import { cacheHitStats, formatHitRate, type CacheUsageSample } from "./cache.js";
+import { DEFAULT_PANEL_LABELS, fill, padLabel, renderTitleBox, type PanelLabels } from "./labels.js";
 
 export interface StatusPanelInput {
   /** Adapter identifier for the header, e.g. "billion-context-omp@0.1.6".
@@ -33,6 +34,10 @@ export interface StatusPanelInput {
    *  the host's provider-scale number from an estimate-scale number
    *  invents a third, meaningless scale (issue #18 "看板统计的和拆分的有差异"). */
   unprunedTokens?: number;
+  /** Localized display labels; every key optional, per-key fallback to the
+   *  English defaults (DEFAULT_PANEL_LABELS). Display-only — model-facing
+   *  text is unaffected. */
+  labels?: Partial<PanelLabels>;
   /** Per-request prompt-cache usage (from assistant messages' provider-
    *  reported `usage`). Requests without cache reporting are excluded by
    *  cacheHitStats; when no counted request remains, the section is
@@ -66,6 +71,7 @@ function bar(value: number, total: number, width: number = 20): string {
  *  112k compressed") — that is what issue #18 reported. */
 export function buildStatusPanel(input: StatusPanelInput): string {
   const { tokenCount, state, nudge, modelContextLimit } = input;
+  const L: PanelLabels = { ...DEFAULT_PANEL_LABELS, ...input.labels };
   const fmt = input.fmtTokens ?? formatCompactTokens;
   const bd = nudge?.contextBreakdown;
   const limit = modelContextLimit;
@@ -85,39 +91,39 @@ export function buildStatusPanel(input: StatusPanelInput): string {
 
   const lines: string[] = [];
 
-  lines.push("╭─────────────────────────────────────────────╮");
-  lines.push("│           ACP Context Analysis              │");
-  lines.push("╰─────────────────────────────────────────────╯");
+  lines.push(...renderTitleBox(L.title));
   if (input.version) lines.push(input.version);
   lines.push("");
-  lines.push(`Context (session accounting, host footer scale): ${displayPct}% (${fmt(displayTotal)} / ${fmt(limit)}) — includes compressed originals; shrinks slower than the sent view`);
+  lines.push(fill(L.context, { pct: displayPct, used: fmt(displayTotal), limit: fmt(limit) }));
 
   if (nudge && bd) {
     const growth = bd.growth;
     if (growth > 0 && displayTotal > 0) {
-      lines.push(`Growth: +${fmt(growth)} since last nudge`);
+      lines.push(fill(L.growth, { growth: fmt(growth) }));
     }
     lines.push("");
-    lines.push(`Sent to LLM (after compression, est.): ${fmt(sentTotal)}${limit > 0 ? ` (${sentPct}% of limit)` : ""}`);
+    let sentLine = fill(L.sent, { sent: fmt(sentTotal) });
+    if (limit > 0) sentLine += fill(L.sentOfLimit, { pct: sentPct });
+    lines.push(sentLine);
     if (input.unprunedTokens !== undefined && sessionOnly > 0) {
-      lines.push(`Session-only (compressed originals, est.): ${fmt(sessionOnly)} — pruned from every request; the footer/nudge still count them`);
+      lines.push(fill(L.sessionOnly, { only: fmt(sessionOnly) }));
     }
     lines.push("");
-    lines.push("Token Breakdown (sent view):");
+    lines.push(L.breakdown);
 
     const categories: Array<{ label: string; value: number }> = [
-      { label: "Tool", value: bd.tool },
-      { label: "SysPrompt", value: systemPromptTokens },
-      { label: "Text", value: bd.text },
-      { label: "Code", value: bd.code },
-      { label: "Summaries", value: bd.summaries },
+      { label: L.catTool, value: bd.tool },
+      { label: L.catSysPrompt, value: systemPromptTokens },
+      { label: L.catText, value: bd.text },
+      { label: L.catCode, value: bd.code },
+      { label: L.catSummaries, value: bd.summaries },
     ];
 
     for (const cat of categories) {
       if (cat.value <= 0) continue;
       const pct = sentTotal > 0 ? Math.round((cat.value / sentTotal) * 100) : 0;
       const b = bar(cat.value, sentTotal);
-      lines.push(`  ${cat.label.padEnd(10)} ${b} ${String(pct).padStart(3)}%  ${fmt(cat.value)}`);
+      lines.push(`  ${padLabel(cat.label, 10)} ${b} ${String(pct).padStart(3)}%  ${fmt(cat.value)}`);
     }
   }
 
@@ -126,7 +132,13 @@ export function buildStatusPanel(input: StatusPanelInput): string {
     if (cache.requests > 0 && cache.session !== undefined && cache.last !== undefined) {
       lines.push("");
       lines.push(
-        `Prompt cache (provider-reported): ${formatHitRate(cache.last)} last · ${formatHitRate(cache.session)} session avg — ${fmt(cache.cacheRead)} of ${fmt(cache.billedPrompt)} billed prompt tokens served from cache (${cache.requests} req)`,
+        fill(L.promptCache, {
+          last: formatHitRate(cache.last),
+          session: formatHitRate(cache.session),
+          read: fmt(cache.cacheRead),
+          billed: fmt(cache.billedPrompt),
+          requests: cache.requests,
+        }),
       );
     }
   }
@@ -135,10 +147,10 @@ export function buildStatusPanel(input: StatusPanelInput): string {
 
   if (nudge) {
     if (nudge.shouldInject) {
-      const tierInfo = nudge.tier ? ` [T${nudge.tier} distillation]` : "";
-      lines.push(`Nudge: ACTIVE${tierInfo} — ${nudge.reason}`);
+      const tierInfo = nudge.tier ? fill(L.nudgeTierInfo, { tier: nudge.tier }) : "";
+      lines.push(fill(L.nudgeActive, { tierInfo, reason: nudge.reason }));
     } else {
-      lines.push(`Nudge: idle — ${nudge.reason}`);
+      lines.push(fill(L.nudgeIdle, { reason: nudge.reason }));
     }
   }
 
@@ -151,7 +163,7 @@ export function buildStatusPanel(input: StatusPanelInput): string {
 
   if (activeBlocksList.length > 0) {
     lines.push("");
-    lines.push(`Blocks: ${activeBlocksList.length} active / ${totalBlocksList.length} total (${fmt(state.stats.tokensCompressed)} tokens compressed, cumulative)`);
+    lines.push(fill(L.blocksHeader, { active: activeBlocksList.length, total: totalBlocksList.length, tokens: fmt(state.stats.tokensCompressed) }));
     for (const b of activeBlocksList) {
       const topic = b.topic ? `: ${b.topic}` : `: ${topicFallback(b.summary || "")}`;
       const summaryTok = defaultCountTokens(b.summary || "");
@@ -160,14 +172,14 @@ export function buildStatusPanel(input: StatusPanelInput): string {
     }
   } else if (totalBlocksList.length > 0) {
     lines.push("");
-    lines.push(`Blocks: 0 active / ${totalBlocksList.length} total (${fmt(state.stats.tokensCompressed)} tokens compressed, cumulative)`);
+    lines.push(fill(L.blocksHeader, { active: 0, total: totalBlocksList.length, tokens: fmt(state.stats.tokensCompressed) }));
   } else {
     lines.push("");
-    lines.push("Blocks: none (nothing compressed yet)");
+    lines.push(L.blocksNone);
   }
 
   lines.push("");
-  lines.push("Tag visibility: tags injected to LLM only (deep copy), not persisted in session, not shown in terminal.");
+  lines.push(L.tagVisibility);
 
   return lines.join("\n");
 }

--- a/tests/panel-labels.test.ts
+++ b/tests/panel-labels.test.ts
@@ -1,0 +1,194 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildStatusPanel,
+  DEFAULT_PANEL_LABELS,
+  displayWidth,
+  fill,
+  padLabel,
+  renderTitleBox,
+  type PanelLabels,
+  type StatusPanelInput,
+} from "../src/panel/index.js";
+
+function fixture(): StatusPanelInput {
+  const nudge = {
+    shouldInject: true,
+    reason: "ctx high",
+    tier: 2,
+    compressibleRanges: [],
+    contextUsage: 0.43,
+    breakdown: { emergencyOverride: 0 },
+    contextBreakdown: { system: 0, tool: 20_000, text: 4_000, code: 3_000, summaries: 1_000, total: 28_000, growth: 6_100 },
+  };
+  const state = {
+    blocks: [
+      { blockId: "b1", tier: 1, active: true, summary: "Some topic here.", compressedTokens: 25_000, effectiveMessageIds: [], coveredRawIds: [], createdAt: 1 },
+    ],
+    messageRefs: { byRaw: {}, byRef: {} },
+    nudge: {},
+    stats: { tokensCompressed: 25_000 },
+    nextBlockId: 2,
+    nextRunId: 1,
+  };
+  return {
+    version: "test@1",
+    tokenCount: 430_000,
+    systemPromptTokens: 2_000,
+    state: state as never,
+    nudge: nudge as never,
+    modelContextLimit: 1_000_000,
+    unprunedTokens: 134_000,
+    cacheUsages: [{ input: 5_000, cacheRead: 9_000, cacheWrite: 1_000 }],
+  };
+}
+
+test("labels: {} renders byte-identical to no labels", () => {
+  const base = fixture();
+  const plain = buildStatusPanel(base);
+  const empty = buildStatusPanel({ ...base, labels: {} });
+  assert.equal(empty, plain);
+});
+
+test("default title renders the legacy fixed box verbatim", () => {
+  const text = buildStatusPanel(fixture());
+  assert.ok(text.includes("╭─────────────────────────────────────────────╮"));
+  assert.ok(text.includes("│           ACP Context Analysis              │"));
+  assert.ok(text.includes("╰─────────────────────────────────────────────╯"));
+});
+
+test("custom title gets a display-width-aware box (CJK counts double)", () => {
+  const title = "ACP 上下文分析";
+  const [top, mid, bottom] = renderTitleBox(title);
+  assert.equal(top, "╭" + "─".repeat(45) + "╮");
+  // display width 14 (3 ascii + 1 space + 5×2 cjk) → padL 15, padR 16
+  assert.equal(mid, `│${" ".repeat(15)}${title}${" ".repeat(16)}│`);
+  assert.equal(bottom, "╰" + "─".repeat(45) + "╯");
+  const text = buildStatusPanel({ ...fixture(), labels: { title } });
+  assert.ok(text.startsWith(top));
+});
+
+test("long title widens the box past the minimum inner width", () => {
+  const title = "一二三四五六七八九十一二三四五六七八九十甲乙";
+  const [top, mid] = renderTitleBox(title);
+  assert.equal(displayWidth(title), 44);
+  assert.equal(top, "╭" + "─".repeat(46) + "╮");
+  assert.equal(mid, `│ ${title} │`);
+});
+
+test("per-key fallback: overriding only title leaves other lines English", () => {
+  const text = buildStatusPanel({ ...fixture(), labels: { title: "X" } });
+  assert.match(text, /Context \(session accounting, host footer scale\): 43%/);
+  assert.match(text, /Token Breakdown \(sent view\):/);
+  assert.match(text, /Tag visibility:/);
+});
+
+test("full pack substitutes every templated section", () => {
+  const labels: PanelLabels = {
+    title: "T",
+    context: "CTX:{pct}|{used}|{limit}",
+    growth: "GRW:{growth}",
+    sent: "SENT:{sent}",
+    sentOfLimit: "<{pct}>",
+    sessionOnly: "ONLY:{only}",
+    breakdown: "BD:",
+    catTool: "TOOL",
+    catSysPrompt: "SYS",
+    catText: "TXT",
+    catCode: "CODE",
+    catSummaries: "SUM",
+    promptCache: "PC:{last}|{session}|{read}|{billed}|{requests}",
+    nudgeActive: "NA{tierInfo}::{reason}",
+    nudgeTierInfo: "[T{tier}]",
+    nudgeIdle: "NI::{reason}",
+    blocksHeader: "BLK:{active}/{total}/{tokens}",
+    blocksNone: "BLK-NONE",
+    tagVisibility: "TV",
+  };
+  const text = buildStatusPanel({ ...fixture(), labels });
+  const lines = text.split("\n");
+  assert.ok(lines.includes("CTX:43|430k|1.0M"), text);
+  assert.ok(lines.includes("GRW:6.1k"), text);
+  assert.ok(lines.includes("SENT:30k<3>"), text);
+  assert.ok(lines.includes("ONLY:104k"), text);
+  assert.ok(lines.includes("BD:"), text);
+  const toolLine = lines.find((l) => l.trim().startsWith("TOOL"))!;
+  assert.match(toolLine, /67%.*20k/);
+  const sysLine = lines.find((l) => l.trim().startsWith("SYS "))!;
+  assert.match(sysLine, /7%.*2\.0k/);
+  assert.ok(lines.includes("PC:60.0%|60.0%|9.0k|15k|1"), text);
+  assert.ok(lines.includes("NA[T2]::ctx high"), text);
+  assert.ok(lines.includes("BLK:1/1/25k"), text);
+  assert.ok(lines.includes("TV"), text);
+  // per-block line stays structural (ids/tier/topic untranslated); topic falls back to topicFallback (first sentence segment)
+  assert.ok(lines.some((l) => l.includes("[b1] T1 25k→") && l.endsWith(": Some topic here")), text);
+});
+
+test("idle nudge uses nudgeIdle without tier info", () => {
+  const base = fixture();
+  const nudge = { ...(base.nudge as object), shouldInject: false, tier: null, reason: "all quiet" };
+  const text = buildStatusPanel({ ...base, nudge: nudge as never, labels: { nudgeIdle: "NI::{reason}" } });
+  assert.ok(text.includes("NI::all quiet"), text);
+  assert.doesNotMatch(text, /NA/);
+});
+
+test("sentOfLimit omitted when no context limit configured", () => {
+  const text = buildStatusPanel({ ...fixture(), modelContextLimit: 0, labels: { sentOfLimit: "ZZZ{pct}" } });
+  assert.doesNotMatch(text, /ZZZ/);
+  assert.doesNotMatch(text, /% of limit/);
+  assert.match(text, /Sent to LLM \(after compression, est\.\): 30k$/m);
+});
+
+test("zero-active blocks reuse the blocksHeader template", () => {
+  const base = fixture();
+  const state = { ...(base.state as object), blocks: [(base.state as { blocks: unknown[] }).blocks.map((b) => ({ ...(b as object), active: false }))] };
+  const text = buildStatusPanel({ ...base, state: state as never, nudge: undefined, labels: { blocksHeader: "BLK:{active}/{total}/{tokens}" } });
+  assert.ok(text.includes("BLK:0/1/25k"), text);
+});
+
+test("blocksNone renders when no blocks exist at all", () => {
+  const base = fixture();
+  const state = { ...(base.state as object), blocks: [] };
+  const text = buildStatusPanel({ ...base, state: state as never, nudge: undefined, labels: { blocksNone: "BLK-NONE" } });
+  assert.ok(text.includes("BLK-NONE"), text);
+  assert.doesNotMatch(text, /Blocks:/);
+});
+
+test("fill substitutes known placeholders and preserves unknown ones", () => {
+  assert.equal(fill("{a}-{b}", { a: 1, b: "x" }), "1-x");
+  assert.equal(fill("{a}{unknown}", { a: "v" }), "v{unknown}");
+  assert.equal(fill("no placeholders", {}), "no placeholders");
+});
+
+test("padLabel matches padEnd for ASCII and pads CJK by display width", () => {
+  assert.equal(padLabel("Tool", 10), "Tool".padEnd(10));
+  assert.equal(padLabel("工具", 10), "工具" + " ".repeat(6));
+  assert.equal(padLabel("一个很长的标签", 6), "一个很长的标签");
+  assert.equal(displayWidth("abc"), 3);
+  assert.equal(displayWidth("中文"), 4);
+});
+
+test("DEFAULT_PANEL_LABELS keys cover every template used by the panel", () => {
+  const keys = Object.keys(DEFAULT_PANEL_LABELS).sort();
+  assert.deepEqual(keys, [
+    "blocksHeader",
+    "blocksNone",
+    "breakdown",
+    "catCode",
+    "catSummaries",
+    "catSysPrompt",
+    "catText",
+    "catTool",
+    "context",
+    "growth",
+    "nudgeActive",
+    "nudgeIdle",
+    "nudgeTierInfo",
+    "promptCache",
+    "sent",
+    "sentOfLimit",
+    "sessionOnly",
+    "tagVisibility",
+    "title",
+  ]);
+});

--- a/tests/panel-labels.test.ts
+++ b/tests/panel-labels.test.ts
@@ -7,6 +7,7 @@ import {
   fill,
   padLabel,
   renderTitleBox,
+  resolvePanelLabels,
   type PanelLabels,
   type StatusPanelInput,
 } from "../src/panel/index.js";
@@ -191,4 +192,19 @@ test("DEFAULT_PANEL_LABELS keys cover every template used by the panel", () => {
     "tagVisibility",
     "title",
   ]);
+});
+
+test("non-string label values fall back to the English default", () => {
+  const base = fixture();
+  const text = buildStatusPanel({ ...base, labels: { title: undefined, context: "CTX:{pct}", sentOfLimit: null as unknown as string } });
+  assert.ok(text.includes("ACP Context Analysis"), text);
+  assert.ok(text.includes("CTX:43"), text);
+  assert.match(text, /% of limit/);
+});
+
+test("resolvePanelLabels merges only string entries over the defaults", () => {
+  const r = resolvePanelLabels({ title: undefined, context: "X", blocksNone: null as unknown as string });
+  assert.equal(r.title, DEFAULT_PANEL_LABELS.title);
+  assert.equal(r.context, "X");
+  assert.equal(r.blocksNone, DEFAULT_PANEL_LABELS.blocksNone);
 });

--- a/tests/panel-labels.test.ts
+++ b/tests/panel-labels.test.ts
@@ -202,9 +202,20 @@ test("non-string label values fall back to the English default", () => {
   assert.match(text, /% of limit/);
 });
 
-test("resolvePanelLabels merges only string entries over the defaults", () => {
+test("resolvePanelLabels merges only known string entries over the defaults", () => {
   const r = resolvePanelLabels({ title: undefined, context: "X", blocksNone: null as unknown as string });
   assert.equal(r.title, DEFAULT_PANEL_LABELS.title);
   assert.equal(r.context, "X");
   assert.equal(r.blocksNone, DEFAULT_PANEL_LABELS.blocksNone);
+
+  const r2 = resolvePanelLabels({ title: 42 as unknown as string, growth: new String("G"), tagVisibility: "TV2" });
+  assert.equal(r2.title, DEFAULT_PANEL_LABELS.title);
+  assert.equal(r2.growth, DEFAULT_PANEL_LABELS.growth);
+  assert.equal(r2.tagVisibility, "TV2");
+
+  const typoPack = { typoKey: "x", title: "T" } as unknown as Partial<PanelLabels>;
+  const r3 = resolvePanelLabels(typoPack);
+  assert.equal(r3.title, "T");
+  assert.ok(!("typoKey" in r3));
+  assert.deepEqual(Object.keys(resolvePanelLabels()).sort(), Object.keys(DEFAULT_PANEL_LABELS).sort());
 });


### PR DESCRIPTION
## Problem

`buildStatusPanel` hardcodes every user-facing label in English. Adapters that want a localized /acp dashboard (ranxianglei/billion-context-pi#153) cannot translate the panel without patching kernel internals.

## Change

- `StatusPanelInput` gains optional `labels?: Partial<PanelLabels>` — 19 section-header keys (title, context, growth, sent, sentOfLimit, sessionOnly, breakdown, 5 category names, promptCache, nudgeActive/nudgeTierInfo/nudgeIdle, blocksHeader/blocksNone, tagVisibility), each substituting `{placeholder}` params.
- **Per-key fallback**: omit any key and it renders the English default (`DEFAULT_PANEL_LABELS`, exported). Omit `labels` entirely and output is **byte-identical** to before — verified by a dedicated test.
- **Display-only**: per-block lines and the compressible-ranges section stay structural (block/message IDs are never translated). Model-facing text is untouched.
- New exports from `acp-kernel/panel`: `DEFAULT_PANEL_LABELS`, `PanelLabels`, `fill`, `displayWidth`, `padLabel`, `renderTitleBox`.
- Title box is width-aware: CJK titles pad correctly (display-width based); non-default titles get a computed box; the exact default title reuses the frozen legacy box so existing dashboards do not shift.
- `fill()` leaves unknown `{placeholders}` intact instead of crashing (typo in a pack stays visible).

## Verification

- `npm run typecheck` clean; `npm test` 678/678 pass (13 new tests: byte-identical default, legacy box verbatim, CJK box geometry, long-title widening, per-key fallback, full marker pack, idle nudge, sentOfLimit omission at limit=0, zero-active/none block branches, fill/pad/displayWidth units, key-list integrity); `npm run build` OK.

## Release note

Additive only — safe for v0.0.65. Hosts not passing `labels` see zero behavior change (omp included). billion-context-pi P-B (language packs + config + detection chain) lands after this ships on npm.