### PR TITLE
feat(nudge): surface overrides for guidance sections — NudgePromptSections

### DIFF
--- a/DESIGN-prompts.md
+++ b/DESIGN-prompts.md
@@ -43,6 +43,13 @@ passes everywhere, so both layers render the same customized text.
 
 ## Layer 0 — kernel override interface (shipped)
 
+> Nudge surface sections (companion to this layer): `renderNudgeText` accepts a
+> third argument `NudgePromptSections` — `efficiencyNote` / `emergencyHeader` /
+> `t2Guidance` / `t3Guidance` with the same tri-state semantics
+> (`string` = replace, `null` = remove, omitted = default). These are the
+> guidance-class nudge texts (surface, no risk gate); trigger lines, renderer
+> labels and tool feedback stay contract-locked. See `src/nudge-text.ts`.
+
 Scope: open the 4 load-bearing rules for override, behind a risk gate. No
 default wording changes; pure additive.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export {
 } from "./tokenize.js";
 export type { TokenCountFn } from "./tokenize.js";
 export { renderNudgeText, formatRanges } from "./nudge-text.js";
-export type { NudgeVoice, RenderedNudge } from "./nudge-text.js";
+export type { NudgeVoice, RenderedNudge, NudgePromptSections } from "./nudge-text.js";
 export { resolveBlockSpan, activeBlockSpans, formatCreatedBlocks } from "./block-map.js";
 export {
   COMPRESS_PHILOSOPHY,

--- a/src/nudge-text.ts
+++ b/src/nudge-text.ts
@@ -4,16 +4,25 @@ import type { Prompts } from "./prompts.js";
 
 export type NudgeVoice = "gentle" | "emergency";
 
+export interface NudgePromptSections {
+  efficiencyNote?: string | null;
+  emergencyHeader?: string | null;
+  t2Guidance?: string | null;
+  t3Guidance?: string | null;
+}
+
 export interface RenderedNudge {
   voice: NudgeVoice;
   text: string;
 }
 
-function efficiencyNote(prompts: Prompts): string {
+function efficiencyNote(prompts: Prompts, sections: NudgePromptSections): string | null {
+  if (sections.efficiencyNote !== undefined) return sections.efficiencyNote;
   return `This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${prompts.compressPhilosophy}`;
 }
 
-function emergencyHeader(prompts: Prompts): string {
+function emergencyHeader(prompts: Prompts, sections: NudgePromptSections): string | null {
+  if (sections.emergencyHeader !== undefined) return sections.emergencyHeader;
   return `⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n${prompts.compressPhilosophy}`;
 }
 
@@ -136,7 +145,22 @@ export function formatRanges(compressible: CompressibleRange[], protectedRanges:
   return `Compressible ranges (${merged.length}, oldest first):\n${lines.join("\n")}`;
 }
 
-export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts): RenderedNudge {
+const DEFAULT_T2_GUIDANCE = `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`;
+
+const DEFAULT_T3_GUIDANCE = `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`;
+
+function tierGuidance(tier: 2 | 3, sections: NudgePromptSections): string | null {
+  const value = tier === 2 ? sections.t2Guidance : sections.t3Guidance;
+  if (value !== undefined) return value;
+  return tier === 2 ? DEFAULT_T2_GUIDANCE : DEFAULT_T3_GUIDANCE;
+}
+
+function compact(parts: string[]): string[] {
+  while (parts.length > 0 && parts[0] === "") parts.shift();
+  return parts;
+}
+
+export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defaultPrompts, sections: NudgePromptSections = {}): RenderedNudge {
   const breakdownStr = formatBreakdown(decision.contextBreakdown);
   const rangesStr = formatRanges(decision.compressibleRanges, decision.protectedRanges ?? []);
   const blockMapStr = formatBlockMap(decision.activeBlockSpans ?? []);
@@ -152,32 +176,33 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
     const triggerLine = isEmergency
       ? `[EMERGENCY — TIER ${decision.tier} ${isT2 ? "DISTILLATION" : "CONDENSATION"}] Context limit reached — distill NOW into a denser summary to reclaim tokens.`
       : `[TIER ${decision.tier} ${isT2 ? "DISTILLATION" : "CONDENSATION"} TRIGGER]`;
+    const guidance = tierGuidance(isT2 ? 2 : 3, sections);
+    const head = efficiencyNote(prompts, sections);
     return {
       voice,
-      text: [
-        efficiencyNote(prompts),
+      text: compact([
+        ...(head === null ? [] : [head]),
         "",
         breakdownStr,
         "",
         triggerLine,
-        isT2
-          ? `Your tier-1 compression summaries have accumulated. Distill them into a single denser tier-2 summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-2 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 2 distillation rules to the existing summaries, so the whole span is covered and nothing is lost.`
-          : `Your tier-2 compression summaries have accumulated. Condense them further into a tier-3 ultra-condensed summary. Use block IDs as boundaries (startId and endId as bN). Any raw (uncompressed) messages sitting between the boundary blocks are absorbed into the tier-3 block as well — apply HOW TO COMPRESS to those raw messages and the TIER 3 condensation rules to the existing summaries, so the whole span is covered and nothing is lost.`,
+        ...(guidance === null ? [] : [guidance]),
         blockList,
         `Example: compress({ content: [{ startId: "${startId}", endId: "${endId}", summary: "..." }] })`,
         "",
         prompts.howToCompressRules,
         "",
         isT2 ? prompts.tier2DistillRules : prompts.tier3CondenseRules,
-      ].join("\n"),
+      ]).join("\n"),
     };
   }
 
   if (isEmergency) {
+    const head = emergencyHeader(prompts, sections);
     return {
       voice: "emergency",
-      text: [
-        emergencyHeader(prompts),
+      text: compact([
+        ...(head === null ? [] : [head]),
         "",
         breakdownStr,
         "",
@@ -188,14 +213,15 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
         "",
         rangesStr,
         ...(blockMapStr ? ["", blockMapStr] : []),
-      ].join("\n"),
+      ]).join("\n"),
     };
   }
 
+  const gentleHead = efficiencyNote(prompts, sections);
   return {
     voice: "gentle",
-    text: [
-      efficiencyNote(prompts),
+    text: compact([
+      ...(gentleHead === null ? [] : [gentleHead]),
       "",
       breakdownStr,
       "",
@@ -205,6 +231,6 @@ export function renderNudgeText(decision: NudgeDecision, prompts: Prompts = defa
       ...(blockMapStr ? ["", blockMapStr] : []),
       "",
       `💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`,
-    ].join("\n"),
+    ]).join("\n"),
   };
 }

--- a/tests/nudge-sections.test.ts
+++ b/tests/nudge-sections.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { resolvePrompts } from "../src/prompts.js";
 import { renderNudgeText } from "../src/nudge-text.js";
 
-const decision = (opts: { emergency?: boolean; tier?: 2 | 3 | null } = {}): Parameters<typeof renderNudgeText>[0] => ({
+const decision = (
+  opts: { emergency?: boolean; tier?: 2 | 3 | null } = {},
+): Parameters<typeof renderNudgeText>[0] => ({
   shouldInject: true,
   reason: "test",
   compressibleRanges: [],
@@ -24,9 +27,25 @@ const decision = (opts: { emergency?: boolean; tier?: 2 | 3 | null } = {}): Para
     pendingT2: 0,
     pendingT3: 0,
   },
-  contextBreakdown: { system: 1000, tool: 2000, summaries: 0, code: 500, text: 300, growth: 100 },
+  contextBreakdown: {
+    system: 1000,
+    tool: 2000,
+    summaries: 0,
+    code: 500,
+    text: 300,
+    growth: 100,
+  },
   tierTargetBlocks: opts.tier
-    ? [{ blockId: "b1", tier: 1, effectiveMessageIds: ["m1", "m2"], compressedTokens: 2000, summary: "x".repeat(400), topic: "t" }]
+    ? [
+        {
+          blockId: "b1",
+          tier: 1,
+          effectiveMessageIds: ["m1", "m2"],
+          compressedTokens: 2000,
+          summary: "x".repeat(400),
+          topic: "t",
+        },
+      ]
     : undefined,
 });
 
@@ -36,47 +55,66 @@ test("default renders keep guidance sections (omitted overrides)", () => {
   const emergency = renderNudgeText(decision({ emergency: true }));
   assert.ok(emergency.text.includes("⚠️ Context limit reached"));
   const t2 = renderNudgeText(decision({ tier: 2 }));
-  assert.ok(t2.text.includes("Your tier-1 compression summaries have accumulated"));
+  assert.ok(
+    t2.text.includes("Your tier-1 compression summaries have accumulated"),
+  );
   const t3 = renderNudgeText(decision({ tier: 3 }));
-  assert.ok(t3.text.includes("Your tier-2 compression summaries have accumulated"));
+  assert.ok(
+    t3.text.includes("Your tier-2 compression summaries have accumulated"),
+  );
 });
 
 test("string override replaces the whole section including its framing", () => {
-  const gentle = renderNudgeText(decision(), undefined, { efficiencyNote: "SHORT." });
+  const gentle = renderNudgeText(decision(), undefined, {
+    efficiencyNote: "SHORT.",
+  });
   assert.ok(gentle.text.includes("SHORT."));
   assert.ok(!gentle.text.includes("efficiency nudge"));
   assert.ok(!gentle.text.includes("Compression Philosophy"));
-  const emergency = renderNudgeText(decision({ emergency: true }), undefined, { emergencyHeader: "NOW!" });
+  const emergency = renderNudgeText(decision({ emergency: true }), undefined, {
+    emergencyHeader: "NOW!",
+  });
   assert.ok(emergency.text.includes("NOW!"));
   assert.ok(!emergency.text.includes("⚠️ Context limit reached"));
 });
 
 test("null override removes the section without leaving blank-line artifacts", () => {
-  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, { t2Guidance: null });
+  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, {
+    t2Guidance: null,
+  });
   assert.ok(!t2.text.includes("tier-1 compression summaries have accumulated"));
   assert.ok(!t2.text.includes("\n\n\n"));
   assert.ok(t2.text.includes("TIER 2 DISTILLATION"));
   assert.ok(t2.text.includes("Target tier-1 blocks"));
-  const gentle = renderNudgeText(decision(), undefined, { efficiencyNote: null });
+  const gentle = renderNudgeText(decision(), undefined, {
+    efficiencyNote: null,
+  });
   assert.ok(!gentle.text.includes("efficiency nudge"));
   assert.ok(gentle.text.startsWith("Context breakdown:"));
 });
 
 test("t3 null and t2 replace are independent", () => {
-  const t3 = renderNudgeText(decision({ tier: 3 }), undefined, { t3Guidance: null });
+  const t3 = renderNudgeText(decision({ tier: 3 }), undefined, {
+    t3Guidance: null,
+  });
   assert.ok(!t3.text.includes("ultra-condensed summary"));
-  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, { t2Guidance: "CUSTOM-T2" });
+  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, {
+    t2Guidance: "CUSTOM-T2",
+  });
   assert.ok(t2.text.includes("CUSTOM-T2"));
   assert.ok(!t2.text.includes("Distill them into a single denser"));
 });
 
 test("custom prompts still flow through default framings", () => {
-  const prompts = {
-    compressPhilosophy: "MY-PHILOSOPHY",
-    howToCompressRules: "MY-RULES",
-    tier2DistillRules: "MY-T2-RULES",
-    tier3CondenseRules: "MY-T3-RULES",
-  } as Parameters<typeof renderNudgeText>[1];
+  const prompts = resolvePrompts(
+    {
+      compressPhilosophy: "MY-PHILOSOPHY",
+      howToCompressRules: "MY-RULES",
+      tier2DistillRules: "MY-T2-RULES",
+      tier3CondenseRules: "MY-T3-RULES",
+    },
+    { acknowledgeRisk: true },
+  );
   const gentle = renderNudgeText(decision(), prompts);
   assert.ok(gentle.text.includes("MY-PHILOSOPHY"));
   assert.ok(gentle.text.includes("MY-RULES"));

--- a/tests/nudge-sections.test.ts
+++ b/tests/nudge-sections.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderNudgeText } from "../src/nudge-text.js";
+
+const decision = (opts: { emergency?: boolean; tier?: 2 | 3 | null } = {}): Parameters<typeof renderNudgeText>[0] => ({
+  shouldInject: true,
+  reason: "test",
+  compressibleRanges: [],
+  protectedRanges: [],
+  activeBlockSpans: [],
+  contextUsage: 0.5,
+  tier: opts.tier ?? null,
+  breakdown: {
+    usage: 0.5,
+    growth: 100,
+    growthReference: 1,
+    effectiveThreshold: 0.75,
+    nudgeGrowthTokens: 500,
+    growthFloor: 200,
+    hasPendingNudge: 0,
+    overLimit: opts.emergency ? 1 : 0,
+    emergencyOverride: 0,
+    pendingT1: 0,
+    pendingT2: 0,
+    pendingT3: 0,
+  },
+  contextBreakdown: { system: 1000, tool: 2000, summaries: 0, code: 500, text: 300, growth: 100 },
+  tierTargetBlocks: opts.tier
+    ? [{ blockId: "b1", tier: 1, effectiveMessageIds: ["m1", "m2"], compressedTokens: 2000, summary: "x".repeat(400), topic: "t" }]
+    : undefined,
+});
+
+test("default renders keep guidance sections (omitted overrides)", () => {
+  const gentle = renderNudgeText(decision());
+  assert.ok(gentle.text.includes("This is an efficiency nudge"));
+  const emergency = renderNudgeText(decision({ emergency: true }));
+  assert.ok(emergency.text.includes("⚠️ Context limit reached"));
+  const t2 = renderNudgeText(decision({ tier: 2 }));
+  assert.ok(t2.text.includes("Your tier-1 compression summaries have accumulated"));
+  const t3 = renderNudgeText(decision({ tier: 3 }));
+  assert.ok(t3.text.includes("Your tier-2 compression summaries have accumulated"));
+});
+
+test("string override replaces the whole section including its framing", () => {
+  const gentle = renderNudgeText(decision(), undefined, { efficiencyNote: "SHORT." });
+  assert.ok(gentle.text.includes("SHORT."));
+  assert.ok(!gentle.text.includes("efficiency nudge"));
+  assert.ok(!gentle.text.includes("Compression Philosophy"));
+  const emergency = renderNudgeText(decision({ emergency: true }), undefined, { emergencyHeader: "NOW!" });
+  assert.ok(emergency.text.includes("NOW!"));
+  assert.ok(!emergency.text.includes("⚠️ Context limit reached"));
+});
+
+test("null override removes the section without leaving blank-line artifacts", () => {
+  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, { t2Guidance: null });
+  assert.ok(!t2.text.includes("tier-1 compression summaries have accumulated"));
+  assert.ok(!t2.text.includes("\n\n\n"));
+  assert.ok(t2.text.includes("TIER 2 DISTILLATION"));
+  assert.ok(t2.text.includes("Target tier-1 blocks"));
+  const gentle = renderNudgeText(decision(), undefined, { efficiencyNote: null });
+  assert.ok(!gentle.text.includes("efficiency nudge"));
+  assert.ok(gentle.text.startsWith("Context breakdown:"));
+});
+
+test("t3 null and t2 replace are independent", () => {
+  const t3 = renderNudgeText(decision({ tier: 3 }), undefined, { t3Guidance: null });
+  assert.ok(!t3.text.includes("ultra-condensed summary"));
+  const t2 = renderNudgeText(decision({ tier: 2 }), undefined, { t2Guidance: "CUSTOM-T2" });
+  assert.ok(t2.text.includes("CUSTOM-T2"));
+  assert.ok(!t2.text.includes("Distill them into a single denser"));
+});
+
+test("custom prompts still flow through default framings", () => {
+  const prompts = {
+    compressPhilosophy: "MY-PHILOSOPHY",
+    howToCompressRules: "MY-RULES",
+    tier2DistillRules: "MY-T2-RULES",
+    tier3CondenseRules: "MY-T3-RULES",
+  } as Parameters<typeof renderNudgeText>[1];
+  const gentle = renderNudgeText(decision(), prompts);
+  assert.ok(gentle.text.includes("MY-PHILOSOPHY"));
+  assert.ok(gentle.text.includes("MY-RULES"));
+});


