### PR TITLE
feat: prompt-pack resolution layer (issue #259)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ acp-kernel/
 │   ├── prompts.ts            # Prompts (4 load-bearing rules) + defaultPrompts + resolvePrompts
 │   ├── compress-tools.ts     # ACP tool schemas (3 wire shapes) + standing-prompt builders
 │   ├── surface-config.ts     # Surface-text overrides: applySectionOverrides, cloneWithDescriptions, applyAcpToolOverrides
+│   ├── packs/                # Prompt-pack resolution layer (issue #259)
+│   │   ├── types.ts          # Pack/PackSurface/PackSource contracts + isValidPackName
+│   │   ├── sanitize.ts       # sanitizePackSurface — narrow raw pack JSON onto surface primitives
+│   │   ├── builtin.ts        # builtin registry: default (no overrides), lean
+│   │   ├── dir.ts            # createDirPackSource — <dir>/<name>.json file source
+│   │   └── resolver.ts       # createPackResolver (first non-null wins) + defaultPackSources
 │   ├── types.ts              # All shared types
 │   └── defaults.ts           # defaultConfig, defaultNodes
 ├── tests/                    # unit + regression tests (node:test)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,32 @@ safe to customize freely; these helpers implement that:
   `input_schema`, openai `function.parameters`, responses flat
   `parameters`). Shared tool constants are never mutated.
 
+### Prompt packs (`src/packs`)
+
+Named surface presets that bundle the primitives above into reusable packs
+(`Pack` / `PackSurface` / `PackSource` contracts):
+
+- `sanitizePackSurface(raw)` — narrows raw pack JSON onto the surface
+  primitives (`prompts`, `promptSections`, `nudgeSections`, `toolPrompts`).
+  Unknown keys, wrong types, and empty results are dropped, so a bad pack
+  degrades to "no override" and never clobbers a good default. Host-specific
+  data rides under an opaque, shallow-copied `adapters.<hostId>` namespace.
+- `createDirPackSource(id, dir)` — `<dir>/<name>.json` file source; the
+  filename is authoritative for the pack name; tolerant of missing dirs and
+  malformed JSON. Tolerant ≠ trusted: a project-local dir lets whoever
+  controls that repo ship surface overrides (like `.editorconfig`).
+- `builtinSource` — built-in `default` (no overrides) and `lean` (compact
+  ACP-tags section + one-line descriptions for the four ACP tools;
+  compression rules stay default).
+- `createPackResolver(sources)` — first non-null wins; `listPacks()` dedupes
+  by name with the same priority.
+- `defaultPackSources({ projectDir, userDirs })` — project dir > user dirs
+  (in order) > builtins. Directory paths are host policy (the kernel never
+  derives them from cwd/homedir), and pack *selection* (which name is active
+  given a config cascade) stays adapter-side.
+- `isValidPackName(name)` — path-safe identifier check; rejects traversal and
+  dot-leading names before any fs access.
+
 ### Nudge system
 
 The nudge system tells the model *when* to compress. It implements:

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,11 +75,19 @@ export type {
 } from "./surface-config.js";
 export { sanitizePackSurface } from "./packs/sanitize.js";
 export { isValidPackName } from "./packs/types.js";
-export type { PromptPackFile, PackSurface, Pack, PackSource } from "./packs/types.js";
+export type {
+  PromptPackFile,
+  PackSurface,
+  Pack,
+  PackSource,
+} from "./packs/types.js";
 export { defaultPack, leanPack, builtinSource } from "./packs/builtin.js";
 export { createDirPackSource } from "./packs/dir.js";
 export { createPackResolver, defaultPackSources } from "./packs/resolver.js";
-export type { PackResolver, DefaultPackSourcesOptions } from "./packs/resolver.js";
+export type {
+  PackResolver,
+  DefaultPackSourcesOptions,
+} from "./packs/resolver.js";
 export { truncateLargeToolOutputs } from "./truncate-tools.js";
 export type { TruncateOptions, TruncateResult } from "./truncate-tools.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,13 @@ export type {
   ToolPrompts,
   AcpToolLike,
 } from "./surface-config.js";
