### PR TITLE
release v0.0.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.65",
+    "version": "0.0.66",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "acp-kernel",
-            "version": "0.0.65",
+            "version": "0.0.66",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "acp-kernel",
-    "version": "0.0.65",
+    "version": "0.0.66",
     "description": "Framework-agnostic context-compression engine (model-driven, 3-tier LSM). Pure core: no host dependency.",
     "license": "MIT",
     "author": "ranxianglei",


### PR DESCRIPTION
Releases the prompt-packs layer merged via #260 (Fixes #259):

- Pack/PackSource/PackResolver contracts + sanitizePackSurface (tri-state sections, tool prompts, opaque adapters namespace)
- Builtins: default + lean (lean recall rules aligned with pre-lean semantics; filename-canonical dir-source identity)
- createDirPackSource / createPackResolver / defaultPackSources; selection policy stays adapter-side

Ships to billion-context (compress.promptPack, branch feat/compress-prompt-pack, issue #729) and billion-context-pi migration next.

708/708, typecheck clean, build green.