### PR DESCRIPTION
承接 #252(billion-context-pi)综合审计的"引导类大头"部分,与 #169(surface-config)互补 — #169 管常驻 prompt 分区与工具 schema 文本,本 PR 管 **nudge 注入文本**。

## 开放的 4 个键(`renderNudgeText` 第三参数,三态语义:string=替换 / null=删除 / 缺省=默认)

| 键 | 内容 | 默认大小 |
|---|---|---|
| `efficiencyNote` | gentle/tier nudge 开场框定(含 compressPhilosophy 内嵌) | ~200+philosophy |
| `emergencyHeader` | emergency nudge 开场框定 | ~120+philosophy |
| `t2Guidance` | T2 蒸馏引导段 | ~560 |
| `t3Guidance` | T3 凝缩引导段 | ~540 |

## 明确不开放(契约锁定,审计结论)

- 触发行(`[TIER 2 DISTILLATION TRIGGER]` 等)— 宿主侧熔断/模式识别依赖
- 渲染器标签(ranges/breakdown/block map 格式)— 归 #255 本地化层
- compress 工具反馈/错误文本 — 恢复闭环契约

## 保证

- **默认输出逐字节一致**:四 voice(gentle/emergency/t2/t3)与改动前构建输出逐一比对 IDENTICAL
- null 删除不留空行残迹(前导 compaction)
- 670/670 测试(新增 5)、typecheck、build 全绿
- 纯增量,不碰 `Prompts`/风险闸门;与 #169 零文件交集(除 DESIGN-prompts.md 一段注记)

## 动机

billion-context-pi#252 综合审计:内核提示词面六类中,nudge 脚手架的引导段是常驻规则之外最大的不可配置引导文本(~1.1K/次 tier-nudge)。宿主(lean 模式)需要能替换/删除这些段落而不动内核代码。