+export { sanitizePackSurface } from "./packs/sanitize.js";
+export { isValidPackName } from "./packs/types.js";
+export type { PromptPackFile, PackSurface, Pack, PackSource } from "./packs/types.js";
+export { defaultPack, leanPack, builtinSource } from "./packs/builtin.js";
+export { createDirPackSource } from "./packs/dir.js";
+export { createPackResolver, defaultPackSources } from "./packs/resolver.js";
+export type { PackResolver, DefaultPackSourcesOptions } from "./packs/resolver.js";
 export { truncateLargeToolOutputs } from "./truncate-tools.js";
 export type { TruncateOptions, TruncateResult } from "./truncate-tools.js";
 export {

--- a/src/packs/builtin.ts
+++ b/src/packs/builtin.ts
@@ -1,0 +1,73 @@
+import type { Pack, PackSource } from "./types.js";
+
+export const defaultPack: Pack = {
+  name: "default",
+  version: "1.0.0",
+  description: "Built-in defaults (no overrides).",
+  source: "builtin:default",
+  surface: {},
+};
+
+// The tag name is escaped so no live <acp> tag is embedded in prompt text.
+const LEAN_ACP_TAGS = [
+  "ACP TAGS",
+  "",
+  "User/tool messages carry hidden \\x3cacp\\x3e refs such as m00123. Never echo the XML tags; use only refs in ACP tool calls.",
+].join("\n");
+
+export const leanPack: Pack = {
+  name: "lean",
+  version: "1.0.0",
+  description:
+    "Token-lean surface adapted from kunkun9527/billion-context-pi-lean: compact ACP-tags section plus one-line tool descriptions for the four ACP tools. Compression rules stay default (load-bearing, delivered by the builders and nudges); host-specific lean surfaces ride under adapters.<hostId>.",
+  source: "builtin:lean",
+  surface: {
+    promptSections: {
+      acpTags: LEAN_ACP_TAGS,
+    },
+    toolPrompts: {
+      compress: {
+        description:
+          "Replace consumed conversation ranges with self-contained summaries using mNNNNN or bN refs.",
+        paramDescriptions: {
+          content: "Direct array; no JSON strings/nesting/mix.",
+          startId: "Inclusive first mNNNNN or bN ref.",
+          endId: "Inclusive last mNNNNN or bN ref.",
+          summary:
+            "Self-contained replacement preserving exact technical details.",
+          topic:
+            "Short label; a per-range label overrides the top-level fallback.",
+          summaryMaxChars: "Optional summary length limit override.",
+        },
+      },
+      decompress: {
+        description:
+          "Restore compressed content by block id (b5) or message ref; one tier up by default, full:true restores originals, toFile writes to a file instead of context.",
+      },
+      search_context: {
+        description:
+          "Search compressed summaries and historical messages by keyword; returns refs, sizes, previews.",
+      },
+      acp_status: {
+        description:
+          "Context usage overview, compressible ranges, block drilldown.",
+      },
+    },
+  },
+};
+
+/** Built-in packs registered under their stable names. Adding a built-in = adding an entry. */
+const BUILTIN_REGISTRY: Readonly<Record<string, Pack>> = {
+  default: defaultPack,
+  lean: leanPack,
+};
+
+export const builtinSource: PackSource = {
+  id: "builtin",
+  resolve(name: string): Pack | null {
+    return BUILTIN_REGISTRY[name] ?? null;
+  },
+  list(): Pack[] {
+    return Object.values(BUILTIN_REGISTRY);
+  },
+};

--- a/src/packs/dir.ts
+++ b/src/packs/dir.ts
@@ -22,7 +22,13 @@ function readPackFile(file: string): PromptPackFile | null {
 /**
  * A pack directory source: `<dir>/<name>.json` files. One factory serves any
  * directory origin (project-local, user-global, installer-managed); the caller
- * decides which directories exist and their priority order.
+ * decides which directories exist and their priority order. The filename (not
+ * a `name` field inside the file) is authoritative for the pack name, so
+ * every listed pack is resolvable by its listed name. Trust boundary: a
+ * project-local dir lets whoever controls that repo ship surface overrides to
+ * its consumers (inherent to the feature, like `.editorconfig`); content is
+ * still sanitized before use. `resolve` reads from disk on every call — hosts
+ * should resolve once per session and cache.
  */
 export function createDirPackSource(id: string, dir: string): PackSource {
   return {
@@ -33,7 +39,7 @@ export function createDirPackSource(id: string, dir: string): PackSource {
       const raw = readPackFile(file);
       if (!raw) return null;
       return {
-        name: typeof raw.name === "string" ? raw.name : name,
+        name,
         version: typeof raw.version === "string" ? raw.version : undefined,
         description:
           typeof raw.description === "string" ? raw.description : undefined,

--- a/src/packs/dir.ts
+++ b/src/packs/dir.ts
@@ -31,22 +31,23 @@ function readPackFile(file: string): PromptPackFile | null {
  * should resolve once per session and cache.
  */
 export function createDirPackSource(id: string, dir: string): PackSource {
+  const resolve = (name: string): Pack | null => {
+    if (!isValidPackName(name)) return null;
+    const file = path.join(dir, `${name}.json`);
+    const raw = readPackFile(file);
+    if (!raw) return null;
+    return {
+      name,
+      version: typeof raw.version === "string" ? raw.version : undefined,
+      description:
+        typeof raw.description === "string" ? raw.description : undefined,
+      surface: sanitizePackSurface(raw),
+      source: `file:${file}`,
+    };
+  };
   return {
     id,
-    resolve(name: string): Pack | null {
-      if (!isValidPackName(name)) return null;
-      const file = path.join(dir, `${name}.json`);
-      const raw = readPackFile(file);
-      if (!raw) return null;
-      return {
-        name,
-        version: typeof raw.version === "string" ? raw.version : undefined,
-        description:
-          typeof raw.description === "string" ? raw.description : undefined,
-        surface: sanitizePackSurface(raw),
-        source: `file:${file}`,
-      };
-    },
+    resolve,
     list(): Pack[] {
       let names: string[];
       try {
@@ -56,7 +57,7 @@ export function createDirPackSource(id: string, dir: string): PackSource {
       }
       const out: Pack[] = [];
       for (const file of names) {
-        const pack = this.resolve(file.slice(0, -5));
+        const pack = resolve(file.slice(0, -5));
         if (pack) out.push(pack);
       }
       return out;

--- a/src/packs/dir.ts
+++ b/src/packs/dir.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync } from "node:fs";
+import * as path from "node:path";
+import { sanitizePackSurface } from "./sanitize.js";
+import {
+  isValidPackName,
+  type Pack,
+  type PackSource,
+  type PromptPackFile,
+} from "./types.js";
+
+function readPackFile(file: string): PromptPackFile | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as PromptPackFile)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A pack directory source: `<dir>/<name>.json` files. One factory serves any
+ * directory origin (project-local, user-global, installer-managed); the caller
+ * decides which directories exist and their priority order.
+ */
+export function createDirPackSource(id: string, dir: string): PackSource {
+  return {
+    id,
+    resolve(name: string): Pack | null {
+      if (!isValidPackName(name)) return null;
+      const file = path.join(dir, `${name}.json`);
+      const raw = readPackFile(file);
+      if (!raw) return null;
+      return {
+        name: typeof raw.name === "string" ? raw.name : name,
+        version: typeof raw.version === "string" ? raw.version : undefined,
+        description:
+          typeof raw.description === "string" ? raw.description : undefined,
+        surface: sanitizePackSurface(raw),
+        source: `file:${file}`,
+      };
+    },
+    list(): Pack[] {
+      let names: string[];
+      try {
+        names = readdirSync(dir).filter((f) => f.endsWith(".json"));
+      } catch {
+        return [];
+      }
+      const out: Pack[] = [];
+      for (const file of names) {
+        const pack = this.resolve(file.slice(0, -5));
+        if (pack) out.push(pack);
+      }
+      return out;
+    },
+  };
+}

--- a/src/packs/resolver.ts
+++ b/src/packs/resolver.ts
@@ -1,0 +1,68 @@
+import { builtinSource } from "./builtin.js";
+import { createDirPackSource } from "./dir.js";
+import { isValidPackName, type Pack, type PackSource } from "./types.js";
+
+/**
+ * Ordered pack resolution over pluggable sources. The first non-null wins;
+ * `listPacks` dedupes by name with the same priority. Custom sources (e.g. an
+ * installer-managed registry) can be prepended without touching core code.
+ */
+export interface PackResolver {
+  readonly sources: readonly PackSource[];
+  resolve(name: string): Pack | null;
+  listPacks(): Pack[];
+}
+
+export function createPackResolver(
+  sources: readonly PackSource[],
+): PackResolver {
+  return {
+    sources,
+    resolve(name: string): Pack | null {
+      if (!isValidPackName(name)) return null;
+      for (const source of sources) {
+        const pack = source.resolve(name);
+        if (pack) return pack;
+      }
+      return null;
+    },
+    listPacks(): Pack[] {
+      const seen = new Set<string>();
+      const out: Pack[] = [];
+      for (const source of sources) {
+        for (const pack of source.list?.() ?? []) {
+          if (!seen.has(pack.name)) {
+            seen.add(pack.name);
+            out.push(pack);
+          }
+        }
+      }
+      return out;
+    },
+  };
+}
+
+export interface DefaultPackSourcesOptions {
+  /** Project-local pack directory (host decides where that lives). */
+  projectDir?: string;
+  /** User-global pack directories, in priority order. */
+  userDirs?: readonly string[];
+}
+
+/**
+ * The default source chain: project dir > user dirs (in order) > builtins.
+ * Directory paths are host policy — the kernel never derives them from cwd or
+ * homedir. Omitting both yields builtins only.
+ */
+export function defaultPackSources(
+  options: DefaultPackSourcesOptions = {},
+): PackSource[] {
+  const sources: PackSource[] = [];
+  if (options.projectDir)
+    sources.push(createDirPackSource("project", options.projectDir));
+  let i = 0;
+  for (const dir of options.userDirs ?? [])
+    sources.push(createDirPackSource(`user${i++}`, dir));
+  sources.push(builtinSource);
+  return sources;
+}

--- a/src/packs/sanitize.ts
+++ b/src/packs/sanitize.ts
@@ -1,0 +1,122 @@
+import type { Prompts } from "../prompts.js";
+import type { CompressPromptSections, ToolPrompts } from "../surface-config.js";
+import type { NudgePromptSections } from "../nudge-text.js";
+import type { PackSurface, PromptPackFile } from "./types.js";
+
+const PROMPT_RULE_KEYS = [
+  "compressPhilosophy",
+  "howToCompressRules",
+  "tier2DistillRules",
+  "tier3CondenseRules",
+] as const;
+
+const COMPRESS_SECTION_KEYS = [
+  "acpTags",
+  "tools",
+  "summariesInContext",
+  "textProtocol",
+  "textTools",
+  "functionTools",
+] as const;
+
+const NUDGE_SECTION_KEYS = [
+  "efficiencyNote",
+  "emergencyHeader",
+  "t2Guidance",
+  "t3Guidance",
+] as const;
+
+function pickSection(
+  raw: unknown,
+  keys: readonly string[],
+): Record<string, string | null> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, string | null> = {};
+  for (const key of keys) {
+    const value = (raw as Record<string, unknown>)[key];
+    if (typeof value === "string" || value === null) out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function pickToolPrompts(raw: unknown): ToolPrompts | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: ToolPrompts = {};
+  for (const [tool, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const src = value as Record<string, unknown>;
+    const entry: {
+      description?: string;
+      paramDescriptions?: Record<string, string>;
+    } = {};
+    if (typeof src.description === "string")
+      entry.description = src.description;
+    if (
+      src.paramDescriptions &&
+      typeof src.paramDescriptions === "object" &&
+      !Array.isArray(src.paramDescriptions)
+    ) {
+      const params: Record<string, string> = {};
+      for (const [name, description] of Object.entries(
+        src.paramDescriptions as Record<string, unknown>,
+      )) {
+        if (typeof description === "string") params[name] = description;
+      }
+      if (Object.keys(params).length > 0) entry.paramDescriptions = params;
+    }
+    if (Object.keys(entry).length > 0) out[tool] = entry;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Narrow a raw pack file into a sanitized {@link PackSurface}. Unknown keys,
+ * wrong types, and empty results are dropped — a bad pack degrades to "no
+ * override", never corrupts a good default. `adapters` is kept opaquely when
+ * it is a plain object (shallow-copied so later mutation cannot reach the
+ * source file's parsed tree).
+ */
+export function sanitizePackSurface(
+  pack: PromptPackFile | null | undefined,
+): PackSurface {
+  if (!pack || typeof pack !== "object" || Array.isArray(pack)) return {};
+  const surface: PackSurface = {};
+
+  const prompts: Partial<Prompts> = {};
+  const rawPrompts = pack.prompts;
+  if (
+    rawPrompts &&
+    typeof rawPrompts === "object" &&
+    !Array.isArray(rawPrompts)
+  ) {
+    for (const key of PROMPT_RULE_KEYS) {
+      const value = (rawPrompts as Record<string, unknown>)[key];
+      if (typeof value === "string")
+        (prompts as Record<string, string>)[key] = value;
+    }
+  }
+  if (Object.keys(prompts).length > 0) surface.prompts = prompts;
+
+  const promptSections = pickSection(
+    pack.promptSections,
+    COMPRESS_SECTION_KEYS,
+  );
+  if (promptSections)
+    surface.promptSections = promptSections as CompressPromptSections;
+
+  const nudgeSections = pickSection(pack.nudgeSections, NUDGE_SECTION_KEYS);
+  if (nudgeSections)
+    surface.nudgeSections = nudgeSections as NudgePromptSections;
+
+  const toolPrompts = pickToolPrompts(pack.toolPrompts);
+  if (toolPrompts) surface.toolPrompts = toolPrompts;
+
+  if (
+    pack.adapters &&
+    typeof pack.adapters === "object" &&
+    !Array.isArray(pack.adapters)
+  ) {
+    surface.adapters = { ...(pack.adapters as Record<string, unknown>) };
+  }
+  return surface;
+}

--- a/src/packs/sanitize.ts
+++ b/src/packs/sanitize.ts
@@ -8,7 +8,7 @@ const PROMPT_RULE_KEYS = [
   "howToCompressRules",
   "tier2DistillRules",
   "tier3CondenseRules",
-] as const;
+] as const satisfies readonly (keyof Prompts)[];
 
 const COMPRESS_SECTION_KEYS = [
   "acpTags",
@@ -17,14 +17,14 @@ const COMPRESS_SECTION_KEYS = [
   "textProtocol",
   "textTools",
   "functionTools",
-] as const;
+] as const satisfies readonly (keyof CompressPromptSections)[];
 
 const NUDGE_SECTION_KEYS = [
   "efficiencyNote",
   "emergencyHeader",
   "t2Guidance",
   "t3Guidance",
-] as const;
+] as const satisfies readonly (keyof NudgePromptSections)[];
 
 function pickSection(
   raw: unknown,

--- a/src/packs/types.ts
+++ b/src/packs/types.ts
@@ -1,0 +1,71 @@
+import type { Prompts } from "../prompts.js";
+import type { CompressPromptSections, ToolPrompts } from "../surface-config.js";
+import type { NudgePromptSections } from "../nudge-text.js";
+
+/**
+ * Raw on-disk pack JSON schema (user-authored file or future installer
+ * payload). Every field optional and untyped: {@link sanitizePackSurface}
+ * narrows it into a {@link PackSurface} before use, so a malformed pack
+ * degrades to "no override" and never clobbers a good default.
+ */
+export interface PromptPackFile {
+  name?: string;
+  version?: string;
+  description?: string;
+  prompts?: unknown;
+  promptSections?: unknown;
+  nudgeSections?: unknown;
+  toolPrompts?: unknown;
+  adapters?: unknown;
+}
+
+/**
+ * Sanitized surface bundle a pack contributes. Every field layers on the
+ * kernel's surface primitives: `promptSections` applies through the three
+ * `build*SystemPrompt` builders, `nudgeSections` through `renderNudgeText`,
+ * `toolPrompts` through `applyAcpToolOverrides`. `adapters.<hostId>` is
+ * opaque data owned by that host — the kernel stores but never interprets it.
+ */
+export interface PackSurface {
+  /**
+   * Load-bearing compression rules. Apply via resolvePrompts(surface.prompts,
+   * { acknowledgeRisk: true }) — overriding them can degrade summary quality.
+   */
+  prompts?: Partial<Prompts>;
+  promptSections?: CompressPromptSections;
+  nudgeSections?: NudgePromptSections;
+  toolPrompts?: ToolPrompts;
+  adapters?: Record<string, unknown>;
+}
+
+/**
+ * A resolved prompt pack: a name plus a sanitized surface, tagged with its
+ * provenance (`builtin:lean`, `file:/home/u/.acp/packs/x.json`, …). Built-in
+ * packs, user file packs, and future installer-managed packs all implement
+ * this single contract.
+ */
+export interface Pack {
+  name: string;
+  version?: string;
+  description?: string;
+  surface: PackSurface;
+  source: string;
+}
+
+/**
+ * A pluggable pack origin. Sources are consulted in resolver order; the first
+ * non-null wins. Implementations must be safe to call per turn (sync, no throw).
+ */
+export interface PackSource {
+  readonly id: string;
+  resolve(name: string): Pack | null;
+  list?(): Pack[];
+}
+
+/**
+ * Pack names are path-safe identifiers; also guards the `<dir>/<name>.json`
+ * join in directory sources (rejects traversal and dot-leading names).
+ */
+export function isValidPackName(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name) && !name.includes("..");
+}

--- a/tests/packs.test.ts
+++ b/tests/packs.test.ts
@@ -268,12 +268,32 @@ test("dir source roundtrips a pack file", () => {
   }
 });
 
-test("dir source tolerates missing dir and malformed json", () => {
+test("dir source makes the filename authoritative over the inner name field", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "acp-packs-mismatch-"));
+  try {
+    writeFileSync(
+      path.join(dir, "lean.json"),
+      JSON.stringify({ name: "custom", promptSections: { acpTags: "T" } }),
+    );
+    const src = createDirPackSource("project", dir);
+    const pack = src.resolve("lean");
+    assert.ok(pack);
+    assert.equal(pack.name, "lean");
+    assert.deepEqual(src.list().map((p) => p.name), ["lean"]);
+    assert.ok(src.resolve("custom") === null || src.resolve("custom")?.name === "custom");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dir source tolerates missing dir, malformed json, and non-object files", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "acp-packs-bad-"));
   try {
     writeFileSync(path.join(dir, "bad.json"), "{not json");
+    writeFileSync(path.join(dir, "prim.json"), JSON.stringify(["an", "array"]));
     const src = createDirPackSource("user0", dir);
     assert.equal(src.resolve("bad"), null);
+    assert.equal(src.resolve("prim"), null);
     assert.deepEqual(src.list(), []);
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/tests/packs.test.ts
+++ b/tests/packs.test.ts
@@ -1,0 +1,319 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  isValidPackName,
+  sanitizePackSurface,
+  defaultPack,
+  leanPack,
+  builtinSource,
+  createDirPackSource,
+  createPackResolver,
+  defaultPackSources,
+  buildCompressSystemPrompt,
+  buildCompressTextSystemPrompt,
+  buildCompressHybridSystemPrompt,
+  applyAcpToolOverrides,
+  ACP_TOOLS_ANTHROPIC,
+  ACP_TOOLS_OPENAI,
+  ACP_TOOLS_RESPONSES,
+  ACP_TOOL_NAMES,
+  defaultPrompts,
+} from "../src/index.js";
+import type { PackSource } from "../src/index.js";
+
+test("isValidPackName accepts safe names", () => {
+  for (const name of ["lean", "default", "my-pack", "v1.2", "A.b_c-d"]) {
+    assert.equal(isValidPackName(name), true, name);
+  }
+});
+
+test("isValidPackName rejects traversal and malformed names", () => {
+  assert.equal(isValidPackName(""), false);
+  assert.equal(isValidPackName("-x"), false);
+  assert.equal(isValidPackName(".hidden"), false);
+  assert.equal(isValidPackName(".."), false);
+  assert.equal(isValidPackName("../x"), false);
+  assert.equal(isValidPackName("a b"), false);
+  assert.equal(isValidPackName("a/b"), false);
+});
+
+test("sanitizePackSurface drops non-objects and unknown keys", () => {
+  assert.deepEqual(sanitizePackSurface(null), {});
+  assert.deepEqual(sanitizePackSurface(undefined), {});
+  assert.deepEqual(sanitizePackSurface({ bogus: 1 }), {});
+});
+
+test("sanitizePackSurface narrows typed sections and drops wrong types", () => {
+  const surface = sanitizePackSurface({
+    prompts: { compressPhilosophy: "P", howToCompressRules: 42 },
+    promptSections: { acpTags: "TAG", tools: null, bogus: 1 },
+    nudgeSections: { efficiencyNote: "E", t2Guidance: [1] },
+    toolPrompts: {
+      compress: {
+        description: "d",
+        paramDescriptions: { content: "c", other: 7 },
+      },
+      decompress: { description: 9 },
+    },
+    adapters: { pi: { snippet: "s" } },
+  });
+  assert.deepEqual(surface.prompts, { compressPhilosophy: "P" });
+  assert.deepEqual(surface.promptSections, { acpTags: "TAG", tools: null });
+  assert.deepEqual(surface.nudgeSections, { efficiencyNote: "E" });
+  assert.deepEqual(surface.toolPrompts, {
+    compress: { description: "d", paramDescriptions: { content: "c" } },
+  });
+  assert.deepEqual(surface.adapters, { pi: { snippet: "s" } });
+});
+
+test("sanitizePackSurface treats adapters opaquely and copies them", () => {
+  const input = { adapters: { pi: { deep: 1 } } };
+  const surface = sanitizePackSurface(input);
+  assert.ok(surface.adapters);
+  (surface.adapters as Record<string, unknown>).pi = "mutated";
+  assert.deepEqual(input.adapters, { pi: { deep: 1 } });
+  assert.equal(sanitizePackSurface({ adapters: [1] }).adapters, undefined);
+});
+
+test("builtin registry resolves default and lean", () => {
+  assert.equal(builtinSource.resolve("default"), defaultPack);
+  const lean = builtinSource.resolve("lean");
+  assert.ok(lean);
+  assert.equal(lean.name, "lean");
+  assert.equal(lean.source, "builtin:lean");
+  assert.equal(builtinSource.resolve("nope"), null);
+  assert.deepEqual(
+    builtinSource
+      .list?.()
+      .map((p) => p.name)
+      .sort(),
+    ["default", "lean"],
+  );
+});
+
+test("lean toolPrompts cover every ACP tool", () => {
+  const toolPrompts = leanPack.surface.toolPrompts;
+  assert.ok(toolPrompts);
+  for (const name of ACP_TOOL_NAMES) {
+    assert.ok(toolPrompts[name], `missing override for ${name}`);
+    assert.ok(
+      typeof toolPrompts[name]?.description === "string" &&
+        toolPrompts[name]?.description.length < 200,
+    );
+  }
+});
+
+test("lean acpTags section applies through all three builders", () => {
+  const sections = leanPack.surface.promptSections;
+  assert.ok(sections);
+  const marker = "use only refs in ACP tool calls";
+  for (const prompt of [
+    buildCompressSystemPrompt(defaultPrompts, sections),
+    buildCompressTextSystemPrompt(defaultPrompts, sections),
+    buildCompressHybridSystemPrompt(defaultPrompts, sections),
+  ]) {
+    assert.ok(prompt.includes(marker), "lean acpTags line present");
+    assert.ok(prompt.includes(defaultPrompts.compressPhilosophy));
+    assert.ok(prompt.includes(defaultPrompts.howToCompressRules));
+  }
+  assert.notEqual(
+    buildCompressSystemPrompt(),
+    buildCompressSystemPrompt(defaultPrompts, sections),
+  );
+});
+
+test("applyAcpToolOverrides replaces descriptions without mutating originals", () => {
+  const overrides = leanPack.surface.toolPrompts;
+  assert.ok(overrides);
+  const originalDesc = ACP_TOOLS_ANTHROPIC[0].description;
+  const out = applyAcpToolOverrides(ACP_TOOLS_ANTHROPIC, overrides);
+  assert.notEqual(out[0], ACP_TOOLS_ANTHROPIC[0]);
+  assert.equal(out[0].description, overrides["compress"]!.description);
+  assert.equal(ACP_TOOLS_ANTHROPIC[0].description, originalDesc);
+  const props = (
+    out[0].input_schema as {
+      properties: Record<string, { description?: string }>;
+    }
+  ).properties;
+  assert.equal(
+    props.content.description,
+    overrides["compress"]!.paramDescriptions?.content,
+  );
+});
+
+test("applyAcpToolOverrides passes non-matching tools through by reference", () => {
+  const overrides = leanPack.surface.toolPrompts;
+  const extra = { name: "not-an-acp-tool", description: "keep me" };
+  const out = applyAcpToolOverrides(
+    [...ACP_TOOLS_ANTHROPIC, extra] as typeof ACP_TOOLS_ANTHROPIC,
+    overrides,
+  );
+  assert.equal(out[out.length - 1], extra);
+});
+
+test("applyAcpToolOverrides handles openai function shape", () => {
+  const overrides = leanPack.surface.toolPrompts;
+  const out = applyAcpToolOverrides(ACP_TOOLS_OPENAI, overrides!);
+  const compress = out.find((t) => t.function?.name === "compress")!;
+  assert.equal(compress.function.description, overrides!.compress!.description);
+  const params = compress.function.parameters as {
+    properties: Record<string, { description?: string }>;
+  };
+  assert.equal(
+    params.properties.content.description,
+    overrides!.compress!.paramDescriptions?.content,
+  );
+});
+
+test("applyAcpToolOverrides handles responses flat shape", () => {
+  const overrides = leanPack.surface.toolPrompts;
+  const out = applyAcpToolOverrides(ACP_TOOLS_RESPONSES, overrides!);
+  const decompress = out.find((t) => t.name === "decompress")!;
+  assert.equal(decompress.description, overrides!.decompress!.description);
+});
+
+function memorySource(
+  packs: Record<string, { name: string; surface?: unknown; source: string }>,
+): PackSource {
+  return {
+    id: "memory",
+    resolve(name) {
+      const raw = packs[name];
+      if (!raw) return null;
+      return { ...raw, surface: sanitizePackSurface(raw.surface ?? {}) };
+    },
+    list() {
+      return Object.values(packs).map((raw) => ({
+        ...raw,
+        surface: sanitizePackSurface(raw.surface ?? {}),
+      }));
+    },
+  };
+}
+
+test("resolver uses first non-null source in order", () => {
+  const first = memorySource({ custom: { name: "custom", source: "first" } });
+  const second = memorySource({ custom: { name: "custom", source: "second" } });
+  const resolver = createPackResolver([first, second, builtinSource]);
+  assert.equal(resolver.resolve("custom")?.source, "first");
+  assert.equal(resolver.resolve("lean")?.source, "builtin:lean");
+  assert.equal(resolver.resolve("missing"), null);
+});
+
+test("resolver short-circuits invalid names before touching sources", () => {
+  let calls = 0;
+  const spy: PackSource = {
+    id: "spy",
+    resolve() {
+      calls++;
+      return null;
+    },
+    list() {
+      return [];
+    },
+  };
+  const resolver = createPackResolver([spy]);
+  assert.equal(resolver.resolve("../x"), null);
+  assert.equal(calls, 0);
+});
+
+test("listPacks dedupes by name with first-wins priority", () => {
+  const first = memorySource({ dup: { name: "dup", source: "first" } });
+  const second = memorySource({
+    dup: { name: "dup", source: "second" },
+    extra: { name: "extra", source: "second" },
+  });
+  const packs = createPackResolver([first, second, builtinSource]).listPacks();
+  const dups = packs.filter((p) => p.name === "dup");
+  assert.equal(dups.length, 1);
+  assert.equal(dups[0].source, "first");
+  assert.ok(packs.some((p) => p.name === "extra"));
+  assert.ok(packs.some((p) => p.name === "lean"));
+});
+
+test("dir source roundtrips a pack file", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "acp-packs-"));
+  try {
+    writeFileSync(
+      path.join(dir, "mypack.json"),
+      JSON.stringify({
+        name: "mypack",
+        version: "0.1.0",
+        description: "d",
+        promptSections: { acpTags: "TAG" },
+        adapters: { pi: 1 },
+        bogus: true,
+      }),
+    );
+    const src = createDirPackSource("project", dir);
+    const pack = src.resolve("mypack");
+    assert.ok(pack);
+    assert.equal(pack.version, "0.1.0");
+    assert.ok(pack.source.startsWith("file:"));
+    assert.equal(pack.surface.promptSections?.acpTags, "TAG");
+    assert.deepEqual(pack.surface.adapters, { pi: 1 });
+    assert.equal("bogus" in (pack.surface as object), false);
+    assert.deepEqual(
+      src.list().map((p) => p.name),
+      ["mypack"],
+    );
+    assert.equal(src.resolve("missing"), null);
+    assert.equal(src.resolve("../evil"), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dir source tolerates missing dir and malformed json", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "acp-packs-bad-"));
+  try {
+    writeFileSync(path.join(dir, "bad.json"), "{not json");
+    const src = createDirPackSource("user0", dir);
+    assert.equal(src.resolve("bad"), null);
+    assert.deepEqual(src.list(), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  const ghost = createDirPackSource(
+    "ghost",
+    path.join(os.tmpdir(), "acp-packs-no-such-dir"),
+  );
+  assert.equal(ghost.resolve("lean"), null);
+  assert.deepEqual(ghost.list(), []);
+});
+
+test("defaultPackSources builds project > user > builtin chain", () => {
+  assert.deepEqual(
+    defaultPackSources().map((s) => s.id),
+    ["builtin"],
+  );
+  const sources = defaultPackSources({
+    projectDir: "/tmp/p",
+    userDirs: ["/tmp/u0", "/tmp/u1"],
+  });
+  assert.deepEqual(
+    sources.map((s) => s.id),
+    ["project", "user0", "user1", "builtin"],
+  );
+});
+
+test("project pack shadows builtin lean end-to-end", () => {
+  const projectDir = mkdtempSync(path.join(os.tmpdir(), "acp-packs-shadow-"));
+  try {
+    writeFileSync(
+      path.join(projectDir, "lean.json"),
+      JSON.stringify({ promptSections: { acpTags: "PROJECT LEAN" } }),
+    );
+    const resolver = createPackResolver(defaultPackSources({ projectDir }));
+    const pack = resolver.resolve("lean");
+    assert.ok(pack);
+    assert.ok(pack.source.startsWith("file:"));
+    assert.equal(pack.surface.promptSections?.acpTags, "PROJECT LEAN");
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/tests/packs.test.ts
+++ b/tests/packs.test.ts
@@ -261,6 +261,11 @@ test("dir source roundtrips a pack file", () => {
       src.list().map((p) => p.name),
       ["mypack"],
     );
+    const { list } = src;
+    assert.deepEqual(
+      list().map((p) => p.name),
+      ["mypack"],
+    );
     assert.equal(src.resolve("missing"), null);
     assert.equal(src.resolve("../evil"), null);
   } finally {
@@ -279,8 +284,14 @@ test("dir source makes the filename authoritative over the inner name field", ()
     const pack = src.resolve("lean");
     assert.ok(pack);
     assert.equal(pack.name, "lean");
-    assert.deepEqual(src.list().map((p) => p.name), ["lean"]);
-    assert.ok(src.resolve("custom") === null || src.resolve("custom")?.name === "custom");
+    assert.deepEqual(
+      src.list().map((p) => p.name),
+      ["lean"],
+    );
+    assert.ok(
+      src.resolve("custom") === null ||
+        src.resolve("custom")?.name === "custom",
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

Moves the prompt-pack resolution layer out of the Pi adapter (local copy shipped in billion-context-pi #397) into acp-kernel, so the billion-context proxy and any future host can consume named surface presets without copying modules.

### New module `src/packs/`

- **`types.ts`** — `Pack` / `PackSurface` / `PackSource` contracts + `isValidPackName` (rejects traversal/malformed names before any fs access).
- **`sanitize.ts`** — `sanitizePackSurface`: narrows raw pack JSON into a typed surface over the existing primitives (`Prompts` rules, `CompressPromptSections`, `NudgePromptSections`, `ToolPrompts`). Unknown keys, wrong types, and empty results are dropped — a bad pack degrades to "no override", never corrupts a good default. `adapters.<hostId>` is kept opaquely (shallow-copied) as the namespace for host-specific surface data.
- **`builtin.ts`** — builtin registry: `default` (no overrides) and `lean`. Lean carries only host-agnostic content: a compact ACP-tags section plus one-line descriptions for all four ACP tools. Compression rules stay default (load-bearing, delivered by builders/nudges); Pi-specific lean surfaces ride under `adapters.pi`.
- **`dir.ts`** — `createDirPackSource(id, dir)`: one factory for any directory origin, `<dir>/<name>.json` files, tolerant of missing dirs and malformed JSON.
- **`resolver.ts`** — `createPackResolver(sources)` (first non-null wins; `listPacks` dedupes by name with the same priority) + `defaultPackSources({projectDir, userDirs})` = project > user dirs (in order) > builtins. Directory paths stay host policy — the kernel never derives them from cwd or homedir.

Pack *selection* (which name is active given the config cascade) stays adapter-side, as proposed in the issue.

### Acceptance

- [x] kernel exports the packs module (`src/index.ts`), zero new runtime deps (only `node:fs`/`node:path`, already used by `persist/`)
- [x] lean resolves and applies through existing builders — tests assert the lean acpTags section through `buildCompressSystemPrompt` / `buildCompressTextSystemPrompt` / `buildCompressHybridSystemPrompt`, and the one-line descriptions through `applyAcpToolOverrides` over all three wire shapes (anthropic/openai/responses), with originals verified unmutated and non-matching tools passed through by reference
- [x] full test suite green: 712/712 (typecheck + build also clean)

中文摘要：把 prompt-pack 解析层从 Pi 适配器搬进内核（新增 `src/packs/*`，共 5 个模块 + 测试）；lean 包只含主机无关的压缩表面，主机专属数据走不透明的 `adapters.<hostId>` 命名空间，目录路径策略留在宿主侧。验收三条全部满足（导出、经现有 builders 应用、712/712 全绿），可以合并；合并后 Pi 适配器可删除本地副本改用内核实现。