### PR TITLE
release v0.0.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.64",
+    "version": "0.0.65",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.64",
+            "version": "0.0.65",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.64",
+    "version": "0.0.65",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Bundles:
- #249 — StateStore optional record codec (compress/encrypt at rest)
- #256 — nudge guidance surface overrides (NudgePromptSections)
- #169 — surface-config layer (promptSections + toolPrompts) + Object.hasOwn guard

Version bump only (0.0.64 → 0.0.65). Local pre-flight: typecheck ✅ / 686 tests ✅ / build ✅